### PR TITLE
DirectoryWatcher Logging and error handling LDEV-1768

### DIFF
--- a/core/src/main/cfml/context/gateway/DirectoryWatcher.cfc
+++ b/core/src/main/cfml/context/gateway/DirectoryWatcher.cfc
@@ -32,7 +32,7 @@
 				<cflog text="init #variables.id# Listener is not a component" type="Error" file="#variables.logFileName#">
 				<cfreturn>
 			</cfif>
-			<cflog text="init #variables.id# [#len(arguments.listener)#]" type="information" file="#variables.logFileName#">
+			<cflog text="init #variables.id# [#GetComponentMetaData(arguments.listener).path#]" type="information" file="#variables.logFileName#">
 			<cfset variables.listener=arguments.listener>
 			<cfcatch>
 				<cfset _handleError(cfcatch, "init") />

--- a/core/src/main/cfml/context/gateway/DirectoryWatcher.cfc
+++ b/core/src/main/cfml/context/gateway/DirectoryWatcher.cfc
@@ -230,7 +230,7 @@
 
 	<cffunction name="stop" access="public" output="no" returntype="void">
 		<cflog text="stop #variables.id#" type="information" file="#variables.logFileName#">
-		<cfset variables.state="stopping">
+		<cfset variables.setState("stopping")>
 	</cffunction>
 
 	<cffunction name="restart" access="public" output="no" returntype="void">
@@ -246,15 +246,7 @@
 				file="#variables.logFileName#" />
 		<cfscript>
 			switch (arguments.newState){
-				case "start":
-					start();
-					break;
-				case "stop":
-					stop();
-					break;
-				case "restart":
-					restart();
-					break;
+				case "stopping":					
 				case "running":
 				case "stopped":
 					variables.state=arguments.newState;

--- a/core/src/main/cfml/context/gateway/DirectoryWatcher.cfc
+++ b/core/src/main/cfml/context/gateway/DirectoryWatcher.cfc
@@ -29,7 +29,7 @@
 			<cfset variables.id=arguments.id>
 			<cfset variables.config=arguments.config>
 			<cfif len(arguments.listener) eq 0>
-				<cflog text="init #variables.id# Listener is not an component" type="Error" file="#variables.logFileName#">
+				<cflog text="init #variables.id# Listener is not a component" type="Error" file="#variables.logFileName#">
 				<cfreturn>
 			</cfif>
 			<cflog text="init #variables.id# [#len(arguments.listener)#]" type="information" file="#variables.logFileName#">

--- a/core/src/main/java/resource/context/gateway/DirectoryWatcher.cfc
+++ b/core/src/main/java/resource/context/gateway/DirectoryWatcher.cfc
@@ -32,7 +32,7 @@
 				<cflog text="init #variables.id# Listener is not a component" type="Error" file="#variables.logFileName#">
 				<cfreturn>
 			</cfif>
-			<cflog text="init #variables.id# [#len(arguments.listener)#]" type="information" file="#variables.logFileName#">
+			<cflog text="init #variables.id# [#GetComponentMetaData(arguments.listener).path#]" type="information" file="#variables.logFileName#">
 			<cfset variables.listener=arguments.listener>
 			<cfcatch>
 				<cfset _handleError(cfcatch, "init") />

--- a/core/src/main/java/resource/context/gateway/DirectoryWatcher.cfc
+++ b/core/src/main/java/resource/context/gateway/DirectoryWatcher.cfc
@@ -230,7 +230,7 @@
 
 	<cffunction name="stop" access="public" output="no" returntype="void">
 		<cflog text="stop #variables.id#" type="information" file="#variables.logFileName#">
-		<cfset variables.state="stopping">
+		<cfset variables.setState("stopping")>
 	</cffunction>
 
 	<cffunction name="restart" access="public" output="no" returntype="void">
@@ -246,15 +246,7 @@
 				file="#variables.logFileName#" />
 		<cfscript>
 			switch (arguments.newState){
-				case "start":
-					start();
-					break;
-				case "stop":
-					stop();
-					break;
-				case "restart":
-					restart();
-					break;
+				case "stopping":					
 				case "running":
 				case "stopped":
 					variables.state=arguments.newState;

--- a/core/src/main/java/resource/context/gateway/DirectoryWatcher.cfc
+++ b/core/src/main/java/resource/context/gateway/DirectoryWatcher.cfc
@@ -29,7 +29,7 @@
 			<cfset variables.id=arguments.id>
 			<cfset variables.config=arguments.config>
 			<cfif len(arguments.listener) eq 0>
-				<cflog text="init #variables.id# Listener is not an component" type="Error" file="#variables.logFileName#">
+				<cflog text="init #variables.id# Listener is not a component" type="Error" file="#variables.logFileName#">
 				<cfreturn>
 			</cfif>
 			<cflog text="init #variables.id# [#len(arguments.listener)#]" type="information" file="#variables.logFileName#">


### PR DESCRIPTION
- include the name of the directoryWatcher instance in all DirectoryWatcher.log messages
- include stack traces with exception logs
- detect if no listener cfc is passed in, log out a message
- if there's no listener cfc, just stop
- track polling execution time and log when exceeds config.warningTimeout (default 1000ms, use 0 to disable)

LDEV-1768