### PR TITLE
Fixes: LDEV-574

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/international/LSCurrencyFormat.java
+++ b/core/src/main/java/lucee/runtime/functions/international/LSCurrencyFormat.java
@@ -21,6 +21,7 @@
  */
 package lucee.runtime.functions.international;
 
+import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.util.Currency;
 import java.util.Locale;
@@ -60,12 +61,14 @@ public final class LSCurrencyFormat implements Function {
 	}
 
 	public static String none(Locale locale, double number) {
+		BigDecimal d = new BigDecimal(Double.toString(number)).setScale(2, BigDecimal.ROUND_HALF_UP);
         NumberFormat nf = NumberFormat.getCurrencyInstance(locale);
-        return StringUtil.replace(nf.format(number),nf.getCurrency().getSymbol(locale),"",false).trim();
+        return StringUtil.replace(nf.format(d.doubleValue()),nf.getCurrency().getSymbol(locale),"",false).trim();
 	}
 	
 	public static String local(Locale locale, double number) {
-		return NumberFormat.getCurrencyInstance(locale).format(number);	
+		BigDecimal d = new BigDecimal(Double.toString(number)).setScale(2, BigDecimal.ROUND_HALF_UP);
+		return NumberFormat.getCurrencyInstance(locale).format(d.doubleValue());		
 	}
 	
 	public static String international(Locale locale, double number) {


### PR DESCRIPTION
Using BigDecimal() setScale() to round number before passing it to NumberFormat.format()

@joel-ferreira was able to illustrate rounding errors with the following code snippet:

```
<cfoutput>
<cfloop from="1" to="999" index="i">
    <cfset number1 = 1 />
    <cfset number2 = number1 + (i/1000) />
    <cfset number3 = dollarFormat(number2) />
    <cfset number4 = '$' & numberFormat(number2, '0.00') />
    <cfif number3 NEQ number4>

    #number1#<br />
    #number2#<br />
    #number3#<br />
    #number4#<br />
        PROBLEM<br />
         <hr />
    </cfif>
</cfloop>
</cfoutput>
```
