### PR TITLE
LDEV-1515 Collapse SQL results in modern debugging output

### DIFF
--- a/core/src/main/java/resource/context/admin/debug/Debug.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Debug.cfc
@@ -52,6 +52,17 @@
     	<cfthrow message="implement function output():string">
     </cffunction>
     
-    
+    <cfscript>      
+        variables.serverTimingHeaders = [];
+
+        function addServerTimingHeader(metric, name, timeMs){
+            arrayAppend(variables.serverTimingHeaders, '#arguments.metric#=#arguments.timeMs#; "#arguments.name#"');
+        }
+
+        function outputServerTimingHeaders(){
+            if (not getPageContext().getHttpServletResponse().isCommitted() ) // avoid cfflush error
+                header name="Server-Timing" value="#ArrayToList(variables.serverTimingHeaders,", ")#";
+        }
+    </cfscript>    
     
 </cfcomponent>

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -333,7 +333,7 @@
 										<cfif pages.avg LT arguments.custom.minimal * 1000>
 											<cfcontinue>
 										</cfif>
-										<cfset bad=pages.avg GTE arguments.custom.highlight * 1000>
+										<cfset var bad=pages.avg GTE arguments.custom.highlight * 1000>
 										<cfif bad>
 											<cfset hasBad = true>
 										</cfif>
@@ -418,7 +418,7 @@
 											<th>Var</th>
 											<th>Count</th>
 										</tr>
-										<cfset total=0 />
+										<cfset var total=0 />
 										<cfloop query="implicitAccess">
 											<tr>
 												<td>#implicitAccess.template#</td>
@@ -478,8 +478,8 @@
 
 						<div class="section-title">Trace Points</div>
 
-						<cfset hasAction=!isColumnEmpty(traces,'action') />
-						<cfset hasCategory=!isColumnEmpty(traces,'category') />
+						<cfset var hasAction=!isColumnEmpty(traces,'action') />
+						<cfset var hasCategory=!isColumnEmpty(traces,'category') />
 
 						<table>
 
@@ -583,6 +583,7 @@
 						<cfset local.total  =0>
 						<cfset local.records=0>
 						<cfset local.openConns=0>
+						<cfset var dsn = "">
 						<cfloop struct="#debugging.datasources#" index="dsn" item="item">
 							<cfset local.openConns=item.openConnections>
 						</cfloop>
@@ -597,8 +598,6 @@
 
 							<tr>
 								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
-
-
 									<table><tr><td>
 										<b>General</b>
 										<table class="details">
@@ -615,84 +614,81 @@
 										</tr>
 										</cfloop>
 										</table>
-									<cfset hasCachetype=ListFindNoCase(queries.columnlist,"cachetype") gt 0>
+									<cfset var hasCachetype=ListFindNoCase(queries.columnlist,"cachetype") gt 0>
 									<br><b>SQL Queries</b>
+										<table class="details">
+										<tr>
+											<th></th>
+											<th>Name</th>
+											<th>Records</th>
+											<th>Time (ms)</th>
+											<th>Datasource</th>
+											<th>Source</th>
+											<cfif hasCachetype><th>Cache Type</th></cfif>
+										</tr>
 										<cfloop query="queries">
+											<cfset var bad=queries.time gt (arguments.custom.highlight * 1000)>
+											<tr class="sql-result #bad ? 'red' : ''#" onclick="__LUCEE.debug.toggleClass('query-id-#queries.currentRow#')">
+												<th></th>
+												<td><a>#queries.name#</a></td>
+												<td class="txt-r">#queries.count#</td>
+												<td class="txt-r">#unitFormat(arguments.custom.unit, queries.time,prettify)#</td>
+												<td>#queries.datasource#</td>
+												<td>#queries.src#</td>
+												<cfif hasCachetype><td>#isEmpty(queries.cacheType)?"none":queries.cacheType#</td></cfif>
+											</tr>
+											<tr class="sql #bad ? '' : 'collapsed'#" id="-lucee-debug-query-id-#queries.currentRow#">
+												<th class="label">SQL:</th>
+												<td id="-lucee-debug-query-sql-#queries.currentRow#" colspan="6" oncontextmenu="__LUCEE.debug.selectText( this.id );"><pre>#trim( queries.sql )#</pre></td>
+											</tr>
 
-											<table class="details">
+											<cfif listFindNoCase(queries.columnlist, 'usage') && isStruct(queries.usage)>
+
+												<cfset local.usage=queries.usage>
+												<cfset local.usageNotRead = []>
+												<cfset local.usageRead  = []>
+
+												<cfloop collection="#usage#" index="local.item" item="local.value">
+													<cfif !value>
+														<cfset arrayAppend( usageNotRead, item )>
+													<cfelse>
+														<cfset arrayAppend( usageRead, item )>
+													</cfif>
+												</cfloop>
+
 												<tr>
-													<th></th>
-													<th>Name</th>
-													<th>Records</th>
-													<th>Time (ms)</th>
-													<th>Datasource</th>
-													<th>Source</th>
-													<cfif hasCachetype><th>Cache Type</th></cfif>
-
-												</tr>
-												<tr>
-													<th></th>
-													<td>#queries.name#</td>
-													<td class="txt-r">#queries.count#</td>
-													<td class="txt-r">#unitFormat(arguments.custom.unit, queries.time,prettify)#</td>
-													<td>#queries.datasource#</td>
-													<td>#queries.src#</td>
-													<cfif hasCachetype><td>#isEmpty(queries.cacheType)?"none":queries.cacheType#</td></cfif>
-												</tr>
-												<tr>
-													<th class="label">SQL:</th>
-													<td id="-lucee-debug-query-sql-#queries.currentRow#" colspan="6" oncontextmenu="__LUCEE.debug.selectText( this.id );"><pre>#trim( queries.sql )#</pre></td>
+													<th colspan="7"><b>Query usage within the request</b></th>
 												</tr>
 
-												<cfif listFindNoCase(queries.columnlist, 'usage') && isStruct(queries.usage)>
-
-													<cfset local.usage=queries.usage>
-													<cfset local.usageNotRead = []>
-													<cfset local.usageRead  = []>
-
-													<cfloop collection="#usage#" index="local.item" item="local.value">
-														<cfif !value>
-															<cfset arrayAppend( usageNotRead, item )>
-														<cfelse>
-															<cfset arrayAppend( usageRead, item )>
-														</cfif>
-													</cfloop>
-
+												<cfset local.arr = usageRead>
+												<cfset local.arrLenU = arrayLen( arr )>
+												<cfif arrLenU>
 													<tr>
-														<th colspan="7"><b>Query usage within the request</b></th>
+														<td colspan="7">
+															Used:<cfloop from="1" to="#arrLenU#" index="local.ii">
+																#arr[ ii ]# <cfif ii LT arrLenU>, </cfif>
+															</cfloop>
+														</td>
 													</tr>
-
-													<cfset local.arr = usageRead>
-													<cfset local.arrLenU = arrayLen( arr )>
-													<cfif arrLenU>
-														<tr>
-															<td colspan="7">
-																Used:<cfloop from="1" to="#arrLenU#" index="local.ii">
-																	#arr[ ii ]# <cfif ii LT arrLenU>, </cfif>
-																</cfloop>
-															</td>
-														</tr>
-													</cfif>
-													<cfset local.arr = usageNotRead>
-													<cfset local.arrLenN = arrayLen( arr )>
-													<cfif arrLenN>
-														<tr class="red">
-															<td colspan="7">
-																Unused:
-																<cfloop from="1" to="#arrLenN#" index="local.ii">
-																	#arr[ ii ]# <cfif ii LT arrLenN>, </cfif>
-																</cfloop>
-															</td>
-														</tr>
-														<tr class="red">
-															<td colspan="7"><b>#arrLenU ? numberFormat( arrLenU / ( arrLenU + arrLenN ) * 100, "999.9" ) : 100# %</b></td>
-														</tr>
-													</cfif>
 												</cfif>
-
-											</table>
-
+												<cfset local.arr = usageNotRead>
+												<cfset local.arrLenN = arrayLen( arr )>
+												<cfif arrLenN>
+													<tr class="red">
+														<td colspan="7">
+															Unused:
+															<cfloop from="1" to="#arrLenN#" index="local.ii">
+																#arr[ ii ]# <cfif ii LT arrLenN>, </cfif>
+															</cfloop>
+														</td>
+													</tr>
+													<tr class="red">
+														<td colspan="7"><b>#arrLenU ? numberFormat( arrLenU / ( arrLenU + arrLenN ) * 100, "999.9" ) : 100# %</b></td>
+													</tr>
+												</cfif>
+											</cfif>
 										</cfloop>
+										</table>
 
 									</tr></td></table>
 								</td><!--- #-lucee-debug-#sectionId# !--->

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -286,8 +286,6 @@
 						local.q=0;
 					</cfscript>
 
-					<cfdump var=#pages#>
-
 					<cfloop query="pages">
 						<cfset tot=tot+pages.total>
 						<cfset q=q+pages.query>


### PR DESCRIPTION
combine sql queries into a single table
add toggle to display sql source
highlight slow queries, expand slow queries by default, hide sql for all other queries
add a couple of missing var statements

BTW I'd love to add query resultset size to the debug output, it would be really useful for monitoring memory usage