### PR TITLE
default to modern when debugging template not available

### DIFF
--- a/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
@@ -15,7 +15,7 @@
 		<cfset drivers[trim(tmp.getId())]=tmp>
 	</cfloop>
 	<cfset template ="" >
-	<cfif IsEmpty(entries.type)>
+	<cfif IsEmpty(entries.type) or not StructKeyExists(drivers, entries.type)>
 		<cfset driver=drivers["lucee-modern"]>
 		<cfset template= "lucee-modern">
 	<cfelse>


### PR DESCRIPTION
due to https://luceeserver.atlassian.net/browse/LDEV-2229, Deleting a debugging template doesn't remove it from Lucee-server.xml
I had some left over debugging template configuration which caused the debugging to crash in my dev environment.

This change means if the specified debugging template type isn't available, just fall back to lucee-modern