### PR TITLE
Solved ticket https://luceeserver.atlassian.net/browse/LDEV-1061

### DIFF
--- a/core/src/main/java/lucee/transformer/bytecode/statement/tag/TagLoop.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/tag/TagLoop.java
@@ -341,6 +341,8 @@ public final class TagLoop extends TagGroup implements FlowControlBreak,FlowCont
 		//VariableReference item=VariableInterpreter.getVariableReference(pc,index);
 		int index = -1;
 		Attribute attrIndex = getAttribute("index");
+		if (attrIndex == null)
+			attrIndex = getAttribute("key");
 		if(attrIndex!=null){
 			index = adapter.newLocal(Types.VARIABLE_REFERENCE);
 			adapter.loadArg(0);
@@ -352,6 +354,8 @@ public final class TagLoop extends TagGroup implements FlowControlBreak,FlowCont
 		//VariableReference item=VariableInterpreter.getVariableReference(pc,item);
 		int item = -1;
 		Attribute attrItem = getAttribute("item");
+		if (attrItem == null)
+			attrItem = getAttribute("value");
 		if(attrItem!=null){
 			item = adapter.newLocal(Types.VARIABLE_REFERENCE);
 			adapter.loadArg(0);

--- a/core/src/main/java/lucee/transformer/cfml/evaluator/impl/Loop.java
+++ b/core/src/main/java/lucee/transformer/cfml/evaluator/impl/Loop.java
@@ -107,16 +107,16 @@ public final class Loop extends EvaluatorSupport {
 
         // struct loop      
         if(tag.containsAttribute("struct")) {
-        	if(!tag.containsAttribute("index") && !tag.containsAttribute("item"))
-				throw new EvaluatorException("Wrong Context, when you use attribute struct,you must define attribute index and/or item");
+			if (!tag.containsAttribute("index") && !tag.containsAttribute("item") && !tag.containsAttribute("key") && !tag.containsAttribute("value"))
+				throw new EvaluatorException("Wrong Context, when you use attribute struct, you must define attribute index (alias key) and/or item (alias value)");
 			loop.setType(TagLoop.TYPE_STRUCT);
             return;
         }
 
         // collection loop      
         if(tag.containsAttribute("collection")) {
-        	if(!tag.containsAttribute("index") && !tag.containsAttribute("item"))
-				throw new EvaluatorException("Wrong Context, when you use attribute collection,you must define attribute index and/or item");
+			if (!tag.containsAttribute("index") && !tag.containsAttribute("item") && !tag.containsAttribute("key") && !tag.containsAttribute("value"))
+				throw new EvaluatorException("Wrong Context, when you use attribute struct, you must define attribute index (alias key) and/or item (alias value)");
 			loop.setType(TagLoop.TYPE_COLLECTION);
             return;
         }

--- a/loader/build.xml
+++ b/loader/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="core" basedir="." name="Lucee" xmlns:artifact="antlib:org.apache.maven.artifact.ant">
 
-  <property name="version" value="5.1.1.8-SNAPSHOT"/>
+  <property name="version" value="5.1.1.9-SNAPSHOT"/>
 
   <path id="maven-ant-tasks.classpath" path="../ant/lib/maven-ant-tasks-2.1.3.jar" />
   <typedef resource="org/apache/maven/artifact/ant/antlib.xml"

--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.lucee</groupId>
   <artifactId>lucee</artifactId>
-  <version>5.1.1.8-SNAPSHOT</version>
+  <version>5.1.1.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Lucee Loader Build</name>


### PR DESCRIPTION
Added `key` and `value` attributes as aliases for `index` and `item` when using CFLOOP with Collection or Struct.

This should have been added when we added `Struct` as an alias for `Collection`.