### PR TITLE
Page engines

### DIFF
--- a/core/src/main/java/lucee/runtime/PageContextImpl.java
+++ b/core/src/main/java/lucee/runtime/PageContextImpl.java
@@ -2230,14 +2230,12 @@ public final class PageContextImpl extends PageContext {
 
 	@Override
 	public final void execute(String realPath, boolean throwExcpetion, boolean onlyTopLevel) throws PageException  {
-		requestDialect=currentTemplateDialect=CFMLEngine.DIALECT_LUCEE;
 		_execute(realPath, throwExcpetion, onlyTopLevel);
 	}
 	
 
 	@Override
 	public final void executeCFML(String realPath, boolean throwExcpetion, boolean onlyTopLevel) throws PageException  {
-		requestDialect=currentTemplateDialect=CFMLEngine.DIALECT_CFML;
 		_execute(realPath, throwExcpetion, onlyTopLevel);
 	}
 	
@@ -2269,6 +2267,8 @@ public final class PageContextImpl extends PageContext {
 			if(base==null) base=PageSourceImpl.best(config.getPageSources(this,null,realPath,onlyTopLevel,false,true));
 		}
 		else base=PageSourceImpl.best(config.getPageSources(this,null,realPath,onlyTopLevel,false,true));
+		
+		requestDialect=currentTemplateDialect=base.getDialect();
 		
 		execute(base, throwExcpetion, onlyTopLevel);
 	}
@@ -2965,7 +2965,7 @@ public final class PageContextImpl extends PageContext {
 	@Override
 	public synchronized void compile(PageSource pageSource) throws PageException {
 		Resource classRootDir = pageSource.getMapping().getClassRootDirectory();
-		int dialect=getCurrentTemplateDialect();
+		int dialect=pageSource.getDialect(); //getCurrentTemplateDialect();
         
 		try {
 			config.getCompiler().compile(

--- a/core/src/main/java/lucee/runtime/PageContextImpl.java
+++ b/core/src/main/java/lucee/runtime/PageContextImpl.java
@@ -2233,7 +2233,10 @@ public final class PageContextImpl extends PageContext {
 		_execute(realPath, throwExcpetion, onlyTopLevel);
 	}
 	
-
+	/**
+	 * @deprecated Use execute instead.
+	 */
+	@Deprecated
 	@Override
 	public final void executeCFML(String realPath, boolean throwExcpetion, boolean onlyTopLevel) throws PageException  {
 		_execute(realPath, throwExcpetion, onlyTopLevel);

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -47,6 +47,7 @@ import lucee.runtime.exp.PageRuntimeException;
 import lucee.runtime.exp.TemplateException;
 import lucee.runtime.functions.system.GetDirectoryFromPath;
 import lucee.runtime.op.Caster;
+import lucee.runtime.page.engine.PageEngine;
 import lucee.runtime.type.util.ArrayUtil;
 import lucee.runtime.type.util.ListUtil;
 
@@ -81,12 +82,13 @@ public final class PageSourceImpl implements PageSource {
 	private boolean flush=false;
     //private boolean recompileAlways;
     //private boolean recompileAfterStartUp;
+	
+	private PageEngine pageEngine = null;
     
     private PageSourceImpl() {
     	mapping=null;
         relPath=null;
     }
-    
     
     /**
 	 * constructor of the class
@@ -113,10 +115,8 @@ public final class PageSourceImpl implements PageSource {
 			}
 		}
 		this.relPath=realPath;
-	    
+	    _loadPageEngine();
 	}
-	
-	
 	
 	/**
 	 * private constructor of the class
@@ -131,9 +131,14 @@ public final class PageSourceImpl implements PageSource {
 	    this.isOutSide=isOutSide;
 	    if(realPath.indexOf("//")!=-1) {
         	realPath=StringUtil.replace(realPath, "//", "/",false);
-        }this.relPath=realPath;
-		
+        }
+	    this.relPath=realPath;
+	    _loadPageEngine();
 	}
+    
+    private void _loadPageEngine() {
+    	this.pageEngine = this.mapping.getConfig().getPageEngine(relPath);
+    }
 	
 	/**
 	 * return page when already loaded, otherwise null
@@ -155,6 +160,9 @@ public final class PageSourceImpl implements PageSource {
 	
 	@Override
 	public Page loadPage(PageContext pc, boolean forceReload) throws PageException {
+		return pageEngine.getPageFactory().getPage(pc, this, forceReload, null);
+		
+		/*
 		if(forceReload) page=null;
 		
 		Page page=this.page;
@@ -169,12 +177,20 @@ public final class PageSourceImpl implements PageSource {
 	        if(page!=null) return page;
 	    }
 		throw new MissingIncludeException(this);
-	    
+	    */
 	}
 	
 	@Override
 	public Page loadPageThrowTemplateException(PageContext pc, boolean forceReload, Page defaultValue) throws TemplateException {
-		if(forceReload) page=null;
+		try {
+			return pageEngine.getPageFactory().getPage(pc, this, forceReload, defaultValue);
+		} catch(PageException e) {
+			if (e instanceof TemplateException)
+				throw (TemplateException)e;
+			return null;
+		}
+		
+		/*if(forceReload) page=null;
 		
 		Page page=this.page;
 		if(mapping.isPhysicalFirst()) {
@@ -187,13 +203,22 @@ public final class PageSourceImpl implements PageSource {
 	        if(page==null)page=loadPhysical(pc,page);
 	        if(page!=null) return page;
 	    }
-	    return defaultValue;
+	    return defaultValue;*/
 	}
 
 	
 	@Override
 	public Page loadPage(PageContext pc, boolean forceReload, Page defaultValue) {
-		if(forceReload) page=null;
+		try {
+			return pageEngine.getPageFactory().getPage(pc, this, forceReload, defaultValue);
+		} catch(PageException e) {
+			if (forceReload)
+				return null;
+			else
+				return defaultValue;
+		}
+		
+		/*if(forceReload) page=null;
 		
 		Page page=this.page;
 		if(mapping.isPhysicalFirst()) {
@@ -216,101 +241,101 @@ public final class PageSourceImpl implements PageSource {
 	        }
 	        if(page!=null) return page;
 	    }
-	    return defaultValue;
+	    return defaultValue;*/
 	}
 	
-    private Page loadArchive(Page page) {
-    	if(!mapping.hasArchive()) return null;
-		if(page!=null && page.getLoadType()==LOAD_ARCHIVE) return page;
-        try {
-            synchronized(this) {
-                Class clazz=mapping.getArchiveClass(getClassName());
-                
-                this.page=page=newInstance(clazz);
-                page.setPageSource(this);
-                //page.setTimeCreated(System.currentTimeMillis());
-                page.setLoadType(LOAD_ARCHIVE);
-    			////load=LOAD_ARCHIVE;
-    			return page;
-            }
-        } 
-        catch (Exception e) {
-        	// MUST print.e(e); is there a better way?
-        	return null;
-        }
-    }
-    
-    /**
-     * throws only an exception when compilation fails
-     * @param pc
-     * @param page
-     * @return
-     * @throws PageException
-     */
-    private Page loadPhysical(PageContext pc,Page page) throws TemplateException {
-    	if(!mapping.hasPhysical()) return null;
-    	
-    	ConfigWeb config=pc.getConfig();
-    	PageContextImpl pci=(PageContextImpl) pc;
-    	if((mapping.getInspectTemplate()==Config.INSPECT_NEVER || pci.isTrusted(page)) && isLoad(LOAD_PHYSICAL)) return page;
-    	Resource srcFile = getPhyscalFile();
-    	
-		long srcLastModified = srcFile.lastModified();
-        if(srcLastModified==0L) return null;
-    	
-		// Page exists    
-			if(page!=null) {
-			//if(page!=null && !recompileAlways) {
-				if(srcLastModified!=page.getSourceLastModified()) {
-					this.page=page=compile(config,mapping.getClassRootDirectory(),page,false,pc.ignoreScopes());
-                	page.setPageSource(this);
-					page.setLoadType(LOAD_PHYSICAL);
-				}
-		    	
-			}
-		// page doesn't exist
-			else {
-                ///synchronized(this) {
-                    Resource classRootDir=mapping.getClassRootDirectory();
-                    Resource classFile=classRootDir.getRealResource(getJavaName()+".class");
-                    boolean isNew=false;
-                    // new class
-                    if(flush || !classFile.exists()) {
-                    //if(!classFile.exists() || recompileAfterStartUp) {
-                    	this.page=page= compile(config,classRootDir,null,false,pc.ignoreScopes());
-                    	flush=false;
-                        isNew=true;
-                    }
-                    // load page
-                    else {
-                    	try {
-                    		this.page=page=newInstance(mapping.getPhysicalClass(this.getClassName()));
-    					} catch (Throwable t) {t.printStackTrace();
-							this.page=page=null;
-						}
-                    	if(page==null) this.page=page=compile(config,classRootDir,null,false,pc.ignoreScopes());
-                              
-                    }
-                    
-                    // check if version changed or lasMod
-                    if(!isNew && 
-                    		(
-                    				srcLastModified!=page.getSourceLastModified()
-                    				||
-                    				page.getVersion()!=pc.getConfig().getFactory().getEngine().getInfo().getFullVersionInfo()
-                    		)
-                    ) {
-                    	isNew=true;
-                    	this.page=page=compile(config,classRootDir,page,false,pc.ignoreScopes());
-    				}
-                    
-                    page.setPageSource(this);
-    				page.setLoadType(LOAD_PHYSICAL);
-
-			}
-			pci.setPageUsed(page);
-			return page;
-    }
+//    private Page loadArchive(Page page) {
+//    	if(!mapping.hasArchive()) return null;
+//		if(page!=null && page.getLoadType()==LOAD_ARCHIVE) return page;
+//        try {
+//            synchronized(this) {
+//                Class clazz=mapping.getArchiveClass(getClassName());
+//                
+//                this.page=page=newInstance(clazz);
+//                page.setPageSource(this);
+//                //page.setTimeCreated(System.currentTimeMillis());
+//                page.setLoadType(LOAD_ARCHIVE);
+//    			////load=LOAD_ARCHIVE;
+//    			return page;
+//            }
+//        } 
+//        catch (Exception e) {
+//        	// MUST print.e(e); is there a better way?
+//        	return null;
+//        }
+//    }
+//    
+//    /**
+//     * throws only an exception when compilation fails
+//     * @param pc
+//     * @param page
+//     * @return
+//     * @throws PageException
+//     */
+//    private Page loadPhysical(PageContext pc,Page page) throws TemplateException {
+//    	if(!mapping.hasPhysical()) return null;
+//    	
+//    	ConfigWeb config=pc.getConfig();
+//    	PageContextImpl pci=(PageContextImpl) pc;
+//    	if((mapping.getInspectTemplate()==Config.INSPECT_NEVER || pci.isTrusted(page)) && isLoad(LOAD_PHYSICAL)) return page;
+//    	Resource srcFile = getPhyscalFile();
+//    	
+//		long srcLastModified = srcFile.lastModified();
+//        if(srcLastModified==0L) return null;
+//    	
+//		// Page exists    
+//			if(page!=null) {
+//			//if(page!=null && !recompileAlways) {
+//				if(srcLastModified!=page.getSourceLastModified()) {
+//					this.page=page=compile(config,mapping.getClassRootDirectory(),page,false,pc.ignoreScopes());
+//                	page.setPageSource(this);
+//					page.setLoadType(LOAD_PHYSICAL);
+//				}
+//		    	
+//			}
+//		// page doesn't exist
+//			else {
+//                ///synchronized(this) {
+//                    Resource classRootDir=mapping.getClassRootDirectory();
+//                    Resource classFile=classRootDir.getRealResource(getJavaName()+".class");
+//                    boolean isNew=false;
+//                    // new class
+//                    if(flush || !classFile.exists()) {
+//                    //if(!classFile.exists() || recompileAfterStartUp) {
+//                    	this.page=page= compile(config,classRootDir,null,false,pc.ignoreScopes());
+//                    	flush=false;
+//                        isNew=true;
+//                    }
+//                    // load page
+//                    else {
+//                    	try {
+//                    		this.page=page=newInstance(mapping.getPhysicalClass(this.getClassName()));
+//    					} catch (Throwable t) {t.printStackTrace();
+//							this.page=page=null;
+//						}
+//                    	if(page==null) this.page=page=compile(config,classRootDir,null,false,pc.ignoreScopes());
+//                              
+//                    }
+//                    
+//                    // check if version changed or lasMod
+//                    if(!isNew && 
+//                    		(
+//                    				srcLastModified!=page.getSourceLastModified()
+//                    				||
+//                    				page.getVersion()!=pc.getConfig().getFactory().getEngine().getInfo().getFullVersionInfo()
+//                    		)
+//                    ) {
+//                    	isNew=true;
+//                    	this.page=page=compile(config,classRootDir,page,false,pc.ignoreScopes());
+//    				}
+//                    
+//                    page.setPageSource(this);
+//    				page.setLoadType(LOAD_PHYSICAL);
+//
+//			}
+//			pci.setPageUsed(page);
+//			return page;
+//    }
 
     public void flush() {
 		page=null;
@@ -320,62 +345,61 @@ public final class PageSourceImpl implements PageSource {
     private boolean isLoad(byte load) {
 		return page!=null && load==page.getLoadType();
 	}
-    
 
-	private synchronized Page compile(ConfigWeb config,Resource classRootDir, Page existing, boolean returnValue, boolean ignoreScopes) throws TemplateException {
-		try {
-			return _compile(config, classRootDir,existing,returnValue,ignoreScopes);
-        }
-			catch(RuntimeException re) {re.printStackTrace();
-	    	String msg=StringUtil.emptyIfNull(re.getMessage());
-	    	if(StringUtil.indexOfIgnoreCase(msg, "Method code too large!")!=-1) {
-	    		throw new TemplateException("There is too much code inside the template ["+getDisplayPath()+"], "+Constants.NAME+" was not able to break it into pieces, move parts of your code to an include or a external component/function",msg);
-	    	}
-	    	throw re;
-	    }
-        catch(ClassFormatError e) {
-        	String msg=StringUtil.emptyIfNull(e.getMessage());
-        	if(StringUtil.indexOfIgnoreCase(msg, "Invalid method Code length")!=-1) {
-        		throw new TemplateException("There is too much code inside the template ["+getDisplayPath()+"], "+Constants.NAME+" was not able to break it into pieces, move parts of your code to an include or a external component/function",msg);
-        	}
-        	throw new TemplateException("ClassFormatError:"+e.getMessage());
-        }
-        catch(Throwable t) {
-        	if(t instanceof TemplateException) throw (TemplateException)t;
-        	throw new PageRuntimeException(Caster.toPageException(t));
-        	//throw new TemplateException(t.getClass().getName()+":"+t.getMessage());
-        }
-	}
-
-	private Page _compile(ConfigWeb config,Resource classRootDir, Page existing,boolean returnValue, boolean ignoreScopes) throws IOException, SecurityException, IllegalArgumentException, PageException {
-        ConfigWebImpl cwi=(ConfigWebImpl) config;
-        int dialect=getDialect();
-        
-        long now;
-        if((getPhyscalFile().lastModified()+10000)>(now=System.currentTimeMillis()))
-        	cwi.getCompiler().watch(this,now);//SystemUtil.get
-        
-                
-        Result result = cwi.getCompiler().
-        	compile(cwi,this,cwi.getTLDs(dialect),cwi.getFLDs(dialect),classRootDir,returnValue,ignoreScopes);
-        
-        try{
-        	
-        	Class<?> clazz = mapping.getPhysicalClass(getClassName(), result.barr);
-        	return  newInstance(clazz);
-        }
-        catch(Throwable t){
-        	PageException pe = Caster.toPageException(t);
-        	pe.setExtendedInfo("failed to load template "+getDisplayPath());
-        	throw pe;
-        }
-    }
-
-    private Page newInstance(Class clazz) throws SecurityException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-    	Constructor<?> c = clazz.getConstructor(new Class[]{PageSource.class});
-		return (Page) c.newInstance(new Object[]{this});
-	}
-
+//	private synchronized Page compile(ConfigWeb config,Resource classRootDir, Page existing, boolean returnValue, boolean ignoreScopes) throws TemplateException {
+//		try {
+//			return _compile(config, classRootDir,existing,returnValue,ignoreScopes);
+//        }
+//			catch(RuntimeException re) {re.printStackTrace();
+//	    	String msg=StringUtil.emptyIfNull(re.getMessage());
+//	    	if(StringUtil.indexOfIgnoreCase(msg, "Method code too large!")!=-1) {
+//	    		throw new TemplateException("There is too much code inside the template ["+getDisplayPath()+"], "+Constants.NAME+" was not able to break it into pieces, move parts of your code to an include or a external component/function",msg);
+//	    	}
+//	    	throw re;
+//	    }
+//        catch(ClassFormatError e) {
+//        	String msg=StringUtil.emptyIfNull(e.getMessage());
+//        	if(StringUtil.indexOfIgnoreCase(msg, "Invalid method Code length")!=-1) {
+//        		throw new TemplateException("There is too much code inside the template ["+getDisplayPath()+"], "+Constants.NAME+" was not able to break it into pieces, move parts of your code to an include or a external component/function",msg);
+//        	}
+//        	throw new TemplateException("ClassFormatError:"+e.getMessage());
+//        }
+//        catch(Throwable t) {
+//        	if(t instanceof TemplateException) throw (TemplateException)t;
+//        	throw new PageRuntimeException(Caster.toPageException(t));
+//        	//throw new TemplateException(t.getClass().getName()+":"+t.getMessage());
+//        }
+//	}
+//
+//	private Page _compile(ConfigWeb config,Resource classRootDir, Page existing,boolean returnValue, boolean ignoreScopes) throws IOException, SecurityException, IllegalArgumentException, PageException {
+//        ConfigWebImpl cwi=(ConfigWebImpl) config;
+//        int dialect=getDialect();
+//        
+//        long now;
+//        if((getPhyscalFile().lastModified()+10000)>(now=System.currentTimeMillis()))
+//        	cwi.getCompiler().watch(this,now);//SystemUtil.get
+//        
+//                
+//        Result result = cwi.getCompiler().
+//        	compile(cwi,this,cwi.getTLDs(dialect),cwi.getFLDs(dialect),classRootDir,returnValue,ignoreScopes);
+//        
+//        try{
+//        	
+//        	Class<?> clazz = mapping.getPhysicalClass(getClassName(), result.barr);
+//        	return  newInstance(clazz);
+//        }
+//        catch(Throwable t){
+//        	PageException pe = Caster.toPageException(t);
+//        	pe.setExtendedInfo("failed to load template "+getDisplayPath());
+//        	throw pe;
+//        }
+//    }
+//
+//    private Page newInstance(Class clazz) throws SecurityException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+//    	Constructor<?> c = clazz.getConstructor(new Class[]{PageSource.class});
+//		return (Page) c.newInstance(new Object[]{this});
+//	}
+//
 
 	/**
      * return source path as String 
@@ -568,7 +592,7 @@ public final class PageSourceImpl implements PageSource {
 		return javaName;
 	}
 
-	private String _getPackageName() {
+	public String getPackageName() {
 		if(packageName==null) createClassAndPackage();
 		return packageName;
 	}
@@ -699,7 +723,7 @@ public final class PageSourceImpl implements PageSource {
         if(!mapping.hasArchive()) 		return IOUtil.toBufferedInputStream(getPhyscalFile().getInputStream());
         else if(isLoad(LOAD_PHYSICAL))	return IOUtil.toBufferedInputStream(getPhyscalFile().getInputStream());
         else if(isLoad(LOAD_ARCHIVE)) 	{
-            StringBuffer name=new StringBuffer(_getPackageName().replace('.','/'));
+            StringBuffer name=new StringBuffer(getPackageName().replace('.','/'));
             if(name.length()>0)name.append("/");
             name.append(getFileName());
             
@@ -890,7 +914,8 @@ public final class PageSourceImpl implements PageSource {
 
 	@Override
 	public int getDialect() {
-		Config c = getMapping().getConfig();
+		return pageEngine.getDialect();
+		/*Config c = getMapping().getConfig();
 		if(!((ConfigImpl)c).allowLuceeDialect()) return CFMLEngine.DIALECT_CFML;
 		// MUST improve performance on this
 		ConfigWeb cw=null;
@@ -909,7 +934,7 @@ public final class PageSourceImpl implements PageSource {
 					.toDialect(ext,CFMLEngine.DIALECT_CFML);
 		}
 		
-		return ConfigWebUtil.toDialect(ext, CFMLEngine.DIALECT_CFML);
+		return ConfigWebUtil.toDialect(ext, CFMLEngine.DIALECT_CFML);*/
 	}
 
 	/**
@@ -931,5 +956,23 @@ public final class PageSourceImpl implements PageSource {
 	@Override
 	public boolean executable() {
 		return (getMapping().getInspectTemplate()==Config.INSPECT_NEVER && isLoad()) || exists();
+	}
+	
+	public synchronized void setPage(Page page) {
+		this.page = page;
+	}
+	
+	public boolean isFlush() {
+		return flush;
+	}
+	
+	public synchronized void resetFlush() {
+		flush = false;
+	}
+	
+	@Override
+	public PageEngine getPageEngine() {
+		if (pageEngine == null) _loadPageEngine();
+		return pageEngine;
 	}
 }

--- a/core/src/main/java/lucee/runtime/config/ConfigImpl.java
+++ b/core/src/main/java/lucee/runtime/config/ConfigImpl.java
@@ -117,6 +117,7 @@ import lucee.runtime.orm.ORMConfiguration;
 import lucee.runtime.orm.ORMEngine;
 import lucee.runtime.osgi.EnvClassLoader;
 import lucee.runtime.osgi.OSGiUtil.BundleDefinition;
+import lucee.runtime.page.engine.PageEngine;
 import lucee.runtime.rest.RestSettingImpl;
 import lucee.runtime.rest.RestSettings;
 import lucee.runtime.schedule.Scheduler;
@@ -428,6 +429,8 @@ public abstract class ConfigImpl implements Config {
 
 	private Map<Integer,Object> cachedWithins=new HashMap<Integer, Object>();
 	
+	private PageEngine[] pageEngines = new PageEngine[0];
+	private PageEngine defaultPageEngine;
 
 	private int queueMax=100;
 	private long queueTimeout=0;
@@ -3479,8 +3482,32 @@ public abstract class ConfigImpl implements Config {
 	public Object getCachedWithin(int type) {
 		return cachedWithins.get(type);
 	}
-
+	
+    public void setPageEngines(PageEngine[] pageEngines) {
+    	this.pageEngines = pageEngines;
+    }
     
+    public void setDefaultPageEngine(PageEngine pageEngine) {
+    	this.defaultPageEngine = pageEngine;
+    }
+    
+    @Override
+    public PageEngine[] getPageEngines() {
+    	return this.pageEngines;
+    }
+    
+    public PageEngine getPageEngine(String path) {
+		PageEngine engine = defaultPageEngine;
+		
+		for (PageEngine _engine : this.getPageEngines()) {
+			if (_engine.handlesExtension(ResourceUtil.getExtension(path, null))) {
+				engine = _engine;
+				break;
+			}
+		}
+		
+		return engine;
+	}
 
     public Resource getPluginDirectory() {
     	return getConfigDir().getRealResource("context/admin/plugin");

--- a/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
+++ b/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
@@ -975,8 +975,8 @@ public final class XMLConfigWebFactory extends XMLConfigFactory {
 				SecurityManager.VALUE_YES), _attr(el, "cfx_usage", SecurityManager.VALUE_YES), _attr(el, "debugging", SecurityManager.VALUE_YES), _attr(el, "search",
 				SecurityManager.VALUE_YES), _attr(el, "scheduled_task", SecurityManager.VALUE_YES), _attr(el, "tag_execute", SecurityManager.VALUE_YES), _attr(el, "tag_import",
 				SecurityManager.VALUE_YES), _attr(el, "tag_object", SecurityManager.VALUE_YES), _attr(el, "tag_registry", SecurityManager.VALUE_YES), _attr(el, "cache",
-				SecurityManager.VALUE_YES), _attr(el, "gateway", SecurityManager.VALUE_YES), _attr(el, "orm", SecurityManager.VALUE_YES), _attr2(el, "access_read",
-				SecurityManager.ACCESS_PROTECTED), _attr2(el, "access_write", SecurityManager.ACCESS_PROTECTED));
+				SecurityManager.VALUE_YES), _attr(el, "gateway", SecurityManager.VALUE_YES), _attr(el, "orm", SecurityManager.VALUE_YES), _attr(el, "page_engines", 
+				SecurityManager.VALUE_YES),	_attr2(el, "access_read", SecurityManager.ACCESS_PROTECTED), _attr2(el, "access_write", SecurityManager.ACCESS_PROTECTED));
 		return sm;
 	}
 

--- a/core/src/main/java/lucee/runtime/engine/CFMLEngineImpl.java
+++ b/core/src/main/java/lucee/runtime/engine/CFMLEngineImpl.java
@@ -837,34 +837,34 @@ public final class CFMLEngineImpl implements CFMLEngine {
     
     @Override
     public void service(HttpServlet servlet, HttpServletRequest req, HttpServletResponse rsp) throws ServletException, IOException {
-    	CFMLFactory factory=getCFMLFactory(servlet.getServletConfig(), req);
-    	
-    	// is Lucee dialect enabled?
-    	if(!((ConfigImpl)factory.getConfig()).allowLuceeDialect()){
-    		try {
-				PageContextImpl.notSupported();
-			} catch (ApplicationException e) {
-				throw new PageServletException(e);
-			}
-    	}
-        PageContext pc = factory.getLuceePageContext(servlet,req,rsp,null,false,-1,false,true,-1,true,false);
-        ThreadQueue queue = factory.getConfig().getThreadQueue();
-        queue.enter(pc);
-        try {
-        	pc.execute(pc.getHttpServletRequest().getServletPath(),false,true);
-        } 
-        catch (PageException pe) {
-			throw new PageServletException(pe);
-		}
-        finally {
-        	queue.exit(pc);
-            factory.releaseLuceePageContext(pc,true);
-            //FDControllerFactory.notifyPageComplete();
-        }
-    }
-    
-    @Override
-    public void serviceCFML(HttpServlet servlet, HttpServletRequest req, HttpServletResponse rsp) throws ServletException, IOException {
+//    	CFMLFactory factory=getCFMLFactory(servlet.getServletConfig(), req);
+//    	
+//    	// is Lucee dialect enabled?
+//    	if(!((ConfigImpl)factory.getConfig()).allowLuceeDialect()){
+//    		try {
+//				PageContextImpl.notSupported();
+//			} catch (ApplicationException e) {
+//				throw new PageServletException(e);
+//			}
+//    	}
+//        PageContext pc = factory.getLuceePageContext(servlet,req,rsp,null,false,-1,false,true,-1,true,false);
+//        ThreadQueue queue = factory.getConfig().getThreadQueue();
+//        queue.enter(pc);
+//        try {
+//        	pc.execute(pc.getHttpServletRequest().getServletPath(),false,true);
+//        } 
+//        catch (PageException pe) {
+//			throw new PageServletException(pe);
+//		}
+//        finally {
+//        	queue.exit(pc);
+//            factory.releaseLuceePageContext(pc,true);
+//            //FDControllerFactory.notifyPageComplete();
+//        }
+//    }
+//    
+//    @Override
+//    public void serviceCFML(HttpServlet servlet, HttpServletRequest req, HttpServletResponse rsp) throws ServletException, IOException {
     	CFMLFactory factory=getCFMLFactory(servlet.getServletConfig(), req);
     	
         PageContext pc = factory.getLuceePageContext(servlet,req,rsp,null,false,-1,false,true,-1,true,false);
@@ -1235,7 +1235,7 @@ public final class CFMLEngineImpl implements CFMLEngine {
 		req.setProtocol("CLI/1.0");
 		HttpServletResponse rsp=new HttpServletResponseDummy(os);
 		
-		serviceCFML(servlet, req, rsp);
+		service(servlet, req, rsp);
 		String res = os.toString(ReqRspUtil.getCharacterEncoding(null,rsp).name());
 		System.out.println(res);
 	}

--- a/core/src/main/java/lucee/runtime/page/engine/CFPageEngine.java
+++ b/core/src/main/java/lucee/runtime/page/engine/CFPageEngine.java
@@ -8,7 +8,7 @@ public class CFPageEngine extends CorePageEngine {
 	public CFPageEngine(Config cfg) {super(cfg);}
 
 	@Override
-	int _getDialect() {
+	public int getDialect() {
 		return CFMLEngine.DIALECT_CFML;
 	}
 	

--- a/core/src/main/java/lucee/runtime/page/engine/CFPageEngine.java
+++ b/core/src/main/java/lucee/runtime/page/engine/CFPageEngine.java
@@ -1,0 +1,15 @@
+package lucee.runtime.page.engine;
+
+import lucee.loader.engine.CFMLEngine;
+import lucee.runtime.config.Config;
+
+public class CFPageEngine extends CorePageEngine {
+	
+	public CFPageEngine(Config cfg) {super(cfg);}
+
+	@Override
+	int _getDialect() {
+		return CFMLEngine.DIALECT_CFML;
+	}
+	
+}

--- a/core/src/main/java/lucee/runtime/page/engine/CorePageEngine.java
+++ b/core/src/main/java/lucee/runtime/page/engine/CorePageEngine.java
@@ -1,0 +1,22 @@
+package lucee.runtime.page.engine;
+
+import lucee.runtime.config.Config;
+import lucee.runtime.page.engine.PageEngine;
+import lucee.runtime.page.engine.PageFactory;
+
+public abstract class CorePageEngine extends PageEngine {
+	
+	protected final Config cfg;
+	protected final PageFactory pageFactory;
+	
+	public CorePageEngine(Config cfg) {
+		this.cfg = cfg;
+		pageFactory = new CorePageFactory(this);
+	}
+	
+	@Override
+	public PageFactory getPageFactory() {
+		return pageFactory;
+	}
+	
+}

--- a/core/src/main/java/lucee/runtime/page/engine/CorePageEngine.java
+++ b/core/src/main/java/lucee/runtime/page/engine/CorePageEngine.java
@@ -6,11 +6,10 @@ import lucee.runtime.page.engine.PageFactory;
 
 public abstract class CorePageEngine extends PageEngine {
 	
-	protected final Config cfg;
 	protected final PageFactory pageFactory;
 	
 	public CorePageEngine(Config cfg) {
-		this.cfg = cfg;
+		this.setConfig(cfg);
 		pageFactory = new CorePageFactory(this);
 	}
 	

--- a/core/src/main/java/lucee/runtime/page/engine/CorePageFactory.java
+++ b/core/src/main/java/lucee/runtime/page/engine/CorePageFactory.java
@@ -1,0 +1,211 @@
+package lucee.runtime.page.engine;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import lucee.commons.io.res.Resource;
+import lucee.commons.lang.StringUtil;
+import lucee.runtime.Mapping;
+import lucee.runtime.Page;
+import lucee.runtime.PageContext;
+import lucee.runtime.PageContextImpl;
+import lucee.runtime.PageSource;
+import lucee.runtime.PageSourceImpl;
+import lucee.runtime.compiler.CFMLCompilerImpl.Result;
+import lucee.runtime.config.Config;
+import lucee.runtime.config.ConfigWeb;
+import lucee.runtime.config.ConfigWebImpl;
+import lucee.runtime.config.Constants;
+import lucee.runtime.exp.MissingIncludeException;
+import lucee.runtime.exp.PageException;
+import lucee.runtime.exp.TemplateException;
+import lucee.runtime.op.Caster;
+import lucee.runtime.page.engine.PageFactory;
+
+public class CorePageFactory implements PageFactory {
+	
+	private final CorePageEngine engine;
+	private final int dialect;
+	
+	public CorePageFactory(CorePageEngine engine) {
+		this.engine = engine;
+		dialect = engine.getDialect();
+	}
+	
+	public static final byte LOAD_ARCHIVE=2;
+	public static final byte LOAD_PHYSICAL=3;
+	
+	@Override
+	public Page getPage(PageContext pc, PageSource ps, boolean forceReload, Page defaultValue) throws PageException {
+		PageSourceImpl psi = (PageSourceImpl) ps;
+		
+		if (forceReload)
+			psi.setPage(null);
+		
+		Page page = psi.getPage();
+		Mapping mapping = ps.getMapping();
+		
+		if (mapping.isPhysicalFirst()) {
+			page = loadPhysical(pc, ps, page);
+			if (page==null) page = loadArchive(ps, page);
+			if (page != null) return page;
+		} else {
+			page = loadArchive(ps, page);
+			if (page==null) page=loadPhysical(pc, ps, page);
+			if (page != null) return page;
+		}
+		
+		if(defaultValue == null)
+			throw new MissingIncludeException(ps);
+		
+		return defaultValue;
+	}
+
+	private Page loadArchive(PageSource ps, Page page) {
+		PageSourceImpl psi = (PageSourceImpl) ps;
+		Mapping mapping = ps.getMapping();
+		if (!mapping.hasArchive()) return null;
+		if (page != null && page.getLoadType() == LOAD_ARCHIVE) return page;
+		try {
+			synchronized(ps) {
+				Class<?> clazz = mapping.getArchiveClass(psi.getClassName());
+				page = newInstance(clazz, ps);
+				psi.setPage(page);
+				page.setPageSource(psi);
+				page.setLoadType(LOAD_ARCHIVE);
+				return page;
+			}
+		} catch(Exception e) {
+			return null;
+		}
+	}
+	
+	private Page loadPhysical(PageContext pc, PageSource ps, Page page) throws TemplateException {
+		PageSourceImpl psi = (PageSourceImpl)ps;
+		Mapping mapping = ps.getMapping();
+		
+		if (!mapping.hasPhysical()) return null;
+		
+		ConfigWeb config = pc.getConfig();
+		PageContextImpl pci = (PageContextImpl)pc;
+		if ((mapping.getInspectTemplate() == Config.INSPECT_NEVER || pci.isTrusted(page)) && isLoad(page, LOAD_PHYSICAL))
+			return page;
+		
+		Resource srcFile = ps.getPhyscalFile();
+		long srcLastModified = srcFile.lastModified();
+		if (srcLastModified == 0L) return null;
+		
+		// page exists
+		if (page != null) {
+			if (srcLastModified != page.getSourceLastModified()) {
+				page = compile(config, ps, page, false, false);
+				psi.setPage(page);
+				page.setPageSource(psi);
+				page.setLoadType(LOAD_PHYSICAL);
+			}
+		
+		// page doesn't exist
+		} else {
+			
+			Resource crd = mapping.getClassRootDirectory();
+			Resource classFile = crd.getRealResource(psi.getJavaName()+".class");
+			boolean isNew = false;
+			
+			if (psi.isFlush() && !classFile.exists()) {
+				page = compile(config, ps, null, false, false);
+				psi.setPage(page);
+				psi.resetFlush();
+				isNew = true;
+			} else {
+				try {
+					page = newInstance(mapping.getPhysicalClass(psi.getClassName()), ps);
+				} catch(Throwable t) {
+					page = null;
+				}
+				
+				if (page == null) page = compile(config, ps, null, false, false);
+				psi.setPage(page);
+			}
+			
+			// check for newer version
+			if (!isNew)
+				if (   srcLastModified != page.getSourceLastModified()
+					|| page.getVersion() != pc.getConfig().getFactory().getEngine().getInfo().getFullVersionInfo()) {
+					isNew = true;
+					page = compile(config, ps, page, false, false);
+					psi.setPage(page);
+				}
+			
+			page.setPageSource(ps);
+			page.setLoadType(LOAD_PHYSICAL);
+			
+		}
+		
+		pci.setPageUsed(page);
+		
+		return page;
+	}
+	
+	
+	private synchronized Page compile(ConfigWeb config,PageSource ps, Page existing, boolean returnValue, boolean ignoreScopes) throws TemplateException {
+		Resource classRootDir = ps.getMapping().getClassRootDirectory();
+		try {
+			return _compile(config,ps, classRootDir,existing,returnValue,ignoreScopes);
+		}
+			catch(RuntimeException re) {re.printStackTrace();
+			String msg=StringUtil.emptyIfNull(re.getMessage());
+			if(StringUtil.indexOfIgnoreCase(msg, "Method code too large!")!=-1) {
+				throw new TemplateException("There is too much code inside the template ["+ps.getDisplayPath()+"], "+Constants.NAME+" was not able to break it into pieces, move parts of your code to an include or a external component/function",msg);
+			}
+			throw re;
+		}
+		catch(ClassFormatError e) {
+			String msg=StringUtil.emptyIfNull(e.getMessage());
+			if(StringUtil.indexOfIgnoreCase(msg, "Invalid method Code length")!=-1) {
+				throw new TemplateException("There is too much code inside the template ["+ps.getDisplayPath()+"], "+Constants.NAME+" was not able to break it into pieces, move parts of your code to an include or a external component/function",msg);
+			}
+			throw new TemplateException("ClassFormatError:"+e.getMessage());
+		}
+		catch(Throwable t) {
+			if(t instanceof TemplateException) throw (TemplateException)t;
+			throw new TemplateException(t.getClass().getName()+":"+t.getMessage());
+		}
+	}
+
+	private Page _compile(ConfigWeb config,PageSource ps, Resource classRootDir, Page existing,boolean returnValue, boolean ignoreScopes) throws IOException, SecurityException, IllegalArgumentException, PageException {
+		ConfigWebImpl cwi=(ConfigWebImpl) config;
+		
+		long now;
+		if((ps.getPhyscalFile().lastModified()+10000)>(now=System.currentTimeMillis()))
+			cwi.getCompiler().watch(ps,now);
+		
+		Result result = cwi.getCompiler().
+			compile(cwi,ps,cwi.getTLDs(dialect),cwi.getFLDs(dialect),classRootDir,returnValue,ignoreScopes);
+		
+		try {
+			Class<?> clazz = ps.getMapping().getPhysicalClass(ps.getClassName(), result.barr);
+			return newInstance(clazz, ps);
+		} catch(Throwable t) {
+			PageException pe = Caster.toPageException(t);
+			pe.setExtendedInfo("failed to load template "+ps.getDisplayPath());
+			throw pe;
+		}
+	}
+	
+	
+
+	private boolean isLoad(Page page, byte load) {
+		return page!=null && load==page.getLoadType();
+	}
+	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private Page newInstance(Class clazz, PageSource ps) throws SecurityException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+		Constructor<?> c = clazz.getConstructor(new Class[]{PageSource.class});
+		return (Page) c.newInstance(new Object[]{ps});
+	}
+
+	public CorePageEngine getEngine() {
+		return engine;
+	}
+}

--- a/core/src/main/java/lucee/runtime/page/engine/LuceePageEngine.java
+++ b/core/src/main/java/lucee/runtime/page/engine/LuceePageEngine.java
@@ -12,8 +12,9 @@ public class LuceePageEngine extends CorePageEngine {
 	}
 
 	@Override
-	int _getDialect() {
+	public int getDialect() {
 		return CFMLEngine.DIALECT_LUCEE;
 	}
+	
 	
 }

--- a/core/src/main/java/lucee/runtime/page/engine/LuceePageEngine.java
+++ b/core/src/main/java/lucee/runtime/page/engine/LuceePageEngine.java
@@ -1,0 +1,19 @@
+package lucee.runtime.page.engine;
+
+import lucee.loader.engine.CFMLEngine;
+import lucee.runtime.config.Config;
+
+public class LuceePageEngine extends CorePageEngine {
+
+	public LuceePageEngine(Config cfg) {
+		super(cfg);
+		// when the time comes to switch it on by default ;)
+		//((ConfigImpl)cfg).setAllowLuceeDialect(true);
+	}
+
+	@Override
+	int _getDialect() {
+		return CFMLEngine.DIALECT_LUCEE;
+	}
+	
+}

--- a/core/src/main/java/lucee/runtime/security/SecurityManagerImpl.java
+++ b/core/src/main/java/lucee/runtime/security/SecurityManagerImpl.java
@@ -43,7 +43,7 @@ public final class SecurityManagerImpl implements Cloneable, SecurityManager {
     private static final Resource[] EMPTY_RESOURCE_ARRAY = new Resource[0];
 
 
-	private short[] accesses=new short[22];
+	private short[] accesses=new short[23];
     private Resource rootDirectory;
 	private Resource[] customFileAccess=EMPTY_RESOURCE_ARRAY;
    
@@ -69,13 +69,15 @@ public final class SecurityManagerImpl implements Cloneable, SecurityManager {
      * @param tagObject
      * @param tagRegistry
      * @param t 
-     * @param accessRead 
+     * @param accessRead
      */
 	 public SecurityManagerImpl(short setting, short file,short directJavaAccess,
 	       short mail, short datasource, short mapping, short remote, short customTag,
 	       short cfxSetting, short cfxUsage, short debugging,
            short search, short scheduledTasks,
-	       short tagExecute, short tagImport, short tagObject, short tagRegistry, short cache, short gateway, short orm, short accessRead, short accessWrite) {
+	       short tagExecute, short tagImport, short tagObject, short tagRegistry, short cache, short gateway, short orm, short pageEngines, 
+	       
+	       short accessRead, short accessWrite) {
         accesses[TYPE_SETTING]=setting;
         accesses[TYPE_FILE]=file;
         accesses[TYPE_DIRECT_JAVA_ACCESS]=directJavaAccess;
@@ -99,6 +101,8 @@ public final class SecurityManagerImpl implements Cloneable, SecurityManager {
         accesses[TYPE_ACCESS_READ]=accessRead;
         accesses[TYPE_ACCESS_WRITE]=accessWrite;
         accesses[TYPE_REMOTE]=remote;
+
+        accesses[TYPE_PAGE_ENGINES]=pageEngines;
         
         
     }
@@ -128,6 +132,7 @@ public final class SecurityManagerImpl implements Cloneable, SecurityManager {
                 VALUE_YES,  // Cache
                 VALUE_YES,  // Gateway
                 VALUE_YES,  // ORM
+                VALUE_YES,  // Template Engines
               	ACCESS_OPEN,
               	ACCESS_PROTECTED);
         
@@ -175,6 +180,7 @@ public final class SecurityManagerImpl implements Cloneable, SecurityManager {
         else if(accessType.equals("cache")) return TYPE_CACHE;
         else if(accessType.equals("gateway")) return TYPE_GATEWAY;
         else if(accessType.equals("orm")) return TYPE_ORM;
+        else if(accessType.equals("pageEngines")) return TYPE_PAGE_ENGINES;
         else if(accessType.startsWith("scheduled_task")) return TYPE_SCHEDULED_TASK;
         else throw new SecurityException(
                 "invalid access type ["+accessType+"]", 

--- a/core/src/main/java/resource/config/web.xml
+++ b/core/src/main/java/resource/config/web.xml
@@ -174,7 +174,12 @@ Path placeholders:
 		cache-directory-max-size="100mb"/>
 		
 		
-		
+<!-- Page Engines
+	<pageEngines>
+		<pageEngine class="lucee.template.HandlebarsEngine" file_extensions="hbs" />
+	</pageEngines>
+ -->
+	<pageEngines></pageEngines>
 		
 <!--
 LOGGING

--- a/loader/src/main/java/lucee/loader/engine/CFMLEngine.java
+++ b/loader/src/main/java/lucee/loader/engine/CFMLEngine.java
@@ -112,18 +112,18 @@ public interface CFMLEngine {
 	public void service(HttpServlet servlet, HttpServletRequest req,
 			HttpServletResponse rsp) throws IOException, ServletException;
 
-	/**
-	 * method to invoke the engine for CFML
-	 * 
-	 * @param servlet
-	 * @param req
-	 * @param rsp
-	 * @throws ServletException
-	 * @throws IOException
-	 * @throws ServletException
-	 */
-	public void serviceCFML(HttpServlet servlet, HttpServletRequest req,
-			HttpServletResponse rsp) throws IOException, ServletException;
+//	/**
+//	 * method to invoke the engine for CFML
+//	 * 
+//	 * @param servlet
+//	 * @param req
+//	 * @param rsp
+//	 * @throws ServletException
+//	 * @throws IOException
+//	 * @throws ServletException
+//	 */
+//	public void serviceCFML(HttpServlet servlet, HttpServletRequest req,
+//			HttpServletResponse rsp) throws IOException, ServletException;
 
 	/**
 	 * method to invoke the engine for AMF

--- a/loader/src/main/java/lucee/loader/engine/CFMLEngineWrapper.java
+++ b/loader/src/main/java/lucee/loader/engine/CFMLEngineWrapper.java
@@ -95,12 +95,12 @@ public class CFMLEngineWrapper implements CFMLEngine {
 		engine.service(servlet, req, rsp);
 	}
 
-	@Override
-	public void serviceCFML(final HttpServlet servlet,
-			final HttpServletRequest req, final HttpServletResponse rsp)
-			throws ServletException, IOException {
-		engine.serviceCFML(servlet, req, rsp);
-	}
+//	@Override
+//	public void serviceCFML(final HttpServlet servlet,
+//			final HttpServletRequest req, final HttpServletResponse rsp)
+//			throws ServletException, IOException {
+//		engine.serviceCFML(servlet, req, rsp);
+//	}
 
 	@Override
 	public void serviceAMF(final HttpServlet servlet,

--- a/loader/src/main/java/lucee/loader/servlet/CFMLServlet.java
+++ b/loader/src/main/java/lucee/loader/servlet/CFMLServlet.java
@@ -18,54 +18,46 @@
  **/
 package lucee.loader.servlet;
 
-import java.io.IOException;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import lucee.loader.engine.CFMLEngineFactory;
-
 /**
  */
-public class CFMLServlet extends AbsServlet {
+@Deprecated
+public class CFMLServlet extends LuceeServlet {
 
 	private static final long serialVersionUID = -1878214660283329587L;
-
-	/**
-	 * @see javax.servlet.Servlet#init(javax.servlet.ServletConfig)
-	 */
-	@Override
-	public void init(final ServletConfig sg) throws ServletException {
-		super.init(sg);
-		//CFMLEngineFactory.log(Log.LEVEL_INFO, "init servlet");
-		try {
-			engine = CFMLEngineFactory.getInstance(sg, this);
-		} catch (final ServletException se) {
-			se.printStackTrace();// TEMP remove stacktrace
-			throw se;
-		} catch (final Throwable t) {
-			t.printStackTrace();// TEMP remove stacktrace
-		}
-	}
-
-	/**
-	 * @see javax.servlet.http.HttpServlet#service(javax.servlet.http.HttpServletRequest,
-	 *      javax.servlet.http.HttpServletResponse)
-	 */
-	@Override
-	protected void service(final HttpServletRequest req,
-			final HttpServletResponse rsp) throws ServletException, IOException {
-		//CFMLEngineFactory.log(Log.LEVEL_INFO, "service CFML");
-		try {
-			engine.serviceCFML(this, req, rsp);
-		} catch (final ServletException se) {
-			se.printStackTrace();// TEMP remove stacktrace
-			throw se;
-		} catch (final Throwable t) {
-			t.printStackTrace();// TEMP remove stacktrace
-		}
-
-	}
+//
+//	/**
+//	 * @see javax.servlet.Servlet#init(javax.servlet.ServletConfig)
+//	 */
+//	@Override
+//	public void init(final ServletConfig sg) throws ServletException {
+//		super.init(sg);
+//		//CFMLEngineFactory.log(Log.LEVEL_INFO, "init servlet");
+//		try {
+//			engine = CFMLEngineFactory.getInstance(sg, this);
+//		} catch (final ServletException se) {
+//			se.printStackTrace();// TEMP remove stacktrace
+//			throw se;
+//		} catch (final Throwable t) {
+//			t.printStackTrace();// TEMP remove stacktrace
+//		}
+//	}
+//
+//	/**
+//	 * @see javax.servlet.http.HttpServlet#service(javax.servlet.http.HttpServletRequest,
+//	 *      javax.servlet.http.HttpServletResponse)
+//	 */
+//	@Override
+//	protected void service(final HttpServletRequest req,
+//			final HttpServletResponse rsp) throws ServletException, IOException {
+//		//CFMLEngineFactory.log(Log.LEVEL_INFO, "service CFML");
+//		try {
+//			engine.service(this, req, rsp);
+//		} catch (final ServletException se) {
+//			se.printStackTrace();// TEMP remove stacktrace
+//			throw se;
+//		} catch (final Throwable t) {
+//			t.printStackTrace();// TEMP remove stacktrace
+//		}
+//
+//	}
 }

--- a/loader/src/main/java/lucee/loader/servlet/LuceeRuntimeServlet.java
+++ b/loader/src/main/java/lucee/loader/servlet/LuceeRuntimeServlet.java
@@ -1,0 +1,71 @@
+/**
+ *
+ * Copyright (c) 2014, the Railo Company Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ **/
+package lucee.loader.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lucee.loader.engine.CFMLEngineFactory;
+
+/**
+ */
+public class LuceeRuntimeServlet extends AbsServlet {
+
+	private static final long serialVersionUID = -1878214660283329587L;
+
+	/**
+	 * @see javax.servlet.Servlet#init(javax.servlet.ServletConfig)
+	 */
+	@Override
+	public void init(final ServletConfig sg) throws ServletException {
+		super.init(sg);
+		//CFMLEngineFactory.log(Log.LEVEL_INFO, "init servlet");
+		try {
+			engine = CFMLEngineFactory.getInstance(sg, this);
+		} catch (final ServletException se) {
+			se.printStackTrace();// TEMP remove stacktrace
+			throw se;
+		} catch (final Throwable t) {
+			t.printStackTrace();// TEMP remove stacktrace
+		}
+	}
+
+	/**
+	 * @see javax.servlet.http.HttpServlet#service(javax.servlet.http.HttpServletRequest,
+	 *      javax.servlet.http.HttpServletResponse)
+	 */
+	@Override
+	protected void service(final HttpServletRequest req,
+			final HttpServletResponse rsp) throws ServletException, IOException {
+		//CFMLEngineFactory.log(Log.LEVEL_INFO, "service CFML");
+		try {
+			engine.service(this, req, rsp);
+		} catch (final ServletException se) {
+			se.printStackTrace();// TEMP remove stacktrace
+			throw se;
+		} catch (final Throwable t) {
+			t.printStackTrace();// TEMP remove stacktrace
+		}
+
+	}
+}

--- a/loader/src/main/java/lucee/loader/servlet/LuceeServlet.java
+++ b/loader/src/main/java/lucee/loader/servlet/LuceeServlet.java
@@ -29,43 +29,44 @@ import lucee.loader.engine.CFMLEngineFactory;
 
 /**
  */
-public class LuceeServlet extends AbsServlet {
+@Deprecated
+public class LuceeServlet extends LuceeRuntimeServlet {
 
 	private static final long serialVersionUID = -1878214660283329587L;
-
-	/**
-	 * @see javax.servlet.Servlet#init(javax.servlet.ServletConfig)
-	 */
-	@Override
-	public void init(final ServletConfig sg) throws ServletException {
-		super.init(sg);
-		//CFMLEngineFactory.log(Log.LEVEL_INFO, "init servlet");
-		try {
-			engine = CFMLEngineFactory.getInstance(sg, this);
-		} catch (final ServletException se) {
-			se.printStackTrace();// TEMP remove stacktrace
-			throw se;
-		} catch (final Throwable t) {
-			t.printStackTrace();// TEMP remove stacktrace
-		}
-	}
-
-	/**
-	 * @see javax.servlet.http.HttpServlet#service(javax.servlet.http.HttpServletRequest,
-	 *      javax.servlet.http.HttpServletResponse)
-	 */
-	@Override
-	protected void service(final HttpServletRequest req,
-			final HttpServletResponse rsp) throws ServletException, IOException {
-		//CFMLEngineFactory.log(Log.LEVEL_INFO, "service CFML");
-		try {
-			engine.service(this, req, rsp);
-		} catch (final ServletException se) {
-			se.printStackTrace();// TEMP remove stacktrace
-			throw se;
-		} catch (final Throwable t) {
-			t.printStackTrace();// TEMP remove stacktrace
-		}
-
-	}
+//
+//	/**
+//	 * @see javax.servlet.Servlet#init(javax.servlet.ServletConfig)
+//	 */
+//	@Override
+//	public void init(final ServletConfig sg) throws ServletException {
+//		super.init(sg);
+//		//CFMLEngineFactory.log(Log.LEVEL_INFO, "init servlet");
+//		try {
+//			engine = CFMLEngineFactory.getInstance(sg, this);
+//		} catch (final ServletException se) {
+//			se.printStackTrace();// TEMP remove stacktrace
+//			throw se;
+//		} catch (final Throwable t) {
+//			t.printStackTrace();// TEMP remove stacktrace
+//		}
+//	}
+//
+//	/**
+//	 * @see javax.servlet.http.HttpServlet#service(javax.servlet.http.HttpServletRequest,
+//	 *      javax.servlet.http.HttpServletResponse)
+//	 */
+//	@Override
+//	protected void service(final HttpServletRequest req,
+//			final HttpServletResponse rsp) throws ServletException, IOException {
+//		//CFMLEngineFactory.log(Log.LEVEL_INFO, "service CFML");
+//		try {
+//			engine.service(this, req, rsp);
+//		} catch (final ServletException se) {
+//			se.printStackTrace();// TEMP remove stacktrace
+//			throw se;
+//		} catch (final Throwable t) {
+//			t.printStackTrace();// TEMP remove stacktrace
+//		}
+//
+//	}
 }

--- a/loader/src/main/java/lucee/runtime/PageSource.java
+++ b/loader/src/main/java/lucee/runtime/PageSource.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 
 import lucee.commons.io.res.Resource;
 import lucee.runtime.exp.PageException;
+import lucee.runtime.page.engine.PageEngine;
 
 /**
  * extends the source file with class features
@@ -182,5 +183,7 @@ public interface PageSource extends Serializable {
 	 * or is trusted and loaded
 	 */
 	public boolean executable();
+	
+	public PageEngine getPageEngine();
 
 }

--- a/loader/src/main/java/lucee/runtime/config/Config.java
+++ b/loader/src/main/java/lucee/runtime/config/Config.java
@@ -48,6 +48,7 @@ import lucee.runtime.monitor.RequestMonitor;
 import lucee.runtime.net.mail.Server;
 import lucee.runtime.net.proxy.ProxyData;
 import lucee.runtime.orm.ORMEngine;
+import lucee.runtime.page.engine.PageEngine;
 import lucee.runtime.rest.RestSettings;
 import lucee.runtime.schedule.Scheduler;
 import lucee.runtime.search.SearchEngine;
@@ -848,5 +849,10 @@ public interface Config {
 	public Resource getLocalExtensionProviderDirectory();
 
 	public Resource getDeployDirectory();
-
+	
+	public PageEngine[] getPageEngines();
+	
+	public PageEngine getPageEngine(String path);
+	
+	public boolean allowLuceeDialect();
 }

--- a/loader/src/main/java/lucee/runtime/page/engine/PageEngine.java
+++ b/loader/src/main/java/lucee/runtime/page/engine/PageEngine.java
@@ -56,22 +56,7 @@ public abstract class PageEngine {
 		return this.extensions.contains(extension);
 	}
 	
-	final public int getDialect() {
-		int _d = _getDialect();
-		switch (_d) {
-			case CFMLEngine.DIALECT_BOTH:
-			case CFMLEngine.DIALECT_CFML:
-			case CFMLEngine.DIALECT_LUCEE:
-				return _d;
-			
-			default:
-				return CFMLEngine.DIALECT_LUCEE;
-		}
-	}
-	
-	int _getDialect() {
-		return config.allowLuceeDialect() ? CFMLEngine.DIALECT_LUCEE : CFMLEngine.DIALECT_CFML;
-	}
+	abstract public int getDialect();
 	
 	abstract public PageFactory getPageFactory();
 	

--- a/loader/src/main/java/lucee/runtime/page/engine/PageEngine.java
+++ b/loader/src/main/java/lucee/runtime/page/engine/PageEngine.java
@@ -1,0 +1,78 @@
+package lucee.runtime.page.engine;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lucee.loader.engine.CFMLEngine;
+import lucee.runtime.config.Config;
+
+/**
+ * Template engines are the interface used to convert source files
+ * into Page objects.
+ * 
+ * @author dajester2013
+ *
+ */
+public abstract class PageEngine {
+	
+	private String label;
+	private List<String> extensions;
+	private Config config;
+	
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public PageEngine setExtensions(String extensionList) {
+		return this.setExtensions(extensionList.split(",\\s*"));
+	}
+	
+	public PageEngine setExtensions(String[] extensions) {
+		return this.setExtensions(Arrays.asList(extensions));
+	}
+	
+	public PageEngine setExtensions(List<String> extensions) {
+		this.extensions = extensions;
+		return this;
+	}
+	
+	public List<String> getExtensions() {
+		return this.extensions;
+	}
+	
+	public Config getConfig() {
+		return config;
+	}
+
+	public void setConfig(Config config) {
+		this.config = config;
+	}
+
+	public boolean handlesExtension(String extension) {
+		return this.extensions.contains(extension);
+	}
+	
+	final public int getDialect() {
+		int _d = _getDialect();
+		switch (_d) {
+			case CFMLEngine.DIALECT_BOTH:
+			case CFMLEngine.DIALECT_CFML:
+			case CFMLEngine.DIALECT_LUCEE:
+				return _d;
+			
+			default:
+				return CFMLEngine.DIALECT_LUCEE;
+		}
+	}
+	
+	int _getDialect() {
+		return config.allowLuceeDialect() ? CFMLEngine.DIALECT_LUCEE : CFMLEngine.DIALECT_CFML;
+	}
+	
+	abstract public PageFactory getPageFactory();
+	
+}

--- a/loader/src/main/java/lucee/runtime/page/engine/PageFactory.java
+++ b/loader/src/main/java/lucee/runtime/page/engine/PageFactory.java
@@ -1,0 +1,21 @@
+/**
+ * 
+ */
+package lucee.runtime.page.engine;
+
+import lucee.runtime.Page;
+import lucee.runtime.PageContext;
+import lucee.runtime.PageSource;
+import lucee.runtime.exp.PageException;
+
+/**
+ * For a given page source, return a Page object.
+ *  
+ * @author dajester2013
+ *
+ */
+public interface PageFactory {
+
+	public Page getPage(PageContext pc, PageSource ps, boolean forceReload, Page defaultValue) throws PageException;
+	
+}

--- a/loader/src/main/java/lucee/runtime/security/SecurityManager.java
+++ b/loader/src/main/java/lucee/runtime/security/SecurityManager.java
@@ -118,6 +118,7 @@ public interface SecurityManager {
 	public static final int TYPE_CACHE = 19;
 	public static final int TYPE_GATEWAY = 20;
 	public static final int TYPE_ORM = 21;
+	public static final int TYPE_PAGE_ENGINES = 22;
 
 	/**
 	 * Field <code>VALUE_NO</code>


### PR DESCRIPTION
This PR is to add the Page Engines (formerly Template Engines) feature to Lucee.  This is a pretty big feature, so I'll provide more-than-usual explanation:

Currently, the compilation of a page happens in the `PageSourceImpl` class.  That is, a `PageSource` "knows" how to compile itself.  This changes it up so that a page source runs itself through it's assigned page engine that in return builds the `Page` instance.  The main benefit of this is that now, alternate templating engines can be plugged into the system, and can return Lucee `Page` objects from non-CFML source.

In doing this, I've also re-implemented the compilation of .cf*/.lucee files using page engines.  The "request dialect" is no longer determined by the servlet/execute methods, but by the PageEngine.  Because of this, I've deprecated the `PageContext`'s `executeCFML` method, and merged/deprecated the `CFMLServlet` and `LuceeServlet` implementations into the `LuceeRuntimeServlet`. Now you need only set up one servlet.  Also, you can configure .cfm files to be run through the `LuceePageEngine`, and it would use the Lucee dialect.  The inverse is true for assigning .lucee files to the `CFPageEngine`.  By default, the CFPageEngine is loaded and used as the default page engine for all file extensions.  However, if the lucee dialect is enabled, the LuceePageEngine is loaded as the default in addition to the CFPageEngine.

Currently, page engines can only be configured in the xml config files (either server or web).  In addition, security was added so that web-contexts can be prevented from loading their own page engines (/security/setting[page_engines]).  Next step is to integrate into LEX packaging, so that page engines can be configured by extensions.
