### PR TITLE
LDEV-2129 - Changing to return input instead of NULL when empty.

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/owasp/ESAPIEncode.java
+++ b/core/src/main/java/lucee/runtime/functions/owasp/ESAPIEncode.java
@@ -146,7 +146,8 @@ public class ESAPIEncode implements Function {
 	}
 
 	public static String canonicalize(String input, boolean restrictMultiple, boolean restrictMixed) {
-		if(StringUtil.isEmpty(input)) return null;
+		if(StringUtil.isEmpty(input)) return input;
+
 		PrintStream out = System.out;
 		try {
 			 System.setOut(new PrintStream(DevNullOutputStream.DEV_NULL_OUTPUT_STREAM));

--- a/test/functions/Canonicalize.cfc
+++ b/test/functions/Canonicalize.cfc
@@ -23,17 +23,16 @@
 	--->
 	<cffunction name="testCanonicalize" localMode="modern">
 
-<!--- begin old test code --->
-<cfscript>
-valueEquals(canonicalize("&lt;",false,false),'<');
-valueEquals(canonicalize("%26lt; %26lt; %2526lt%253B %2526lt%253B%2526lt%253B",false,false),'< < < <<');
-valueEquals(canonicalize("&##X25;3c",false,false),'<');
-valueEquals(canonicalize("&##x25;3c",false,false),'<');
-</cfscript>
-<!--- end old test code --->
-	
-		
-		<!--- <cfset assertEquals("","")> --->
+		<!--- begin old test code --->
+		<cfscript>
+			valueEquals(canonicalize("&lt;",false,false),'<');
+			valueEquals(canonicalize("%26lt; %26lt; %2526lt%253B %2526lt%253B%2526lt%253B",false,false),'< < < <<');
+			valueEquals(canonicalize("&##X25;3c",false,false),'<');
+			valueEquals(canonicalize("&##x25;3c",false,false),'<');
+			valueEquals(canonicalize("",false,false),'');
+		</cfscript>
+		<!--- end old test code --->
+
 	</cffunction>
 	
 	<cffunction access="private" name="valueEquals">


### PR DESCRIPTION
Fixing ACF compat issue by changing to return input instead of NULL when empty. Details on:

https://luceeserver.atlassian.net/browse/LDEV-2129