### PR TITLE
Lucee 5.0 thread stop issue

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -763,6 +763,9 @@
       <jvmarg value="-Dlucee.web.dir=${temp}/archive/webroot"/>
       <jvmarg value="-Dlucee-extensions=${extH2},${extMongo},${extOracle}"/>
       <jvmarg value="-Dlucee.enable.dialect=true"/>
+      <jvmarg value="-Dlucee.full.null.support=false"/>
+
+
     </java>
     <echo>${exc2}</echo>
 

--- a/core/src/main/java/lucee/commons/io/SystemUtil.java
+++ b/core/src/main/java/lucee/commons/io/SystemUtil.java
@@ -1382,7 +1382,8 @@ class StopThread extends Thread {
 				catch(UnsupportedOperationException uoe){
 					LogUtil.log(log, Log.LEVEL_INFO, "", "Thread.stop(Throwable) is not supported by this JVM and failed with UnsupportedOperationException", thread.getStackTrace());
 					try {
-						Method m = thread.getClass().getDeclaredMethod("stop0", new Class[]{Object.class});
+						// This is a private, native method on the java.lang.Thread object directly
+						Method m = Thread.class.getDeclaredMethod("stop0", new Class[]{Object.class});
 						m.setAccessible(true); // allow to access private method
 						m.invoke(thread, new Object[]{t});
 					}

--- a/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
+++ b/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
@@ -4626,7 +4626,8 @@ public final class XMLConfigWebFactory extends XMLConfigFactory {
 			}
 			else {
 				String str = getAttr(compiler,"full-null-support");
-
+				if(StringUtil.isEmpty(str, true)) str=getSystemPropOrEnvVar("lucee.full.null.support",null);
+				
 				if (!StringUtil.isEmpty(str, true)) {
 					fns = Caster.toBooleanValue(str, false);
 				}

--- a/core/src/main/java/lucee/transformer/bytecode/cast/CastOther.java
+++ b/core/src/main/java/lucee/transformer/bytecode/cast/CastOther.java
@@ -79,7 +79,6 @@ public final class CastOther extends ExpressionBase implements Cast {
         break;
         case 's':
         	if("string".equals(lcType))							return expr.getFactory().toExprString(expr);
-        	//if("string_array".equals(lcType))					return StringArray.toExpr(expr);     
         break;
         case 'u':
         	if("uuid".equals(lcType)) 							return  expr.getFactory().toExprString(expr);
@@ -408,6 +407,12 @@ public final class CastOther extends ExpressionBase implements Cast {
                 adapter.invokeStatic(Types.CASTER,Methods_Caster.TO_TIMEZONE);
                 return Types.TIMEZONE;
             }
+            else if("timespan".equals(lcType)) {
+            	rtn=expr.writeOut(bc,MODE_REF);
+                if(!rtn.equals(Types.TIMESPAN))
+                	adapter.invokeStatic(Types.CASTER,Methods_Caster.TO_TIMESPAN);
+                return Types.TIMESPAN;
+            }
         break;
         case 's':
             if("struct".equals(lcType)) {
@@ -459,12 +464,6 @@ public final class CastOther extends ExpressionBase implements Cast {
                 	adapter.invokeStatic(Types.CASTER,Methods_Caster.TO_QUERY_COLUMN);
                 }
                 return Types.QUERY_COLUMN;
-            }
-            else if("timespan".equals(lcType)) {
-            	rtn=expr.writeOut(bc,MODE_REF);
-                if(!rtn.equals(Types.TIMESPAN))
-                	adapter.invokeStatic(Types.CASTER,Methods_Caster.TO_TIMESPAN);
-                return Types.TIMESPAN;
             }
         }
         Type t=getType(type);

--- a/loader/build.xml
+++ b/loader/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="core" basedir="." name="Lucee" xmlns:artifact="antlib:org.apache.maven.artifact.ant">
 
-  <property name="version" value="5.0.1.10-SNAPSHOT"/>
+  <property name="version" value="5.0.1.11-SNAPSHOT"/>
 
   <path id="maven-ant-tasks.classpath" path="../ant/lib/maven-ant-tasks-2.1.3.jar" />
   <typedef resource="org/apache/maven/artifact/ant/antlib.xml"

--- a/loader/build.xml
+++ b/loader/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="core" basedir="." name="Lucee" xmlns:artifact="antlib:org.apache.maven.artifact.ant">
 
-  <property name="version" value="5.0.1.11-SNAPSHOT"/>
+  <property name="version" value="5.0.1.12-SNAPSHOT"/>
 
   <path id="maven-ant-tasks.classpath" path="../ant/lib/maven-ant-tasks-2.1.3.jar" />
   <typedef resource="org/apache/maven/artifact/ant/antlib.xml"

--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.lucee</groupId>
   <artifactId>lucee</artifactId>
-  <version>5.0.1.10-SNAPSHOT</version>
+  <version>5.0.1.11-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Lucee Loader Build</name>

--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.lucee</groupId>
   <artifactId>lucee</artifactId>
-  <version>5.0.1.11-SNAPSHOT</version>
+  <version>5.0.1.12-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Lucee Loader Build</name>

--- a/test/tickets/LDEV0875.cfc
+++ b/test/tickets/LDEV0875.cfc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014, the Railo Company LLC. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ component extends="org.lucee.cfml.test.LuceeTestCase" {
+	variables.cacheName="Test"&ListFirst(ListLast(getCurrentTemplatePath(),"\/"),".");
+	
+	public function testCachePutEHCache() {
+		createRAMCache();
+		
+		cachePut('abc','123',1);
+
+		deleteCache();
+	}
+
+
+	
+	
+	private function createRAMCache(){
+		admin 
+				action="updateCacheConnection"
+				type="web"
+				password="#request.webadminpassword#"
+				
+				
+				name="#cacheName#" 
+				class="lucee.runtime.cache.ram.RamCache" 
+				storage="false"
+				default="object" 
+				custom="#{timeToLiveSeconds:86400
+					,timeToIdleSeconds:86400}#";
+	}
+				
+	private function deleteCache(){
+		admin 
+			action="removeCacheConnection"
+			type="web"
+			password="#request.webadminpassword#"
+			name="#cacheName#";
+						
+	}
+}


### PR DESCRIPTION
Use of thread.stop0 will only work on java.lang.Thread directly - fix reflection to use the parent class.

Specific cases of this - reported by @mjhagen on lucee channel on Slack... Related to database errors within a scheduled task.  Errors on the console are non-descript, and hide the actual error returned from the code.  stop0 isn't able to be executed on a TaskThread, so stop() is the only recourse, which sends ThreadDeath instead of the appropriate exception.
