### PR TITLE
trigger automated docker image builds after travis build success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,6 @@ after_success:
 - curl "http://stable.lucee.org/rest/update/provider/buildLatest"
 - curl "https://download.lucee.org/?type=snapshots&reset=force"
 
-
+- chmod +x travis-docker-build.sh && ./travis-docker-build.sh
 
 #- git commit -a -m "Committed by Travis-CI build number: $TRAVIS_JOB_ID "

--- a/travis-docker-build.sh
+++ b/travis-docker-build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# read current job log after a short delay
+sleep 10s
+curl -m 30 -s "https://api.travis-ci.org/v3/job/${TRAVIS_JOB_ID}/log.txt?deansi=true" > travis_output.log
+
+# get lucee version
+LUCEE_VERSION=$(grep -oP "(?<=\[INFO\] Building Lucee Loader Build )(\d+\.\d+\.\d+\.\d+([-a-zA-Z]*))" travis_output.log)
+
+# build the travis request body
+function build_request {
+cat <<EOF
+{
+  "request": {
+    "message": "Automated build for version ${LUCEE_VERSION}",
+    "branch":"travis-build-matrix",
+    "config": {
+      "merge_mode": "deep_merge",
+      "env": {
+        "global": {
+          "LUCEE_VERSION": "${LUCEE_VERSION}"
+        }
+      }
+    }
+  }
+}
+EOF
+}
+REQUEST_BODY=$(build_request)
+
+# trigger the lucee-dockerfiles travis job for this lucee version
+curl -m 30 -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token ${TRAVIS_TOKEN}" \
+  -d "${REQUEST_BODY}" \
+  https://api.travis-ci.org/repo/lucee%2Flucee-dockerfiles/requests


### PR DESCRIPTION
This PR adds a script which is run after a successful Travis build of Lucee to trigger automated Docker image builds in the lucee-dockerfiles repo. The script depends on a TRAVIS_TOKEN environment variable which I've already configured in the lucee/Lucee repo in Travis.

For now the Docker image builds will be triggered against the "travis-build-matrix" branch, and this will be updated to use "master" after we've verified that this integration is working correctly.