### PR TITLE
remove italic and grey font from comments (again)

### DIFF
--- a/core/src/main/cfml/context/res/css/admin.css
+++ b/core/src/main/cfml/context/res/css/admin.css
@@ -421,7 +421,7 @@ td.fieldPadded {
 /* display boxes etc. */
 .commentError{font-size : 10px;color:#bf4f36;text-decoration:none;}
 .comment{	
-	font-size:11px;color:#999;font-style: italic;
+	font-size:11px;
 	text-decoration:none;	
 	padding: 1px 0px;
 	/* PK: when using mouseover helptexts, this padding might be better:


### PR DESCRIPTION
this previous commit got lost somehow?
https://github.com/lucee/Lucee/pull/455

![image](https://user-images.githubusercontent.com/426404/55785373-98751800-5ab2-11e9-8542-b7f44bdc4be6.png)

becomes

![image](https://user-images.githubusercontent.com/426404/55785332-87c4a200-5ab2-11e9-9dad-dacfb5b72143.png)

