### PR TITLE
Fixed exception for undefined function clickAjax()

### DIFF
--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -702,9 +702,9 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 					clickAjax(section);
 				</script>
 			<cfelseif REQUEST.admin=true>
-				<cfscript>
+				<script>
 					clickAjax("debug");
-				</cfscript>
+				</script>
 			</cfif>
 		</cfoutput>
 	</cffunction><!--- output() !--->


### PR DESCRIPTION
clickAjax() is a javascript function, but line 705-707 wrap it in <cfscript>