### PR TITLE
IsNumeric(...) & IsValid("numeric", ...) not working for negative exponent notation numbers as strings LDEV-2353

### DIFF
--- a/core/src/main/java/lucee/runtime/op/Decision.java
+++ b/core/src/main/java/lucee/runtime/op/Decision.java
@@ -179,7 +179,7 @@ public final class Decision {
 		for (; pos < len; pos++) {
 			curr = str.charAt(pos);
 			if (curr < '0') {
-				if (curr == '.') {
+				if (curr == '.' || curr == '-' || curr == '+') {
 					if (pos + 1 >= len || hasDot) return false;
 					hasDot = true;
 				}
@@ -189,7 +189,7 @@ public final class Decision {
 				if (curr == 'e' || curr == 'E') {
 					if (pos + 1 >= len || hasExp) return false;
 					hasExp = true;
-					hasDot = true;
+					// hasDot = true;
 				}
 				else return false;
 			}

--- a/test/tickets/LDEV2353.cfc
+++ b/test/tickets/LDEV2353.cfc
@@ -1,7 +1,7 @@
 component extends="org.lucee.cfml.test.LuceeTestCase" {
 	function run( testResults , testBox ){
 		describe( title = "Testcase for LDEV-2353", body = function(){
-			it( title = "IsNumeric(...) Not working for negative exponent notation numbers as string", bod = function( currentSpec ){
+			it( title = "IsNumeric(...) Not working for negative exponent notation numbers as string", body = function( currentSpec ){
 				expect(IsNumeric(2E05)).tobe(true);
 				expect(IsNumeric("2E05")).tobe(true);
 				expect(IsNumeric("-143")).tobe(true);
@@ -11,6 +11,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 				expect(IsNumeric(-0.000+00001)).tobe(true);
 				expect(IsNumeric(+23-2E5)).tobe(true);
 				expect(IsNumeric(+1E123)).tobe(true);
+				expect(IsNumeric(2E+05)).tobe(true);
+				expect(IsNumeric("5E+23")).tobe(true);
 			});	
 
 			it( title = "IsValid('numeric',...) Not working for negative exponent notation numbers as string", body = function( currentSpec ){
@@ -22,6 +24,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 				expect(IsValid("numeric","2E-05")).tobe(true);
 				expect(IsValid("numeric",-0.000+00001)).tobe(true);
 				expect(IsValid("numeric",+23-2E5)).tobe(true);
+				expect(IsValid("numeric","6E+12")).tobe(true);
+				expect(IsValid("numeric",8E+40)).tobe(true);
 			});
 		});
 	}

--- a/test/tickets/LDEV2353.cfc
+++ b/test/tickets/LDEV2353.cfc
@@ -1,0 +1,28 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" {
+	function run( testResults , testBox ){
+		describe( title = "Testcase for LDEV-2353", body = function(){
+			it( title = "IsNumeric(...) Not working for negative exponent notation numbers as string", bod = function( currentSpec ){
+				expect(IsNumeric(2E05)).tobe(true);
+				expect(IsNumeric("2E05")).tobe(true);
+				expect(IsNumeric("-143")).tobe(true);
+				expect(IsNumeric(-407)).tobe(true);
+				expect(IsNumeric(6E-05)).tobe(true);
+				expect(IsNumeric("9E-05")).tobe(true);
+				expect(IsNumeric(-0.000+00001)).tobe(true);
+				expect(IsNumeric(+23-2E5)).tobe(true);
+				expect(IsNumeric(+1E123)).tobe(true);
+			});	
+
+			it( title = "IsValid('numeric',...) Not working for negative exponent notation numbers as string", body = function( currentSpec ){
+				expect(IsValid("numeric",1E08)).tobe(true);
+				expect(IsValid("numeric","1E08")).tobe(true);
+				expect(IsValid("numeric",2E-05)).tobe(true);
+				expect(IsValid("numeric","-9E89")).tobe(true);
+				expect(IsValid("numeric","-343E12")).tobe(true);
+				expect(IsValid("numeric","2E-05")).tobe(true);
+				expect(IsValid("numeric",-0.000+00001)).tobe(true);
+				expect(IsValid("numeric",+23-2E5)).tobe(true);
+			});
+		});
+	}
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-2353