### PR TITLE
fixes for LDEV-655 and building on Windows

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -322,7 +322,7 @@ LUCEE BUILD PROCESS
       srcdir="${srcInst}" 
       target="1.7" 
       destdir="${temp}/agent"
-      debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
+      debug="true" debuglevel="lines,vars,source" classpath="${dependencies}" encoding="utf-8">
     </javac>
 
     <!-- create the manifest file -->
@@ -341,7 +341,7 @@ LUCEE BUILD PROCESS
       srcdir="${srcLoader}" 
       target="1.7" 
       destdir="${temp}/loader"
-      debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
+      debug="true" debuglevel="lines,vars,source" classpath="${dependencies}" encoding="utf-8">
     </javac>
     
     <!-- copy all non java files -->
@@ -376,7 +376,7 @@ LUCEE BUILD PROCESS
       srcdir="${srcCore}" 
       target="1.7" 
       destdir="${core}"
-      debug="true" debuglevel="lines,vars,source">
+      debug="true" debuglevel="lines,vars,source" encoding="utf-8">
        <classpath refid="classpath" />
     </javac>
 

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -896,10 +896,13 @@ public final class PageSourceImpl implements PageSource {
 
 	@Override
 	public int getDialect() {
-		// page sources that are not a known dialect, default to lucee if enabled, otherwise fallback to a known CFML extension.
+		// page sources that are not a known dialect, default to lucee if enabled, otherwise fallback to CFML dialect.
 		boolean allowLuceeDialect = ((ConfigImpl)getMapping().getConfig()).allowLuceeDialect();
 		// MUST is the mapping always configWeb?
-		return ((ConfigWeb)getMapping().getConfig()).getFactory().toDialect(ResourceUtil.getExtension(relPath, allowLuceeDialect ? Constants.getLuceeComponentExtension() : Constants.getCFMLTemplateExtensions()[0]));
+		return allowLuceeDialect
+				?	((ConfigWeb)getMapping().getConfig()).getFactory().toDialect(ResourceUtil.getExtension(relPath, Constants.getLuceeComponentExtension()))
+				:	CFMLEngine.DIALECT_CFML		
+				;
 	}
 
 	/**

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -34,6 +34,7 @@ import lucee.commons.lang.types.RefBooleanImpl;
 import lucee.loader.engine.CFMLEngine;
 import lucee.runtime.compiler.CFMLCompilerImpl.Result;
 import lucee.runtime.config.Config;
+import lucee.runtime.config.ConfigImpl;
 import lucee.runtime.config.ConfigWeb;
 import lucee.runtime.config.ConfigWebImpl;
 import lucee.runtime.config.Constants;
@@ -895,8 +896,10 @@ public final class PageSourceImpl implements PageSource {
 
 	@Override
 	public int getDialect() {
+		// page sources that are not a known dialect, default to lucee if enabled, otherwise fallback to a known CFML extension.
+		boolean allowLuceeDialect = ((ConfigImpl)getMapping().getConfig()).allowLuceeDialect();
 		// MUST is the mapping always configWeb?
-		return ((ConfigWeb)getMapping().getConfig()).getFactory().toDialect(ResourceUtil.getExtension(relPath, Constants.getLuceeComponentExtension()));
+		return ((ConfigWeb)getMapping().getConfig()).getFactory().toDialect(ResourceUtil.getExtension(relPath, allowLuceeDialect ? Constants.getLuceeComponentExtension() : Constants.getCFMLTemplateExtensions()[0]));
 	}
 
 	/**

--- a/test/general/Resources.cfc
+++ b/test/general/Resources.cfc
@@ -6,8 +6,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 	//public function setUp(){}
 
-	variables.FSEP = server.separator.file;
-
 	private void function directoryCreateDelete(string label,string dir){
 		var sub=arguments.dir&"test1/";
 		var subsub=sub&"test2/";
@@ -307,9 +305,9 @@ private function testResourceFileCreateDelete(res) localMode=true {
 }
 
 private function testResourceListening(res) localMode=true {
-    s=res.getRealResource("s#FSEP#ss.txt");
+	s=res.getRealResource("s/ss.txt");
     s.createFile(true);
-    ss=res.getRealResource("ss#FSEP#");
+    ss=res.getRealResource("ss/");
     ss.createDirectory(true);
     sss=res.getRealResource("sss.txt");
     sss.createFile(true);
@@ -375,8 +373,8 @@ private function testResourceMoveCopy(res) localMode=true {
 
 }
 
-private function testResourceGetter(res) localMode=true {
-    f=res.getRealResource("original.txt");
+private function testResourceGetter(res, fsep) localMode=true {
+	f=res.getRealResource("original.txt");
     d=res.getRealResource("dir/");
     d2=res.getRealResource("dir2")
     dd=res.getRealResource("dir/test.txt");
@@ -390,7 +388,7 @@ private function testResourceGetter(res) localMode=true {
     assertEquals("dir",dd.getParentResource().getName());
 
     // getRealPath
-    assertEquals(res.toString()&"#FSEP#dir#FSEP#test.txt",dd.toString());
+    assertEquals(res.toString()&"#fsep#dir#fsep#test.txt",dd.toString());
 
 }
 
@@ -412,7 +410,7 @@ private function testResourceReadWrite(res) localMode=true {
     assertEquals("Susi Sorglos foehnte Ihr Haar",res);
 }
 
-private function testResourceProvider(string path) localmode=true {
+private function testResourceProvider(string path, string fsep) localmode=true {
     // first we ceate a resource object
     res=createObject('java','lucee.commons.io.res.util.ResourceUtil').toResourceNotExisting(getPageContext(), path);
 
@@ -431,7 +429,7 @@ private function testResourceProvider(string path) localmode=true {
         res.createDirectory(true);
         testResourceFileCreateDelete(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
+    finally {if(res.exists()) res.remove(true);}
 
     // test listening
     try {
@@ -457,7 +455,7 @@ private function testResourceProvider(string path) localmode=true {
     // test Getter
     try {
         res.createDirectory(true);
-        testResourceGetter(res);
+        testResourceGetter(res, fsep);
     }
     finally {if(res.exists()) res.remove(true);}
 
@@ -475,7 +473,7 @@ private function testResourceProvider(string path) localmode=true {
 
 
 
-	private void function test(string label,string root){
+	private void function test(string label,string root,string fsep=server.separator.file){
 		var start=getTickCount();
 		var dir=arguments.root&"testResource/";
 
@@ -493,7 +491,7 @@ private function testResourceProvider(string path) localmode=true {
 		    fileAMove(arguments.label,dir);
 		    fileAReadAppend(arguments.label,dir);
 		    fileAReadBinary(arguments.label,dir);
-		    testResourceProvider(dir&"testcaseRes");
+		    testResourceProvider(dir&"testcaseRes", fsep);
 
 		}
 		finally {
@@ -519,7 +517,7 @@ private function testResourceProvider(string path) localmode=true {
 	}
 
 	public void function testRam(){
-		test("ram","ram://");
+		test("ram","ram://","/");
 	}
 
 	public void function testLocalFilesystem(){

--- a/test/general/Resources.cfc
+++ b/test/general/Resources.cfc
@@ -6,7 +6,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 	//public function setUp(){}
 
-	private FSEP = server.separator.file;
+	variables.FSEP = server.separator.file;
 
 	private void function directoryCreateDelete(string label,string dir){
 		var sub=arguments.dir&"test1/";

--- a/test/general/Resources.cfc
+++ b/test/general/Resources.cfc
@@ -1,19 +1,21 @@
 component extends="org.lucee.cfml.test.LuceeTestCase"	{
-	
+
 	//public function beforeTests(){}
-	
+
 	//public function afterTests(){}
 
 	//public function setUp(){}
 
+	private FSEP = server.separator.file;
+
 	private void function directoryCreateDelete(string label,string dir){
 		var sub=arguments.dir&"test1/";
 		var subsub=sub&"test2/";
-	    
+
 		// before doing anything it should not exist
 		assertFalse(directoryExists(sub));
 	    assertFalse(directoryExists(subsub));
-	    
+
 	    // create the dirs
 	    directory directory="#sub#" action="create";
 	    directory directory="#subsub#" action="create";
@@ -21,7 +23,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	    // now it should exist
 	    assertTrue(directoryExists(sub));
 	    assertTrue(directoryExists(subsub));
-	    
+
 	    // delete them again
 	    directory directory="#subsub#" action="delete" recurse="no";
 	    directory directory="#sub#" action="delete" recurse="no";
@@ -38,7 +40,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	    // now it should exist
 	    assertTrue(directoryExists(sub));
 	    assertTrue(directoryExists(subsub));
-	    
+
 	    // delete them again
 	    directory directory="#sub#" action="delete" recurse="yes";
 
@@ -66,7 +68,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	    assertTrue(hasException);
 
 	    directory directory="#sub#" action="delete" recurse="yes";
-	    
+
 		// should be gone again
 	    assertFalse(directoryExists(sub));
 	    assertFalse(directoryExists(subsub));
@@ -89,16 +91,16 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		    file action="write" file="#sf#" output="" addnewline="no" fixnewline="no";
 		    file action="write" file="#sdsf#" output="" addnewline="no" fixnewline="no";
 		    file action="write" file="#sdsdsf#" output="" addnewline="no" fixnewline="no";
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="no";
 		    assertEquals(2,children.recordcount);
 		    assertEquals("test1,test2.txt",	listSort(valueList(children.name),'textnocase'));
 		    assertEquals("0,0",				listSort(valueList(children.size),'textnocase'));
 		    assertEquals("Dir,File",		listSort(valueList(children.type),'textnocase'));
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="yes";
 		    assertEquals(5,children.recordcount);
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="yes" filter="*5.txt";
 		    assertEquals(1,children.recordcount);
 	    }
@@ -124,14 +126,14 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		    file action="write" file="#sf#" output="" addnewline="no" fixnewline="no";
 		    file action="write" file="#sdsf#" output="" addnewline="no" fixnewline="no";
 		    file action="write" file="#sdsdsf#" output="" addnewline="no" fixnewline="no";
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="yes";
 		    assertEquals("test1,test2.txt,test3,test4.txt,test5.txt",
 		  		listSort(valueList(children.name),'textnocase'));
 
 		    directory directory="#sdsd#" action="rename" newdirectory="#sdsdNew#";
 		    directory directory="#sd#" action="rename" newdirectory="#sdNew#";
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="yes";
 		    assertEquals("test1New,test2.txt,test3New,test4.txt,test5.txt",
 		  		ListSort( valueList(children.name),'text'));
@@ -158,7 +160,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		    file action="write" file="#s#" output="aaa" addnewline="no" fixnewline="no";
 		    file action="copy" source="#s#" destination="#d#";
 		    file action="copy" source="#s#" destination="#sdsf#";
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="yes";
 		    assertEquals("copy1.txt,copy2.txt,test1,test4.txt",
 			  		ListSort(valueList(children.name),'text'));
@@ -171,7 +173,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	}
 
 	private void function fileAMove(string label,string dir){
-	
+
 	    var children="";
 	    var s=arguments.dir&"move1.txt";
 	    var d=arguments.dir&"move2.txt";
@@ -182,7 +184,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		    file action="write" file="#s#" output="" addnewline="no" fixnewline="no";
 		    file action="move" source="#s#" destination="#d#";
 		    file action="move" source="#d#" destination="#sdsf#";
-		    
+
 		    directory directory="#dir#" action="list" name="children" recurse="yes";
 		    assertEquals("test1,test4.txt",
 			  		valueList(children.name));
@@ -209,7 +211,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	private void function fileAReadBinary(string label,string dir){
 	    var content="";
 	    var s=arguments.dir&"read.gif";
-	    
+
 	    try {
 		    file action="write" file="#s#" output="Susi" addnewline="no" fixnewline="no";
 	    	file action="readbinary" file="#s#" variable="content";
@@ -225,9 +227,9 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 private function testResourceDirectoryCreateDelete(res) localMode=true {
     sss=res.getRealResource("s/ss");
 
-    // must fail 
+    // must fail
     try{
-        sss.createDirectory(false); 
+        sss.createDirectory(false);
         fail=false;
     }
     catch(e){fail=true;}
@@ -243,7 +245,7 @@ private function testResourceDirectoryCreateDelete(res) localMode=true {
 
     // must fail dir with kids
     try{
-        s.remove(false); 
+        s.remove(false);
         fail=false;
     }
     catch(e){fail=true;}
@@ -253,20 +255,20 @@ private function testResourceDirectoryCreateDelete(res) localMode=true {
     s.remove(true);
     assertFalse(s.exists());
 
-    // must fail 
-    try{ 
+    // must fail
+    try{
         s.remove(true);// delete
        fail=false;
     }
     catch(e){fail=true;}
     assertTrue(fail);
-    
+
     assertFalse(sss.exists());
 
 
     d=res.getRealResource("notExist");
     try{
-        d.remove(false); 
+        d.remove(false);
         fail=false;
     }
     catch(e){fail=true;}
@@ -274,12 +276,12 @@ private function testResourceDirectoryCreateDelete(res) localMode=true {
 }
 
 private function testResourceFileCreateDelete(res) localMode=true {
-    
+
     sss=res.getRealResource("s/ss.txt");
 
-    // must fail 
+    // must fail
     try{
-        sss.createFile(false); 
+        sss.createFile(false);
         fail=false;
     }
     catch(e){fail=true;}
@@ -291,9 +293,9 @@ private function testResourceFileCreateDelete(res) localMode=true {
 
     s=sss.getParentresource();
 
-    // must fail 
+    // must fail
     try{
-        s.remove(false); 
+        s.remove(false);
         fail=false;
     }
     catch(e){fail=true;}
@@ -305,12 +307,12 @@ private function testResourceFileCreateDelete(res) localMode=true {
 }
 
 private function testResourceListening(res) localMode=true {
-    s=res.getRealResource("s/ss.txt");
-    s.createFile(true); 
-    ss=res.getRealResource("ss/");
+    s=res.getRealResource("s#FSEP#ss.txt");
+    s.createFile(true);
+    ss=res.getRealResource("ss#FSEP#");
     ss.createDirectory(true);
     sss=res.getRealResource("sss.txt");
-    sss.createFile(true); 
+    sss.createFile(true);
 
     // all
     children=res.list();
@@ -328,7 +330,7 @@ private function toResource(string path) localMode=true {
 }
 
 private function testResourceIS(res) localMode=true {
-    
+
     // must be a existing dir
     assertTrue(res.exists());
     assertTrue(res.isDirectory());
@@ -348,7 +350,7 @@ private function testResourceIS(res) localMode=true {
 
 private function testResourceMoveCopy(res) localMode=true {
     o=res.getRealResource("original.txt");
-    o.createFile(true); 
+    o.createFile(true);
     assertTrue(o.exists());
 
     // copy
@@ -378,7 +380,7 @@ private function testResourceGetter(res) localMode=true {
     d=res.getRealResource("dir/");
     d2=res.getRealResource("dir2")
     dd=res.getRealResource("dir/test.txt");
-    
+
     // Name
     assertEquals("original.txt",f.getName());
     assertEquals("dir",d.getName());
@@ -388,15 +390,15 @@ private function testResourceGetter(res) localMode=true {
     assertEquals("dir",dd.getParentResource().getName());
 
     // getRealPath
-    assertEquals(res.toString()&"/dir/test.txt",dd.toString());
+    assertEquals(res.toString()&"#FSEP#dir#FSEP#test.txt",dd.toString());
 
 }
 
 private function testResourceReadWrite(res) localMode=true {
     f=res.getRealResource("original.txt");
-    
+
     IOUtil=createObject("java","lucee.commons.io.IOUtil");
-    
+
     IOUtil.write(f, "Susi Sorglos", nullValue(), false);
     res=IOUtil.toString(f,nullValue());
     assertEquals("Susi Sorglos",res);
@@ -416,57 +418,57 @@ private function testResourceProvider(string path) localmode=true {
 
     // delete when exists
     if(res.exists()) res.remove(true);
-    
+
     // test create/delete directory
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceDirectoryCreateDelete(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
-    
+    finally {if(res.exists()) res.remove(true);}
+
     // test create/delete file
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceFileCreateDelete(res);
     }
     finally {if(res.exists()) res.remove(true);} 
-    
+
     // test listening
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceListening(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
+    finally {if(res.exists()) res.remove(true);}
 
     // test "is"
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceIS(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
+    finally {if(res.exists()) res.remove(true);}
 
     // test move and copy
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceMoveCopy(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
+    finally {if(res.exists()) res.remove(true);}
 
     // test Getter
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceGetter(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
+    finally {if(res.exists()) res.remove(true);}
 
     // test read/write
     try {
-        res.createDirectory(true); 
+        res.createDirectory(true);
         testResourceReadWrite(res);
     }
-    finally {if(res.exists()) res.remove(true);} 
+    finally {if(res.exists()) res.remove(true);}
 
-    
+
 }
 
 
@@ -476,8 +478,8 @@ private function testResourceProvider(string path) localmode=true {
 	private void function test(string label,string root){
 		var start=getTickCount();
 		var dir=arguments.root&"testResource/";
-		
-		// make sure there are no data from a previous run 
+
+		// make sure there are no data from a previous run
 		if(directoryExists(dir)) {
 			directory directory="#dir#" action="delete" recurse="yes";
 		}
@@ -492,11 +494,11 @@ private function testResourceProvider(string path) localmode=true {
 		    fileAReadAppend(arguments.label,dir);
 		    fileAReadBinary(arguments.label,dir);
 		    testResourceProvider(dir&"testcaseRes");
-		    
+
 		}
 		finally {
 			directory directory="#dir#" action="delete" recurse="yes";
-		}   
+		}
 		assertFalse(DirectoryExists(dir));
 
 	}
@@ -544,11 +546,8 @@ private function testResourceProvider(string path) localmode=true {
 	public void function testS3() localmode=true{
 		var s3=getCredencials();
 		if(!isNull(s3.accessKeyId)) {
-			application action="update" s3=s3; 
+			application action="update" s3=s3;
 			test("s3","s3:///");
 		}
 	}
-} 
-
-
-
+}

--- a/test/tickets/LDEV0655.cfc
+++ b/test/tickets/LDEV0655.cfc
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015, Lucee Assosication Switzerland. All rights reserved.*
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+component extends="org.lucee.cfml.test.LuceeTestCase"	{
+
+	public void function test(){
+		var allowLuceeDialect = GetPageContext().getConfig().allowLuceeDialect();
+
+		for (mapping in GetPageContext().getApplicationContext().getMappings())
+			mapping.getConfig().setAllowLuceeDialect(false);
+
+		include "LDEV0655/test.txt";
+
+		assertTrue(structKeyExists(this, "ldev0655Pass"));
+
+		for (mapping in GetPageContext().getApplicationContext().getMappings())
+			mapping.getConfig().setAllowLuceeDialect(allowLuceeDialect);
+	}
+}

--- a/test/tickets/LDEV0655/test.txt
+++ b/test/tickets/LDEV0655/test.txt
@@ -1,0 +1,1 @@
+<cfset this.ldev0655Pass = true>


### PR DESCRIPTION
This fixes LDEV-655 by returning DIALECT_CFML from PageSourceImpl.getDialect() when the lucee dialect is disabled.

Also, there are two windows build fixes:
1. set the javac task's encoding to utf-8 (RHExtension.java would not compile)
2. an assertation in the resources test was coded with *nix file separators - changed to use platform-specific separator
