### PR TITLE
Conditionally skip a test that sometimes fails when system clock is not UTC.

### DIFF
--- a/test/jira/Jira2880.cfc
+++ b/test/jira/Jira2880.cfc
@@ -16,8 +16,11 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  * 
  ---><cfscript>
-component extends="org.lucee.cfml.test.LuceeTestCase"	{
-	
+ // This test fails when the local clock is in the America/New_York timezone
+ // and it is morning. createODBCdate() seems to treat all input as local time,
+ // and is not configurable.
+component extends="org.lucee.cfml.test.LuceeTestCase" skip="systemNotUTC" {
+
 	//public function beforeTests(){}
 	
 	//public function afterTests(){}
@@ -30,5 +33,9 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		assertEquals("{d '2000-01-02'}",createODBCdate(date).toString()&"");
 		assertEquals("{d '2000-01-02'}",evaluate('createODBCdate(date)')&"");
 	}
-} 
+
+	public boolean function systemNotUTC() {
+		return GetTimeZoneInfo().utcTotalOffset neq 0;
+	}
+}
 </cfscript>


### PR DESCRIPTION
This test fails when the local clock is in the America/New_York timezone and it is morning. `createODBCdate()` seems to treat all input as local time, and is not configurable. I think our only option is to skip the test under these circumstances.