### PR TITLE
Fix spelling s/namesapce/namespace/g;

### DIFF
--- a/core/src/main/java/lucee/transformer/cfml/tag/CFMLTransformer.java
+++ b/core/src/main/java/lucee/transformer/cfml/tag/CFMLTransformer.java
@@ -525,7 +525,7 @@ public final class CFMLTransformer {
 		int start=data.srcCode.getPos();
 		data.srcCode.next();
 		
-		// read in namesapce of tag
+		// read in namespace of tag
 		TagLib tagLib=nameSpace(data);
 		
 		// return if no matching tag lib

--- a/core/src/main/java/resource/fld/core-base.fld
+++ b/core/src/main/java/resource/fld/core-base.fld
@@ -5684,7 +5684,7 @@ The returned number of unallocated bytes is a hint, but not a guarantee, that it
 			<name>nameSpaceWithSeperator</name>
 			<type>string</type>
 			<required>Yes</required>
-			<description>The namesapce of the tag with the seperator Example: cf, rc: aso.</description>
+			<description>The namespace of the tag with the seperator Example: cf, rc: aso.</description>
 		</argument>
 		<argument>
 			<name>tagName</name>


### PR DESCRIPTION
Same as pull request #22  - but on Branch 5.0
