### PR TITLE
performance.cfc focussed debug template

### DIFF
--- a/core/src/main/java/resource/context/admin/debug/Performance.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Performance.cfc
@@ -368,7 +368,7 @@
 											<td>#srcFunc#</td>
 											<td class="txt-r" title="#pages.total - pages.load#">#unitFormat(arguments.custom.unit, pages.total-pages.load,prettify)#</td>
 											<td class="txt-r">#pages.count#</td>
-											<td class="txt-r" title="#pages.avg#"><cfif pages.count GT 1>#unitFormat(arguments.custom.unit, pages.avg,prettify)#<cfelse>-</cfif></td>
+											<td class="txt-r" title="#pages.avg#">#unitFormat(arguments.custom.unit, pages.avg,prettify)#</td>
 											<td class="txt-r"><Cfif pages.query gt 0>#unitFormat(arguments.custom.unit, pages.query,prettify)#</Cfif></td>
 										</tr>
 

--- a/core/src/main/java/resource/context/admin/debug/Performance.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Performance.cfc
@@ -307,7 +307,8 @@
 							, "#unitFormat( arguments.custom.unit, tot-q-loa, prettify )# ms
 								&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Application" )>
 
-						<tr><td><table>
+						<tr><td>
+							<table>
 							<tr>
 								<td class="pad txt-r">#unitFormat( arguments.custom.unit, loa,prettify )# ms</td>
 								<td class="pad">Startup/Compilation</td>
@@ -323,16 +324,20 @@
 						</table></td></tr>
 						<tr>
 							<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+								<cfset querySort(pages,"avg","desc") />
 								<table class="details">
+								<thead onclick="__LUCEE.debug.sortTable(this);">
 									<tr>
 										<th><cfif isExecOrder>Order<cfelse><a onclick="__LUCEE.debug.setFlag( 'ExecOrder' ); __LUCEE.util.addClass( this, 'selected' );" class="sortby" title="Order by ID (starting with the next request)">Order</a></cfif></th>
-										<th>Template</th>
-										<th>Function</th>
+										<th data-type="text">Template</th>
+										<th data-type="text">Function</th>
 										<th>Total Time (ms)</th>
 										<th>Count</th>
 										<th><cfif isExecOrder><a onclick="__LUCEE.debug.clearFlag( 'ExecOrder' ); __LUCEE.util.addClass( this, 'selected' );" class="sortby" title="Order by Avg Time (starting with the next request)">Avg Time</a><cfelse>Avg Time</cfif> (ms)</th>
 										<th>Query</th>
 									</tr>
+								</thead>
+								<tbody>
 									<cfset loa=0>
 									<cfset tot=0>
 									<cfset q=0>
@@ -371,6 +376,7 @@
 									<cfif hasBad>
 										<tr class="red"><td colspan="6">red = over #unitFormat( arguments.custom.unit, arguments.custom.highlight * 1000 ,prettify)# ms average execution time</td></tr>
 									</cfif>
+								</tbody>
 								</table>
 							</td><!--- #-lucee-debug-#sectionId# !--->
 						</tr>
@@ -394,14 +400,16 @@
 							<tr>
 								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
 									<table class="details">
-
+									<thead onclick="__LUCEE.debug.sortTable(this);">
 										<tr>
-											<th>Type</th>
-											<th>Message</th>
-											<th>Detail</th>
-											<th>Template</th>
+											<th data-type="text">Type</th>
+											<th data-type="text">Message</th>
+											<th data-type="text">Detail</th>
+											<th data-type="text">Template</th>
 											<th>Line</th>
 										</tr>
+									</thead>
+									<tbody>
 										<cfloop array="#arguments.debugging.exceptions#" index="local.exp">
 											<tr>
 												<td>#exp.type#</td>
@@ -411,7 +419,7 @@
 												<td class="txt-r">#exp.TagContext[1].line#</td>
 											</tr>
 										</cfloop>
-
+									</tbody>
 									</table>
 								</td><!--- #-lucee-debug-#sectionId# !--->
 							</tr>
@@ -432,14 +440,16 @@
 							<tr>
 								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
 									<table class="details">
-
+									<thead onclick="__LUCEE.debug.sortTable(this);">
 										<tr>
 											<th>Template</th>
-											<th>Line</th>
+											<th data-type="number">Line</th>
 											<th>Scope</th>
 											<th>Var</th>
-											<th>Count</th>
+											<th data-type="number">Count</th>
 										</tr>
+									</thead>
+									<tbody>
 										<cfset var total=0 />
 										<cfloop query="implicitAccess">
 											<tr>
@@ -450,7 +460,7 @@
 												<td class="txt-r">#implicitAccess.count#</td>
 											</tr>
 										</cfloop>
-
+									</tbody>
 									</table>
 								</td><!--- #-lucee-debug-#sectionId# !--->
 							</tr>
@@ -472,12 +482,14 @@
 							<tr>
 								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
 									<table class="details">
-
+									<thead onclick="__LUCEE.debug.sortTable(this);">
 										<tr>
-											<th align="center">Label</th>
+											<th data-type="text" align="center">Label</th>
 											<th>Time (ms)</th>
-											<th>Template</th>
+											<th data-type="text">Template</th>
 										</tr>
+									</thead>
+									<tbody>
 										<cfloop query="timers">
 											<tr>
 												<td class="txt-r">#timers.label#</td>
@@ -485,7 +497,7 @@
 												<td class="txt-r">#timers.template#</td>
 											</tr>
 										</cfloop>
-
+									</tbody>
 									</table>
 								</td><!--- #-lucee-debug-#sectionId# !--->
 							</tr>
@@ -577,11 +589,14 @@
 							<tr>
 								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
 									<table class="details">
+									<thead onclick="__LUCEE.debug.sortTable(this);">
 										<tr>
-											<th>Output</th>
-											<th>Template</th>
+											<th data-type="text">Output</th>
+											<th data-type="text">Template</th>
 											<th>Line</th>
 										</tr>
+									</thead>
+									<tbody>
 										<cfset total=0 />
 										<cfloop query="dumps">
 											<tr>
@@ -590,6 +605,7 @@
 												<td class="txt-r">#dumps.line#</td>
 											</tr>
 										</cfloop>
+									</tbody>
 									</table>
 								</td>
 							</tr>
@@ -625,11 +641,14 @@
 									<table><tr><td>
 										<b>General</b>
 										<table class="details">
-										<tr>
-											<th>Name</th>
-											<th>Open Connections</th>
-											<th>Max Connections</th>
-										</tr>
+										<thead onclick="__LUCEE.debug.sortTable(this);">
+											<tr>
+												<th data-type="text">Name</th>
+												<th>Open Connections</th>
+												<th>Max Connections</th>
+											</tr>
+										</thead>
+										<tbody>
 										<cfloop struct="#debugging.datasources#" index="local.dsName" item="local.dsData">
 										<tr>
 											<td class="txt-r">#dsData.name#</td>
@@ -637,20 +656,23 @@
 											<td class="txt-r">#dsData.connectionLimit==-1?'INF':dsData.connectionLimit#</td>
 										</tr>
 										</cfloop>
+										<tbody>
 										</table>
 									<cfset var hasCachetype=ListFindNoCase(queries.columnlist,"cachetype") gt 0>
 									<br><b>SQL Queries</b>
 										<table class="details">
 										<cfset renderToggleDetailHeadTR( sqlSectionId, "Expand all SQL statements", "-lucee-debug-#sectionId#", "sql", (hasCachetype ? 6 : 5) )>
-
-										<tr>
-											<th>Name</th>
-											<th>Records</th>
-											<th>Time (ms)</th>
-											<th>Datasource</th>
-											<th>Source</th>
-											<cfif hasCachetype><th>Cache Type</th></cfif>
-										</tr>
+										<thead>
+											<tr>
+												<th data-type="text">Name</th>
+												<th>Records</th>
+												<th>Time (ms)</th>
+												<th data-type="text">Datasource</th>
+												<th data-type="text">Source</th>
+												<cfif hasCachetype><th data-type="text" >Cache Type</th></cfif>
+											</tr>
+										</thead>
+										<tbody>
 										<cfloop query="queries">
 											<cfscript>
 												var qryTime = unitFormat(arguments.custom.unit, queries.time,prettify);
@@ -716,6 +738,7 @@
 												</cfif>
 											</cfif>
 										</cfloop>
+										</tbody>
 										</table>
 
 									</tr></td></table>
@@ -874,6 +897,78 @@
 				}
 
 				, selectText:	__LUCEE.util.selectText
+				, sortTable: function (ev){
+					var th = event.target; // th
+					var table = event.currentTarget.parentElement; // table;
+					var tbody = event.currentTarget.nextElementSibling; // tbody
+					var tr = th.parentElement;
+
+					if (!th.dataset.type)
+						th.dataset.type = "number"; // otherwise text
+					if (!th.dataset.dir){
+						th.dataset.dir = "desc";
+					} else {
+						if (th.dataset.dir == "desc")
+							th.dataset.dir = "asc";
+						else
+							th.dataset.dir = "desc";
+					}
+					for (var h = 0; h < tr.children.length; h++){
+						var cell = tr.children[h].style;
+						if (h === th.cellIndex){
+							cell.fontWeight = 700;
+							cell.fontStyle = (th.dataset.dir == "desc") ? "normal" : "italic";
+						} else {
+							cell.fontWeight = 300;
+							cell.fontStyle = "normal";
+						}
+					}
+					var data = [];
+					for ( var r = 0; r < tbody.children.length; r++ ){
+						var row = tbody.children[r];
+						var val = row.children[th.cellIndex].innerText;
+						switch (th.dataset.type){
+							case "text":
+								val = val.toLowerCase();
+								break;
+							case "number":
+								switch (val){
+									case "":
+									case "-":
+										val = -1;
+										break;
+									default:
+										val = Number(val);
+									break;
+								}
+								break;
+						}
+						data.push([val, row]);
+					}
+
+					switch (th.dataset.type){
+						case "text":
+							data = data.sort(function(a,b){
+								if (a[0] < b[0])
+									return -1;
+								if (a[0] > b[0])
+									return 1;
+								return 0;
+							});
+							break;
+						case "number":
+							data = data.sort(function(a,b){
+								return a[0] - b[0];
+							});
+					}
+
+					if (th.dataset.dir === "asc")
+						data.reverse();
+					for (r = 0; r < data.length; r++){
+						tbody.appendChild(data[r][1]);
+					}
+
+				}
 			};
 		</script>
 

--- a/core/src/main/java/resource/context/admin/debug/Performance.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Performance.cfc
@@ -1,0 +1,984 @@
+<cfcomponent extends="Debug" output="no">
+
+	<cfscript>
+		fields=array(
+			  group("Execution Time","Execution times for templates, includes, modules, custom tags, and component method calls. Template execution times over this minimum highlight time appear in red.",3)
+			, field("Minimal Execution Time","minimal","0",true,{_appendix:"microseconds",_bottom:"Execution times for templates, includes, modules, custom tags, and component method calls. Outputs only templates taking longer than the time (in microseconds) defined above."},"text40")
+			, field("Highlight","highlight","250000",true,{_appendix:"microseconds",_bottom:"Highlight templates taking longer than the following (in microseconds) in red."},"text50")
+			, field("Time format","timeFormat","standard",true,
+			{_top:"Format used for time values.",
+			standard:"Always display fratcal number part of a number (123.001)",
+			natural:"Only display fratcal number part for small numbers (123)"
+			},"radio","standard,natural")
+			, group("Custom Debugging Output","Define what is outputted",3)
+			, field("Scope Variables","scopes","Enabled",false,"Enable Scope reporting","checkbox","Enabled")
+			, field("General Debug Information ","general","Enabled",false,
+				"Select this option to show general information about this request. General items are Lucee Version, Template, Time Stamp, User Locale, User Agent, User IP, and Host Name. ",
+				"checkbox","Enabled")
+		);
+
+		string function getLabel(){
+			return "Performance";
+		}
+
+		string function getDescription(){
+			return "Performance orientated debug template";
+		}
+
+		string function getid(){
+			return "Performace";
+		}
+
+		void function onBeforeUpdate(struct custom){
+			throwWhenNotNumeric(custom,"minimal");
+			throwWhenNotNumeric(custom,"highlight");
+		}
+
+		private void function throwWhenEmpty(struct custom, string name){
+			if(!structKeyExists(custom,name) or len(trim(custom[name])) EQ 0)
+				throw "value for [#arguments.name#] is not defined";
+		}
+
+		private void function throwWhenNotNumeric(struct custom, string name){
+			throwWhenEmpty(arguments.custom, arguments.name);
+			if(!isNumeric(trim(arguments.custom[arguments.name])))
+			throw "value for [#arguments.name#] must be numeric";
+		}
+
+		private function isColumnEmpty(query qry,string columnName){
+			if(!QueryColumnExists(qry,columnName)) return true;
+			return !len(arrayToList(queryColumnData(qry,columnName),""));
+		}
+
+		function isSectionOpen( string name ) {
+			try{
+			if ( arguments.name == "ALL" && !structKeyExists( Cookie, variables.cookieName ) )
+				return true;
+
+			var cookieValue = structKeyExists( Cookie, variables.cookieName ) ? Cookie[ variables.cookieName ] : 0;
+
+			return cookieValue && ( bitAnd( cookieValue, this.allSections[ arguments.name ] ) );
+			}
+			catch(e){
+				return false;
+			}
+		}
+
+		function isEnabled( custom, key ) {
+
+			return structKeyExists( arguments.custom, arguments.key ) && ( arguments.custom[ arguments.key ] == "Enabled" || arguments.custom[ arguments.key ] == "true" );
+		}
+
+
+		variables.cookieName = "lucee_debug_modern";
+
+		variables.scopeNames = [ "Application", "CGI", "Client", "Cookie", "Form", "Request", "Server", "Session", "URL" ];
+
+		function buildSectionStruct() {
+
+			var otherSections = [ "ALL", "Dump", "ExecTime", "ExecOrder", "Exceptions", "ImpAccess", "Info", "Query", "Timer", "Trace", "More", "Query-sql" ];
+			var i = 0;
+
+			var result = {};
+
+			for ( var k in otherSections )
+				result[ k ] = 2 ^ i++;
+
+			for ( var k in variables.scopeNames )
+				result[ k ] = 2 ^ i++;
+
+			return result;
+		}
+	</cfscript>
+
+	<cffunction name="output" returntype="void">
+		<cfargument name="custom" type="struct" required="yes" />
+		<cfargument name="debugging" required="true" type="struct" />
+		<cfargument name="context" type="string" default="web" />
+		<cfsilent>
+		<cfif !structKeyExists(arguments.custom,'minimal')><cfset arguments.custom.minimal="0"></cfif>
+		<cfif !structKeyExists(arguments.custom,'highlight')><cfset arguments.custom.highlight="250000"></cfif>
+		<cfif !structKeyExists(arguments.custom,'scopes')><cfset arguments.custom.scopes=false></cfif>
+		<cfif !structKeyExists(arguments.custom,'general')><cfset arguments.custom.general="Enabled"></cfif>
+
+		<cfset var time=getTickCount() />
+		<cfset var _cgi=structKeyExists(arguments.debugging,'cgi')?arguments.debugging.cgi:cgi />
+		<cfset var pages=arguments.debugging.pages />
+		<cfset var queries=arguments.debugging.queries />
+		<cfif not isDefined('arguments.debugging.timers')>
+			<cfset arguments.debugging.timers=queryNew('label,time,template') />
+		</cfif>
+		<cfif not isDefined('arguments.debugging.traces')>
+			<cfset arguments.debugging.traces=queryNew('type,category,text,template,line,var,total,trace') />
+		</cfif>
+		<cfif not isDefined('arguments.debugging.dumps')>
+			<cfset arguments.debugging.traces=queryNew('output,template,line') />
+		</cfif>
+		<cfset var timers=arguments.debugging.timers />
+		<cfset var traces=arguments.debugging.traces />
+		<cfset var dumps=arguments.debugging.dumps />
+
+		<cfset this.allSections = this.buildSectionStruct()>
+		<cfset var isExecOrder  = this.isSectionOpen( "ExecOrder" )>
+
+		<cfif isExecOrder>
+
+			<cfset querySort(pages,"id","asc") />
+		<cfelse>
+
+			<cfset querySort(pages,"avg","desc") />
+		</cfif>
+
+		<cfset var implicitAccess=arguments.debugging.implicitAccess />
+		<cfset querySort(implicitAccess,"template,line,count","asc,asc,desc") />
+		<cfparam name="arguments.custom.unit" default="millisecond">
+		<cfparam name="arguments.custom.color" default="black">
+		<cfparam name="arguments.custom.bgcolor" default="white">
+		<cfparam name="arguments.custom.font" default="Times New Roman">
+		<cfparam name="arguments.custom.size" default="medium">
+		<cfset var unit={
+			millisecond:"ms"
+			,microsecond:"µs"
+			,nanosecond:"ns"
+			} />
+
+		<cfset var ordermap={}>
+		<cfloop query="#arguments.debugging.history#">
+			<cfif !structkeyExists(ordermap, arguments.debugging.history.id)><cfset ordermap[ arguments.debugging.history.id ]=structCount(ordermap)+1></cfif>
+		</cfloop>
+		<cfset var prettify=structKeyExists(arguments.custom,'timeformat') and arguments.custom.timeformat EQ "natural">
+		</cfsilent>
+		<cfif arguments.context EQ "web">
+			</td></td></td></th></th></th></tr></tr></tr></table></table></table></a></abbrev></acronym></address></applet></au></b></banner></big></blink></blockquote></bq></caption></center></cite></code></comment></del></dfn></dir></div></div></dl></em></fig></fn></font></form></frame></frameset></h1></h2></h3></h4></h5></h6></head></i></ins></kbd></listing></map></marquee></menu></multicol></nobr></noframes></noscript></note></ol></p></param></person></plaintext></pre></q></s></samp></script></select></small></strike></strong></sub></sup></table></td></textarea></th></title></tr></tt></u></ul></var></wbr></xmp>
+		</cfif>
+		<style type="text/css">
+			#-lucee-debug 			{ margin: 2.5em 1em 0 1em; padding: 1em; background-color: #FFF; color: #222; border: 1px solid #CCC; border-radius: 5px; text-shadow: none; }
+			#-lucee-debug.collapsed	{ padding: 0; border-width: 0; }
+			#-lucee-debug legend 	{ padding: 0 1em; background-color: #FFF; color: #222; }
+			#-lucee-debug legend span { font-weight: normal; }
+
+			#-lucee-debug, #-lucee-debug td	{ font-family: Helvetica, Arial, sans-serif; font-size: 9pt; line-height: 1.35; }
+			#-lucee-debug.large, #-lucee-debug.large td	{ font-size: 10pt; }
+			#-lucee-debug.small, #-lucee-debug.small td	{ font-size: 8.5pt; }
+
+			#-lucee-debug table		{ empty-cells: show; border-collapse: collapse; border-spacing: 0; }
+			#-lucee-debug table.details	{ margin-top: 0.5em; border: 1px solid #ddd; margin-left: 9pt; max-width: 100%; }
+			#-lucee-debug table.details th { font-size: 9pt; font-weight: normal; background-color: #f2f2f2; color: #3c3e40; }
+			#-lucee-debug table.details td, #-lucee-debug table.details th { padding: 2px 4px;  border: 1px solid #ddd; }
+
+			#-lucee-debug .section-title	{ margin-top: 1.25em; font-size: 1.25em; font-weight: normal; color:#555; }
+			#-lucee-debug .section-title:first-child	{ margin-top: auto; }
+			#-lucee-debug .label		{ white-space: nowrap; vertical-align: top; text-align: right; padding-right: 1em; background-color: inherit; color: inherit; text-shadow: none; }
+			#-lucee-debug .collapsed	{ display: none; }
+			#-lucee-debug .bold 		{ font-weight: bold; }
+			#-lucee-debug .txt-c 	{ text-align: center; }
+			#-lucee-debug .txt-l 	{ text-align: left; }
+			#-lucee-debug .txt-r 	{ text-align: right; }
+			#-lucee-debug .faded 	{ color: #999; }
+			#-lucee-debug .ml14px 	{ margin-left: 14px; }
+			#-lucee-debug table.details td.txt-r { padding-right: 1em; }
+			#-lucee-debug .num-lsv 	{ font-weight: normal; }
+			#-lucee-debug tr.nowrap td { white-space: nowrap; }
+			#-lucee-debug tr.red td, #-lucee-debug .red 	{ background-color: #FDD; }
+
+			#-lucee-debug .sortby.selected, #-lucee-debug .sortby:hover { background-color: #25A; color: #FFF; }
+			#-lucee-debug .pad 	{ padding-left: 16px; }
+			#-lucee-debug a 	{ cursor: pointer; }
+			#-lucee-debug td a 	{ color: #25A; }
+			#-lucee-debug .warning{ color: red; }
+			#-lucee-debug td a:hover	{ color: #58C; text-decoration: underline; }
+			#-lucee-debug pre 	{ background-color: #EEE; padding: 1em; border: solid 1px #333; border-radius: 1em; white-space: pre-wrap; word-break: break-all; word-wrap: break-word; tab-size: 2; }
+
+			.-lucee-icon-plus 	{ background: url(data:image/gif;base64,R0lGODlhCQAJAIABAAAAAP///yH5BAEAAAEALAAAAAAJAAkAAAIRhI+hG7bwoJINIktzjizeUwAAOw==) no-repeat left center; padding: 4px 0 4px 16px; }
+			.-lucee-icon-minus 	{ background: url(data:image/gif;base64,R0lGODlhCQAJAIABAAAAAP///yH5BAEAAAEALAAAAAAJAAkAAAIQhI+hG8brXgPzTHllfKiDAgA7)     no-repeat left center; padding: 4px 0 4px 16px; }
+		</style>
+
+		<cfoutput>
+
+			<cfset var sectionId = "ALL">
+			<cfset var isOpen = this.isSectionOpen( sectionId )>
+
+			<!-- Lucee Debug Output !-->
+			<fieldset id="-lucee-debug" class="#arguments.custom.size# #isOpen ? '' : 'collapsed'#">
+
+				<legend><a id="-lucee-debug-btn-#sectionId#" class="-lucee-icon-#isOpen ? 'minus' : 'plus'#" onclick="__LUCEE.debug.toggleSection( '#sectionId#' ) ? __LUCEE.util.removeClass('-lucee-debug', 'collapsed') : __LUCEE.util.addClass('-lucee-debug', 'collapsed');">
+				 Lucee Debug Output</a> <span>(#this.getLabel()#)</span></legend>
+
+				<div id="-lucee-debug-ALL" class="#isOpen ? '' : 'collapsed'#">
+
+					<!--- General --->
+					<cfif isEnabled( arguments.custom, 'general' )>
+
+						<div class="section-title">Debugging Information</div>
+					    <cfif getJavaVersion() LT 8 >
+							<div class="warning">
+								You are running Lucee with Java #server.java.version# Lucee does not formally support this version of Java. Consider updating to the latest Java version for security and performance reasons.
+							</div>
+					    </cfif>
+
+						<cfset sectionId = "Info">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+						<table>
+
+							<cfset renderSectionHeadTR( sectionId, "Template:", "#HTMLEditFormat(_cgi.SCRIPT_NAME)# (#HTMLEditFormat(expandPath(_cgi.SCRIPT_NAME))#)" )>
+
+							<tr>
+								<td class="pad label">User Agent:</td>
+								<td class="pad">#_cgi.http_user_agent#</td>
+							</tr>
+							<tr>
+								<td colspan="2" id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table class="ml14px">
+										<tr>
+											<td class="label" colspan="2">
+												#server.coldfusion.productname#
+												<cfif StructKeyExists(server.lucee,'versionName')>(<a href="#server.lucee.versionNameExplanation#" target="_blank">#server.lucee.versionName#</a>)
+												</cfif>
+												#ucFirst(server.coldfusion.productlevel)# #server.lucee.version# (CFML Version #server.ColdFusion.ProductVersion#)
+											</td>
+										</tr>
+										<tr>
+											<td class="label">Time Stamp</td>
+											<td class="cfdebug">#LSDateFormat(now())# #LSTimeFormat(now())#</td>
+										</tr>
+										<tr>
+											<td class="label">Time Zone</td>
+											<td class="cfdebug">#getTimeZone()#</td>
+										</tr>
+										<tr>
+											<td class="label">Locale</td>
+											<td class="cfdebug">#ucFirst(GetLocale())#</td>
+										</tr>
+										<tr>
+											<td class="label">Remote IP</td>
+											<td class="cfdebug">#_cgi.remote_addr#</td>
+										</tr>
+										<tr>
+											<td class="label">Host Name</td>
+											<td class="cfdebug">#_cgi.server_name#</td>
+										</tr>
+										<cfif StructKeyExists(server.os,"archModel") and StructKeyExists(server.java,"archModel")>
+											<tr>
+												<td class="label">Architecture</td>
+												<td class="cfdebug">
+													<cfif server.os.archModel NEQ server.os.archModel>
+														OS #server.os.archModel#bit/JRE #server.java.archModel#bit
+													<cfelse>
+														#server.os.archModel#bit
+													</cfif>
+												</td>
+											</tr>
+										</cfif>
+									</table>
+								</td>
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Execution Time --->
+					<cfset sectionId = "ExecTime">
+					<cfset isOpen = this.isSectionOpen( sectionId )>
+
+					<div class="section-title">Execution Time</div>
+					<cfscript>
+						local.loa=0;
+						local.tot=0;
+						local.q=0;
+					</cfscript>
+
+					<cfloop query="pages">
+						<cfset tot=tot+pages.total>
+						<cfset q=q+pages.query>
+						<cfif pages.avg LT arguments.custom.minimal*1000>
+							<cfcontinue>
+						</cfif>
+						<cfset local.bad=pages.avg GTE arguments.custom.highlight*1000>
+						<cfset loa=loa+pages.load />
+					</cfloop>
+
+					<cfscript>
+						addServerTimingHeader("debugging", "Startup/Compilation", unitFormat( arguments.custom.unit, loa,prettify ));
+						addServerTimingHeader("debugging", "Query", unitFormat( arguments.custom.unit, q,prettify ));
+						addServerTimingHeader("debugging", "Execution", unitFormat( arguments.custom.unit, tot, prettify ));
+					</cfscript>
+
+					<table>
+						<cfset renderSectionHeadTR( sectionId
+							, "#unitFormat( arguments.custom.unit, tot-q-loa, prettify )# ms
+								&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Application" )>
+
+						<tr><td><table>
+							<tr>
+								<td class="pad txt-r">#unitFormat( arguments.custom.unit, loa,prettify )# ms</td>
+								<td class="pad">Startup/Compilation</td>
+							</tr>
+							<tr>
+								<td class="pad txt-r">#unitFormat( arguments.custom.unit, q,prettify )# ms</td>
+								<td class="pad">Query</td>
+							</tr>
+							<tr>
+								<td class="pad txt-r bold">#unitFormat( arguments.custom.unit, tot, prettify )# ms</td>
+								<td class="pad bold">Total</td>
+							</tr>
+						</table></td></tr>
+						<tr>
+							<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+								<table class="details">
+									<tr>
+										<th><cfif isExecOrder>Order<cfelse><a onclick="__LUCEE.debug.setFlag( 'ExecOrder' ); __LUCEE.util.addClass( this, 'selected' );" class="sortby" title="Order by ID (starting with the next request)">Order</a></cfif></th>
+										<th>Template</th>
+										<th>Function</th>
+										<th>Total Time (ms)</th>
+										<th>Count</th>
+										<th><cfif isExecOrder><a onclick="__LUCEE.debug.clearFlag( 'ExecOrder' ); __LUCEE.util.addClass( this, 'selected' );" class="sortby" title="Order by Avg Time (starting with the next request)">Avg Time</a><cfelse>Avg Time</cfif> (ms)</th>
+										<th>Query</th>
+									</tr>
+									<cfset loa=0>
+									<cfset tot=0>
+									<cfset q=0>
+									<cfset var hasBad = false>
+									<cfloop query="pages">
+										<cfset tot=tot+pages.total>
+										<cfset q=q+pages.query>
+										<cfif pages.avg LT arguments.custom.minimal * 1000>
+											<cfcontinue>
+										</cfif>
+										<cfset var bad=pages.avg GTE arguments.custom.highlight * 1000>
+										<cfif bad>
+											<cfset hasBad = true>
+										</cfif>
+										<cfset loa=loa+pages.load>
+										<tr class="nowrap #bad ? 'red' : ''#">
+											<td class="txt-r faded" title="#pages.id#">#ordermap[pages.id]#</td>
+											<Cfscript>
+												var srcFile = pages.src;
+												var srcFunc = "";
+												var srcLen  = ListLen(srcFile, "$");
+												if (srcLen gt 1){
+													srcFunc = ListLast(srcFile, "$");
+													srcFile = listDeleteAt(srcFile, srcLen, "$" );
+												}
+											</Cfscript>
+											<td id="-lucee-debug-pages-#pages.currentRow#" oncontextmenu="__LUCEE.debug.selectText( this.id );">#srcFile#</td>
+											<td>#srcFunc#</td>
+											<td class="txt-r" title="#pages.total - pages.load#">#unitFormat(arguments.custom.unit, pages.total-pages.load,prettify)#</td>
+											<td class="txt-r">#pages.count#</td>
+											<td class="txt-r" title="#pages.avg#"><cfif pages.count GT 1>#unitFormat(arguments.custom.unit, pages.avg,prettify)#<cfelse>-</cfif></td>
+											<td class="txt-r"><Cfif pages.query gt 0>#unitFormat(arguments.custom.unit, pages.query,prettify)#</Cfif></td>
+										</tr>
+
+									</cfloop>
+									<cfif hasBad>
+										<tr class="red"><td colspan="6">red = over #unitFormat( arguments.custom.unit, arguments.custom.highlight * 1000 ,prettify)# ms average execution time</td></tr>
+									</cfif>
+								</table>
+							</td><!--- #-lucee-debug-#sectionId# !--->
+						</tr>
+					</table>
+
+
+					<cfset this.doMore( arguments.custom, arguments.debugging, arguments.context )>
+
+
+					<!--- Exceptions --->
+					<cfif structKeyExists( arguments.debugging, "exceptions" ) && arrayLen( arguments.debugging.exceptions )>
+
+						<cfset sectionId = "Exceptions">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+
+						<div class="section-title">Caught Exceptions</div>
+						<table>
+
+							<cfset renderSectionHeadTR( sectionId, "#arrayLen(arguments.debugging.exceptions)# Exception#arrayLen( arguments.debugging.exceptions ) GT 1 ? 's' : ''# Caught" )>
+
+							<tr>
+								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table class="details">
+
+										<tr>
+											<th>Type</th>
+											<th>Message</th>
+											<th>Detail</th>
+											<th>Template</th>
+											<th>Line</th>
+										</tr>
+										<cfloop array="#arguments.debugging.exceptions#" index="local.exp">
+											<tr>
+												<td>#exp.type#</td>
+												<td>#exp.message#</td>
+												<td>#exp.detail#</td>
+												<td>#exp.TagContext[1].template#</td>
+												<td class="txt-r">#exp.TagContext[1].line#</td>
+											</tr>
+										</cfloop>
+
+									</table>
+								</td><!--- #-lucee-debug-#sectionId# !--->
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Implicit variable Access --->
+					<cfif implicitAccess.recordcount>
+
+						<cfset sectionId = "ImpAccess">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+
+						<div class="section-title">Implicit Variable Access</div>
+
+						<table>
+							<cfset renderSectionHeadTR( sectionId, "#implicitAccess.recordcount# Implicit Variable Access#( implicitAccess.recordcount GT 1 ) ? 'es' : ''#" )>
+
+							<tr>
+								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table class="details">
+
+										<tr>
+											<th>Template</th>
+											<th>Line</th>
+											<th>Scope</th>
+											<th>Var</th>
+											<th>Count</th>
+										</tr>
+										<cfset var total=0 />
+										<cfloop query="implicitAccess">
+											<tr>
+												<td>#implicitAccess.template#</td>
+												<td class="txt-r">#implicitAccess.line#</td>
+												<td>#implicitAccess.scope#</td>
+												<td>#implicitAccess.name#</td>
+												<td class="txt-r">#implicitAccess.count#</td>
+											</tr>
+										</cfloop>
+
+									</table>
+								</td><!--- #-lucee-debug-#sectionId# !--->
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Timers --->
+					<cfif timers.recordcount>
+
+						<cfset sectionId = "Timer">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+
+						<div class="section-title">CFTimer Times</div>
+
+						<table>
+
+							<cfset renderSectionHeadTR( sectionId, "#timers.recordcount# Timer#( timers.recordcount GT 1 ) ? 's' : ''# Set" )>
+
+							<tr>
+								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table class="details">
+
+										<tr>
+											<th align="center">Label</th>
+											<th>Time (ms)</th>
+											<th>Template</th>
+										</tr>
+										<cfloop query="timers">
+											<tr>
+												<td class="txt-r">#timers.label#</td>
+												<td class="txt-r">#unitFormat( arguments.custom.unit, timers.time * 1000000,prettify )#</td>
+												<td class="txt-r">#timers.template#</td>
+											</tr>
+										</cfloop>
+
+									</table>
+								</td><!--- #-lucee-debug-#sectionId# !--->
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Traces --->
+					<cfif traces.recordcount>
+
+						<cfset sectionId = "Trace">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+
+						<div class="section-title">Trace Points</div>
+
+						<cfset var hasAction=!isColumnEmpty(traces,'action') />
+						<cfset var hasCategory=!isColumnEmpty(traces,'category') />
+
+						<table>
+
+							<cfset renderSectionHeadTR( sectionId, "#traces.recordcount# Trace Point#( traces.recordcount GT 1 ) ? 's' : ''#" )>
+
+							<tr>
+								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table class="details">
+										<tr>
+											<th>Type</th>
+											<cfif hasCategory>
+												<th>Category</th>
+											</cfif>
+											<th>Text</th>
+											<th>Template</th>
+											<th>Line</th>
+											<cfif hasAction>
+												<th>Action</th>
+											</cfif>
+											<th>Var</th>
+											<th>Total Time (ms)</th>
+											<th>Trace Slot Time (ms)</th>
+										</tr>
+										<cfset total=0 />
+										<cfloop query="traces">
+											<cfset total=total+traces.time />
+											<tr>
+												<td>#traces.type#</td>
+												<cfif hasCategory>
+													<td>#traces.category#&nbsp;</td>
+												</cfif>
+												<td>#traces.text#&nbsp;</td>
+												<td>#traces.template#</td>
+												<td class="txt-r">#traces.line#</td>
+												<cfif hasAction>
+													<td>#traces.action#</td>
+												</cfif>
+												<td>
+													<cfif len(traces.varName)>
+														#traces.varName#
+														<cfif structKeyExists(traces,'varValue')>
+															= #traces.varValue#
+														</cfif>
+													<cfelse>
+														&nbsp;
+														<br />
+													</cfif>
+												</td>
+												<td class="txt-r">#unitFormat(arguments.custom.unit, total,prettify)#</td>
+												<td class="txt-r">#unitFormat(arguments.custom.unit, traces.time,prettify)#</td>
+											</tr>
+										</cfloop>
+
+									</table>
+								</td><!--- #-lucee-debug-#sectionId# !--->
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Dumps --->
+					<cfif dumps.recordcount>
+
+						<cfset sectionId = "Dump">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+
+						<div class="section-title">Dumps</div>
+
+
+						<table>
+
+							<cfset renderSectionHeadTR( sectionId, "#dumps.recordcount# Dump#( dumps.recordcount GT 1 ) ? 's' : ''#" )>
+
+							<tr>
+								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table class="details">
+										<tr>
+											<th>Output</th>
+											<th>Template</th>
+											<th>Line</th>
+										</tr>
+										<cfset total=0 />
+										<cfloop query="dumps">
+											<tr>
+												<td>#dumps.output#</td>
+												<td>#dumps.template#</td>
+												<td class="txt-r">#dumps.line#</td>
+											</tr>
+										</cfloop>
+									</table>
+								</td>
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Queries --->
+					<cfif queries.recordcount>
+
+						<cfset sectionId = "Query">
+						<cfset isOpen = this.isSectionOpen( sectionId )>
+						<cfset var sqlSectionId = "Query-sql">
+						<cfset var isSqlExpanded = this.isSectionOpen(sqlSectionId)>
+						<cfset local.total  =0>
+						<cfset local.records=0>
+						<cfset local.openConns=0>
+						<cfset var dsn = "">
+						<cfloop struct="#debugging.datasources#" index="dsn" item="item">
+							<cfset local.openConns=item.openConnections>
+						</cfloop>
+
+						<cfset var ar_headers = []>
+						<cfloop query="queries">
+							<cfset total   += queries.time>
+							<cfset records += queries.count>
+						</cfloop>
+						<div class="section-title">Datasource Information</div>
+						<table>
+							<cfset renderSectionHeadTR( sectionId, "#queries.recordcount# Quer#queries.recordcount GT 1 ? 'ies' : 'y'# Executed (Total Records: #records#; Total Time: #unitFormat( arguments.custom.unit, total ,prettify)# ms; Total Open Connections: #openConns#)" )>
+
+							<tr>
+								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
+									<table><tr><td>
+										<b>General</b>
+										<table class="details">
+										<tr>
+											<th>Name</th>
+											<th>Open Connections</th>
+											<th>Max Connections</th>
+										</tr>
+										<cfloop struct="#debugging.datasources#" index="local.dsName" item="local.dsData">
+										<tr>
+											<td class="txt-r">#dsData.name#</td>
+											<td class="txt-r">#dsData.openConnections#</td>
+											<td class="txt-r">#dsData.connectionLimit==-1?'INF':dsData.connectionLimit#</td>
+										</tr>
+										</cfloop>
+										</table>
+									<cfset var hasCachetype=ListFindNoCase(queries.columnlist,"cachetype") gt 0>
+									<br><b>SQL Queries</b>
+										<table class="details">
+										<cfset renderToggleDetailHeadTR( sqlSectionId, "Expand all SQL statements", "-lucee-debug-#sectionId#", "sql", (hasCachetype ? 6 : 5) )>
+
+										<tr>
+											<th>Name</th>
+											<th>Records</th>
+											<th>Time (ms)</th>
+											<th>Datasource</th>
+											<th>Source</th>
+											<cfif hasCachetype><th>Cache Type</th></cfif>
+										</tr>
+										<cfloop query="queries">
+											<cfscript>
+												var qryTime = unitFormat(arguments.custom.unit, queries.time,prettify);
+												addServerTimingHeader("sql", "qry: " & queries.name, qryTime);
+											</cfscript>
+											<cfset var bad=queries.time gt (arguments.custom.highlight * 1000)>
+											<tr class="sql-result #bad ? 'red' : ''#" onclick="__LUCEE.debug.toggleClass('query-id-#queries.currentRow#')">
+												<td><a>#queries.name#</a></td>
+												<td class="txt-r">#queries.count#</td>
+												<td class="txt-r">#qryTime#</td>
+												<td>#isEmpty(queries.datasource)? "_queryofquerydb" : queries.datasource#</td>
+												<td>#queries.src#</td>
+												<cfif hasCachetype><td>#isEmpty(queries.cacheType)?"none":queries.cacheType#</td></cfif>
+											</tr>
+											<tr class="sql #bad ? '' : (isSqlExpanded ? "" : 'collapsed')#" id="-lucee-debug-query-id-#queries.currentRow#">
+												<th class="label">SQL:</th>
+												<td id="-lucee-debug-query-sql-#queries.currentRow#" colspan="6" oncontextmenu="__LUCEE.debug.selectText( this.id );"><pre>#trim( queries.sql )#</pre></td>
+											</tr>
+
+											<cfif listFindNoCase(queries.columnlist, 'usage') && isStruct(queries.usage)>
+
+												<cfset local.usage=queries.usage>
+												<cfset local.usageNotRead = []>
+												<cfset local.usageRead  = []>
+
+												<cfloop collection="#usage#" index="local.item" item="local.value">
+													<cfif !value>
+														<cfset arrayAppend( usageNotRead, item )>
+													<cfelse>
+														<cfset arrayAppend( usageRead, item )>
+													</cfif>
+												</cfloop>
+
+												<tr>
+													<th colspan="7"><b>Query usage within the request</b></th>
+												</tr>
+
+												<cfset local.arr = usageRead>
+												<cfset local.arrLenU = arrayLen( arr )>
+												<cfif arrLenU>
+													<tr>
+														<td colspan="7">
+															Used:<cfloop from="1" to="#arrLenU#" index="local.ii">
+																#arr[ ii ]# <cfif ii LT arrLenU>, </cfif>
+															</cfloop>
+														</td>
+													</tr>
+												</cfif>
+												<cfset local.arr = usageNotRead>
+												<cfset local.arrLenN = arrayLen( arr )>
+												<cfif arrLenN>
+													<tr class="red">
+														<td colspan="7">
+															Unused:
+															<cfloop from="1" to="#arrLenN#" index="local.ii">
+																#arr[ ii ]# <cfif ii LT arrLenN>, </cfif>
+															</cfloop>
+														</td>
+													</tr>
+													<tr class="red">
+														<td colspan="7"><b>#arrLenU ? numberFormat( arrLenU / ( arrLenU + arrLenN ) * 100, "999.9" ) : 100# %</b></td>
+													</tr>
+												</cfif>
+											</cfif>
+										</cfloop>
+										</table>
+
+									</tr></td></table>
+								</td><!--- #-lucee-debug-#sectionId# !--->
+							</tr>
+						</table>
+					</cfif>
+
+					<!--- Scopes --->
+					<cfif isEnabled( arguments.custom, "scopes" )>
+
+						<cfset local.scopes = variables.scopeNames>
+
+						<cfset local.appSettings = getApplicationSettings()>
+						<cfset local.isScopeEnabled = true>
+
+						<div class="section-title">Scope Information</div>
+						<table cellpadding="0" cellspacing="0">
+
+							<cfloop array="#local.scopes#" index="local.k">
+
+								<tr><td style="font-size: 4px;">&nbsp;</td></tr>
+
+								<cfset sectionId = k>
+								<cfswitch expression="#k#">
+
+									<cfcase value="Client">
+
+										<cfset isScopeEnabled = local.appSettings.clientManagement>
+									</cfcase>
+									<cfcase value="Session">
+
+										<cfset isScopeEnabled = local.appSettings.sessionManagement>
+									</cfcase>
+									<cfdefaultcase>
+
+										<cfset isScopeEnabled = true>
+									</cfdefaultcase>
+								</cfswitch>
+
+								<cfif isScopeEnabled>
+
+									<cfset isOpen = this.isSectionOpen( sectionId )>
+									<cfset local.v = evaluate( k )>
+									<cfset local.sc = structCount( v )>
+
+									<cftry>
+
+										<cfset local.estSize = byteFormat( sc == 0 ? 0 : sizeOf( v ) )>
+
+										<cfcatch>
+
+											<cfset local.estSize = "not available">
+										</cfcatch>
+									</cftry>
+
+									<cfset renderSectionHeadTR( sectionId, "<b>#k# Scope</b> #sc ? '(~#estSize#)' : '(Empty)' #" )>
+
+									<tr><td colspan="3">
+
+										<table id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'# ml14px"><tr><td>
+
+											<cfif isOpen>
+												<cftry><cfdump var="#v#" keys="1000" label="#sc GT 1000?"First 1000 Records":""#"><cfcatch>not available</cfcatch></cftry>
+											<cfelse>
+												the Scope will be displayed with the next request
+											</cfif>
+										</td></tr></table><!--- #-lucee-debug-#sectionId# !--->
+									</td></tr>
+								<cfelse>
+
+									<tr>
+										<td class="faded" style="padding-left: 16px;"><b>#k# Scope</b> (Not Enabled for this Application)</td>
+									</tr>
+								</cfif>
+							</cfloop>
+
+						</table>
+					</cfif>
+
+				</div><!--- #-lucee-debug-ALL !--->
+			</fieldset><!--- #-lucee-debug !--->
+		</cfoutput>
+		<cfscript>
+			addServerTimingHeader("debugging", "Render debugging output", getTickCount()-time);
+
+			outputServerTimingHeaders();
+		</cfscript>
+		<script>
+			<cfset this.includeInline( "/lucee/res/js/util.min.js" )>
+
+			var __LUCEE = __LUCEE || {};
+
+			__LUCEE.debug = {
+
+				<cfoutput>
+				  cookieName: 	"#variables.cookieName#"
+				, bitmaskAll: 	Math.pow( 2, 31 ) - 1
+				, allSections: 	#serializeJSON( this.allSections )#
+				</cfoutput>
+
+				, setFlag: 		function( name ) {
+
+					var value = __LUCEE.util.getCookie( __LUCEE.debug.cookieName, __LUCEE.debug.allSections.ALL ) | __LUCEE.debug.allSections[ name ];
+					__LUCEE.util.setCookie( __LUCEE.debug.cookieName, value );
+					return value;
+				}
+
+				, clearFlag: 	function( name ) {
+
+					var value = __LUCEE.util.getCookie( __LUCEE.debug.cookieName, 0 ) & ( __LUCEE.debug.bitmaskAll - __LUCEE.debug.allSections[ name ] );
+					__LUCEE.util.setCookie( __LUCEE.debug.cookieName, value );
+					return value;
+				}
+
+				, toggleClass: 	function( name , toggleClass ) {
+ 					if (!toggleClass)
+ 						toggleClass =  "collapsed";
+ 					var obj = __LUCEE.util.getDomObject( "-lucee-debug-" + name );
+ 					__LUCEE.util.toggleClass( obj, toggleClass);
+ 				}
+
+ 				, toggleDetail: 	function( name , parent, targetClass ) {
+ 					var detail = __LUCEE.util.getDomObject(parent).getElementsByClassName(targetClass);
+ 					__LUCEE.debug.toggleSection( name, detail);
+ 				}
+
+				, toggleSection: 	function( name, objs ) {
+
+					var btn = __LUCEE.util.getDomObject( "-lucee-debug-btn-" + name );
+					if (!objs)
+						var obj = __LUCEE.util.getDomObject( "-lucee-debug-" + name );
+					var isOpen = ( __LUCEE.util.getCookie( __LUCEE.debug.cookieName, 0 ) & __LUCEE.debug.allSections[ name ] ) > 0;
+
+					if ( isOpen ) {
+						__LUCEE.util.removeClass( btn, '-lucee-icon-minus' );
+						__LUCEE.util.addClass( btn, '-lucee-icon-plus' );
+						if (objs){
+							for (var i = 0; i < objs.length; i++)
+								__LUCEE.util.addClass( objs[i], 'collapsed' );
+						} else {
+							__LUCEE.util.addClass( obj, 'collapsed' );
+						}
+						__LUCEE.debug.clearFlag( name );
+					} else {
+						__LUCEE.util.removeClass( btn, '-lucee-icon-plus' );
+						__LUCEE.util.addClass( btn, '-lucee-icon-minus' );
+						if (objs){
+							for (var i = 0; i < objs.length; i++)
+								__LUCEE.util.removeClass( objs[i], 'collapsed' );
+						} else {
+							__LUCEE.util.addClass( obj, 'collapsed' );							}
+						__LUCEE.debug.setFlag( name );
+					}
+					return !isOpen;					// returns true if section is open after the operation
+				}
+
+				, selectText:	__LUCEE.util.selectText
+			};
+		</script>
+
+	</cffunction><!--- output() !--->
+
+
+	<cffunction name="doMore" returntype="void">
+		<cfargument name="custom"    type="struct" required="#true#">
+		<cfargument name="debugging" type="struct" required="#true#">
+		<cfargument name="context"   type="string" default="web">
+
+	</cffunction>
+
+	<cffunction name="renderSectionHeadTR" output="#true#">
+		<cfargument name="sectionId">
+		<cfargument name="label1">
+		<cfargument name="label2" default="">
+
+		<cfset var isOpen = this.isSectionOpen( arguments.sectionId )>
+		<tr>
+			<td> <a id="-lucee-debug-btn-#arguments.sectionId#" class="-lucee-icon-#isOpen ? 'minus' : 'plus'#" onclick="__LUCEE.debug.toggleSection( '#arguments.sectionId#' );">
+				#arguments.label1#</a></td>
+			<td class="pad"><a onclick="__LUCEE.debug.toggleSection( '#arguments.sectionId#' );">#arguments.label2#</a></td>
+		</tr>
+	</cffunction>
+
+	<cffunction name="renderToggleDetailHeadTR" output="#true#">
+		<cfargument name="sectionId">
+		<cfargument name="label">
+		<cfargument name="parentId">
+		<cfargument name="targetClass">
+		<cfargument name="colspan" default="1">
+
+		<cfset var isOpen = this.isSectionOpen( arguments.sectionId )>
+		<tr>
+			<td colspan="#arguments.colspan#"> <a id="-lucee-debug-btn-#arguments.sectionId#" class="-lucee-icon-#isOpen ? 'minus' : 'plus'#"
+				onclick="__LUCEE.debug.toggleDetail( '#arguments.sectionId#', '#arguments.parentId#', '#arguments.targetClass#');">
+				#arguments.label#</a></td>
+		</tr>
+	</cffunction>
+
+	<cfscript>
+
+		function unitFormat( string unit, numeric time, boolean prettify=false ) {
+			if ( !arguments.prettify ) {
+				return NumberFormat( arguments.time / 1000000, ",0.000" );
+			}
+
+			// display 0 digits right to the point when more or equal to 100ms
+			if ( arguments.time >= 100000000 )
+				return int( arguments.time / 1000000 );
+
+			// display 1 digit right to the point when more or equal to 10ms
+			if ( arguments.time >=  10000000 )
+				return ( int( arguments.time / 100000 ) / 10 );
+
+			// display 2 digits right to the point when more or equal to 1ms
+			if ( arguments.time >=   1000000 )
+				return ( int( arguments.time / 10000 ) / 100 );
+
+			// display 3 digits right to the point
+			return ( int( arguments.time / 1000 ) / 1000 );
+
+		}
+
+
+		function byteFormat( numeric size ) {
+
+			var values = [ [ 1099511627776, 'TB' ], [ 1073741824, 'GB' ], [ 1048576, 'MB' ], [ 1024, 'KB' ] ];
+
+			for ( var i in values ) {
+
+				if ( arguments.size >= i[ 1 ] )
+					return numberFormat( arguments.size / i[ 1 ], '9.99' ) & i[ 2 ];
+			}
+
+			return arguments.size & 'B';
+		}
+
+		/** reads the file contents and writes it to the output stream */
+		function includeInline(filename) cachedWithin=createTimeSpan(0,1,0,0) {
+
+			echo(fileRead(expandPath(arguments.filename)));
+		}
+
+		function getJavaVersion() {
+	        var verArr=listToArray(server.java.version,'.');
+	        if(verArr[1]>2) return verArr[1];
+	        return verArr[2];
+	    }
+
+	</cfscript>
+
+	<cfscript>
+        variables.serverTimingHeaders = [];
+
+        function addServerTimingHeader(metric, name, timeMs){
+            arrayAppend(variables.serverTimingHeaders, '#arguments.metric#=#arguments.timeMs#; "#arguments.name#"');
+        }
+
+        function outputServerTimingHeaders(){
+            if (not getPageContext().getHttpServletResponse().isCommitted() ) // avoid cfflush error
+                header name="Server-Timing" value="#ArrayToList(variables.serverTimingHeaders,", ")#";
+        }
+    </cfscript>
+
+
+</cfcomponent>

--- a/core/src/main/java/resource/context/admin/debug/Performance.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Performance.cfc
@@ -373,10 +373,12 @@
 										</tr>
 
 									</cfloop>
-									<cfif hasBad>
-										<tr class="red"><td colspan="6">red = over #unitFormat( arguments.custom.unit, arguments.custom.highlight * 1000 ,prettify)# ms average execution time</td></tr>
-									</cfif>
 								</tbody>
+								<tfoot>
+									<cfif hasBad>
+										<tr class="red"><td colspan="7">red = over #unitFormat( arguments.custom.unit, arguments.custom.highlight * 1000 ,prettify)# ms average execution time</td></tr>
+									</cfif>
+								</tfoot>
 								</table>
 							</td><!--- #-lucee-debug-#sectionId# !--->
 						</tr>
@@ -638,7 +640,9 @@
 
 							<tr>
 								<td id="-lucee-debug-#sectionId#" class="#isOpen ? '' : 'collapsed'#">
-									<table><tr><td>
+									<table>
+									<tr>
+										<td>
 										<b>General</b>
 										<table class="details">
 										<thead onclick="__LUCEE.debug.sortTable(this);">
@@ -649,20 +653,20 @@
 											</tr>
 										</thead>
 										<tbody>
-										<cfloop struct="#debugging.datasources#" index="local.dsName" item="local.dsData">
-										<tr>
-											<td class="txt-r">#dsData.name#</td>
-											<td class="txt-r">#dsData.openConnections#</td>
-											<td class="txt-r">#dsData.connectionLimit==-1?'INF':dsData.connectionLimit#</td>
-										</tr>
-										</cfloop>
-										<tbody>
+											<cfloop struct="#debugging.datasources#" index="local.dsName" item="local.dsData">
+											<tr>
+												<td class="txt-r">#dsData.name#</td>
+												<td class="txt-r">#dsData.openConnections#</td>
+												<td class="txt-r">#dsData.connectionLimit==-1?'INF':dsData.connectionLimit#</td>
+											</tr>
+											</cfloop>
+										</tbody>
 										</table>
 									<cfset var hasCachetype=ListFindNoCase(queries.columnlist,"cachetype") gt 0>
 									<br><b>SQL Queries</b>
 										<table class="details">
 										<cfset renderToggleDetailHeadTR( sqlSectionId, "Expand all SQL statements", "-lucee-debug-#sectionId#", "sql", (hasCachetype ? 6 : 5) )>
-										<thead>
+										<thead onclick="__LUCEE.debug.sortTable(this);">
 											<tr>
 												<th data-type="text">Name</th>
 												<th>Records</th>
@@ -926,7 +930,10 @@
 					var data = [];
 					for ( var r = 0; r < tbody.children.length; r++ ){
 						var row = tbody.children[r];
-						var val = row.children[th.cellIndex].innerText;
+						if (row.length === 1)
+							continue;
+						var cell = row.children[th.cellIndex];
+						var val = cell.innerText;
 						switch (th.dataset.type){
 							case "text":
 								val = val.toLowerCase();

--- a/core/src/main/java/resource/context/admin/debug/Performance.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Performance.cfc
@@ -930,8 +930,15 @@
 					var data = [];
 					for ( var r = 0; r < tbody.children.length; r++ ){
 						var row = tbody.children[r];
-						if (row.length === 1)
-							continue;
+						switch (row.childElementCount){
+							case 1:
+								continue;
+							case 2:
+								data[data.length-1][1].push(row);
+								continue;
+							default:
+								break;
+						}
 						var cell = row.children[th.cellIndex];
 						var val = cell.innerText;
 						switch (th.dataset.type){
@@ -950,7 +957,7 @@
 								}
 								break;
 						}
-						data.push([val, row]);
+						data.push([val, [row]]);
 					}
 
 					switch (th.dataset.type){
@@ -972,7 +979,8 @@
 					if (th.dataset.dir === "asc")
 						data.reverse();
 					for (r = 0; r < data.length; r++){
-						tbody.appendChild(data[r][1]);
+						for (var rr = 0; rr < data[r][1].length; rr++)
+							tbody.appendChild(data[r][1][rr]);
 					}
 
 				}


### PR DESCRIPTION
modified modern template, focussed on highlighting performance issues
- execution times are sorted slowest to fastest
- slow sql queries are collapsed by default
- server timing headers, performance stats show up in dev tools under timing

replaces https://github.com/lucee/Lucee/pull/310 which modified the modern.cfc

