### PR TITLE
Lucee 5.0 thread stop issue

### DIFF
--- a/core/src/main/java/lucee/commons/io/SystemUtil.java
+++ b/core/src/main/java/lucee/commons/io/SystemUtil.java
@@ -1382,7 +1382,8 @@ class StopThread extends Thread {
 				catch(UnsupportedOperationException uoe){
 					LogUtil.log(log, Log.LEVEL_INFO, "", "Thread.stop(Throwable) is not supported by this JVM and failed with UnsupportedOperationException", thread.getStackTrace());
 					try {
-						Method m = thread.getClass().getDeclaredMethod("stop0", new Class[]{Object.class});
+						// This is a private, native method on the java.lang.Thread object directly
+						Method m = Thread.class.getDeclaredMethod("stop0", new Class[]{Object.class});
 						m.setAccessible(true); // allow to access private method
 						m.invoke(thread, new Object[]{t});
 					}


### PR DESCRIPTION
Use of thread.stop0 will only work on java.lang.Thread directly - fix reflection to use the parent class.

Specific cases of this - reported by @mjhagen on lucee channel on Slack... Related to database errors within a scheduled task.  Errors on the console are non-descript, and hide the actual error returned from the code.  stop0 isn't able to be executed on a TaskThread, so stop() is the only recourse, which sends ThreadDeath instead of the appropriate exception.
