### PR TITLE
Fix for JDBC drivers that do not implement Statement.getMoreResults(int) correctly

### DIFF
--- a/core/src/main/java/lucee/runtime/type/QueryImpl.java
+++ b/core/src/main/java/lucee/runtime/type/QueryImpl.java
@@ -287,8 +287,10 @@ public class QueryImpl implements Query,Objects,QueryResult {
 				}
 				
 				else break;
+				
 				try{
-					hasResult=stat.getMoreResults(Statement.CLOSE_CURRENT_RESULT);
+					//hasResult=stat.getMoreResults(Statement.CLOSE_CURRENT_RESULT);
+					hasResult=stat.getMoreResults();
 				}
 				catch(Throwable t){
 					break;


### PR DESCRIPTION
Since fillResult closes the ResultSet already, just use Statement.getMoreResults() instead, as some JDBC drivers may not implement getMoreResults(int) correctly.
