### PR TITLE
Added TLSv1.1 and TLSv1.2 for client SSL in CFHTTP

### DIFF
--- a/core/src/main/java/lucee/commons/net/http/httpclient/HTTPEngine4Impl.java
+++ b/core/src/main/java/lucee/commons/net/http/httpclient/HTTPEngine4Impl.java
@@ -352,7 +352,7 @@ public class HTTPEngine4Impl {
                 // Allow TLSv1 protocol only
                 SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(
                     sslContext,
-                    new String[] { "TLSv1" },
+                    new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" },
                     null,
                     SSLConnectionSocketFactory.getDefaultHostnameVerifier());
 
@@ -401,10 +401,10 @@ public class HTTPEngine4Impl {
 	 */
 	private static HttpEntity toHttpEntity(Object value, String mimetype, String charset) throws IOException {
 		if(value instanceof HttpEntity) return (HttpEntity) value;
-		
+
 		// content type
 		ContentType ct=HTTPEngine.toContentType(mimetype, charset);
-		
+
     	try{
     		if(value instanceof TemporaryStream) {
 	    		if(ct!=null)
@@ -424,7 +424,7 @@ public class HTTPEngine4Impl {
 			else {
 				if(ct==null)
 					ct=ContentType.APPLICATION_OCTET_STREAM;
-				
+
 				String str = Caster.toString(value);
 				if(str.equals("<empty>")) {
 					return new EmptyHttpEntity(ct);
@@ -436,7 +436,7 @@ public class HTTPEngine4Impl {
     		throw ExceptionUtil.toIOException(e);
     	}
     }
-	
+
 
 
 	public static Entity getEmptyEntity(ContentType contentType) {


### PR DESCRIPTION
When using clientCert with <cfhttp> only TLSv1(.0) was enabled. I've added TLSv1.1 and TLSv1.2 to setClientSSL().

See https://groups.google.com/forum/#!topic/lucee/ZF7oX1P3xi8
