### PR TITLE
Case-insensitive check for resource.exists() only when resource is case-sensitive

### DIFF
--- a/core/src/main/java/lucee/commons/io/res/util/ResourceUtil.java
+++ b/core/src/main/java/lucee/commons/io/res/util/ResourceUtil.java
@@ -91,9 +91,6 @@ public final class ResourceUtil {
      */
     public static final short LEVEL_GRAND_PARENT_FILE=2;
     
-    
-    private static boolean isUnix=SystemUtil.isUnix();
-    
     private static final HashMap<String, String> EXT_MT=new HashMap<String, String>();
     static {
     	EXT_MT.put("ai","application/postscript");
@@ -373,7 +370,7 @@ public final class ResourceUtil {
      */
     public static Resource toExactResource(Resource res) {
         res=getCanonicalResourceEL(res);
-        if(isUnix) {
+        if(res.getResourceProvider().isCaseSensitive()) {
             if(res.exists()) return res;
             return _check(res);
             


### PR DESCRIPTION
While working on my Azure resourceProvider, I noticed an extra file listing is done when calling fileExists() on a non-existing file. This is done based on the Operating system being unix/linux, where it should actually check if the resourceProvider itself is case-sensitive.

As a side note: my current resource has thousands of files stored directly in the root directory. This case-insensitive check (dir listing) takes quite a while to load; are you sure this is the right way to do it?
