### PR TITLE
Adds failing assertion for LDEV0907.

### DIFF
--- a/test/tickets/LDEV0907.cfc
+++ b/test/tickets/LDEV0907.cfc
@@ -1,29 +1,29 @@
-<!--- 
+<!---
  *
  * Copyright (c) 2016, Lucee Assosication Switzerland. All rights reserved.*
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  ---><cfscript>
 component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 	variables.qry=query(a:[1,2,3,4,5,6]);
 
 	private function exe(time) {
-	    query 
-	        name="qoq" 
-	        dbtype="query" 
+	    query
+	        name="qoq"
+	        dbtype="query"
 	        cachedWithin=createTimeSpan(0,0,0,time) {
 	        echo('select * from qry where a>'&time);
 	    }
@@ -36,6 +36,13 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 		assertFalse(exe(1).isCached());
 		assertTrue(exe(1).isCached());
+
+		// Cache should not be used here, even if it is populated.
+		assertFalse(exe(0).isCached());
+
+		// Legacy ACF/Railo/Lucee pre-5.0 behavior is that the last query would
+		// have cleared that statement from the query cache.
+		assertFalse(exe(1).isCached());
 	}
-} 
+}
 </cfscript>


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-907

Without a way to clear a specific query from the query cache, query caching is
unusable for my applications. Caching mechanisms need a way to invalidate items.
Traditionally in ACF, Railo, and Lucee 4.5, using a cachedwithin value of
CreateTimespan(0,0,0,0) would clear that particular query from the cache.
