### PR TITLE
debugging improvements and bug fixes LDEV-2364

### DIFF
--- a/core/src/main/java/resource/context/admin/debug/Classic.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Classic.cfc
@@ -48,6 +48,9 @@ string function getid(){
 	return "lucee-classic"; 
 }
 
+string function readDebug(struct custom, struct debugging, string context){
+	output(argumentcollection=arguments);
+}
 
 void function onBeforeUpdate(struct custom){
 	throwWhenEmpty(custom,"color");

--- a/core/src/main/java/resource/context/admin/debug/Comment.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Comment.cfc
@@ -47,6 +47,9 @@ component extends="Debug" {
 		return "lucee-comment";
 	}
 	
+	string function readDebug(struct custom, struct debugging, string context){
+		output(argumentcollection=arguments);
+	}	
 	
 	/**
 	* validates settings done by the user

--- a/core/src/main/java/resource/context/admin/debug/Debug.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Debug.cfc
@@ -25,7 +25,6 @@
 		<cfreturn createObject("component","Group").init(arguments.displayName,arguments.description,arguments.level)>
 	</cffunction>
 
-
 	<cffunction name="getCustomFields" returntype="array">
     	<cfreturn fields>
     </cffunction>
@@ -38,20 +37,28 @@
 	
 	<cffunction name="onBeforeError" returntype="void" output="no">
 		<cfargument name="cfcatch" required="true" type="struct">
-	</cffunction>
-	
-    
+	</cffunction>    
     
 	<cffunction name="getId" returntype="string">
-    	<cfthrow message="implement function getID():string">
-    </cffunction>
-    
+		<cfthrow message="debug templates must implement function getID():string"
+		detail="#getCurrentTemplatePath()#">
+	</cffunction>
+	
+	<cffunction name="getDescription" returntype="string">
+		<cfthrow message="debug templates must implement function getDescription():string"
+			detail="#getCurrentTemplatePath()#">
+	</cffunction>
+
+	<cffunction name="getLabel" returntype="string">
+		<cfthrow message="debug templates must implement function getLabel():string"
+			detail="#getCurrentTemplatePath()#">
+	</cffunction>	
+	
 	<cffunction name="output" returntype="string">
 		<cfargument name="custom" required="true" type="struct">
 		<cfargument name="debugging" required="true" type="struct">
-    	<cfthrow message="implement function output():string">
+		<cfthrow message="debug templates must implement function output():string"
+			detail="#getCurrentTemplatePath()#">
     </cffunction>
-    
-    
     
 </cfcomponent>

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -783,10 +783,10 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 			<cfloop query="pages">
 				<cfset querySetCell(pages, "total", pages.app + pages.load + pages.query, pages.currentRow)>
 				<cfset querySetCell(pages, "avg", (pages.app + pages.load + pages.query) / pages.count, pages.currentRow)>
-				<cfset aPage = listToArray(pages.src, '$')>
+				<cfset local.aPage = listToArray(pages.src, '$')>
 				<cfset querySetCell(pages, "path", pages.src, pages.currentRow)>
-				<cfset querySetCell(pages, "src", contractPath(aPage[1]), pages.currentRow)>
-				<cfset querySetCell(pages, "method", !isEmpty(aPage[2] ?: '') ? aPage[2] : '', pages.currentRow)>
+				<cfset querySetCell(pages, "src", contractPath(local.aPage[1]), pages.currentRow)>
+				<cfset querySetCell(pages, "method", !isEmpty(local.aPage[2] ?: '') ? local.aPage[2] : '', pages.currentRow)>
 				<cfset tot      += pages.total />
 				<cfset totCnt   += pages.count />
 				<cfset totLucee += pages.app>
@@ -1073,19 +1073,19 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 							<cfset tot=0 />
 							<cfset q=0 />
 							<cfloop query="pages" group="src">
-									<cfset page.stckTrace = []>
+									<cfset local.page.stckTrace = []>
 									<cfset arrayAppend(page.stckTrace, listLast(pages.src))>
-									<cfquery dbtype="query" name="resultQry">
+									<cfquery dbtype="query" name="local.resultQry">
 										select * from pages where src='#pages.src#' AND id != '#pages.id#'
 									</cfquery>
-									<cfloop query="resultQry">
-										<cfset pages.total += resultQry.total>
-										<cfset pages.count += resultQry.count>
-										<cfset pages.avg += resultQry.avg>
-										<cfset pages.query += resultQry.query>
-										<cfset pages.total += resultQry.total>
-										<cfset pages.app += resultQry.app>
-										<cfset arrayAppend(page.stckTrace, listLast(resultQry.src, "$"))>
+									<cfloop query="local.resultQry">
+										<cfset pages.total += local.resultQry.total>
+										<cfset pages.count += local.resultQry.count>
+										<cfset pages.avg += local.resultQry.avg>
+										<cfset pages.query += local.resultQry.query>
+										<cfset pages.total += local.resultQry.total>
+										<cfset pages.app += local.resultQry.app>
+										<cfset arrayAppend(local.page.stckTrace, listLast(local.resultQry.src, "$"))>
 									</cfloop>
 									<cfset tot += pages.total - (pages.count * pages.avg) />
 									<cfset q += pages.query />
@@ -1102,7 +1102,9 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 									<cfset local.sColor    = RGBtoHex(255 * iPctTotal, 160 * (1 - iPctTotal), 0)>
 
 
-									<cfset sStyle = ''>
+									<cfset var sStyle = ''>
+									<cfset var per = ''>
+									<Cfset var i = 0>
 									<cfif arguments.custom.colorHighlight>
 										<cfset sStyle = sColor>
 									</cfif>
@@ -1161,11 +1163,11 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 											<font color="#sStyle#">#listFirst(pages.src, "$")#</font>
 										</td>
 										<td align="left" class="tblContent" style="#sStyle#">
-											<cfset listStack= arrayToList(#page.stckTrace#) >
-											<cfset getStack = listRemoveDuplicates(listStack,",",true) >
-											<cfset page.stckTrace = listToArray(getStack)>
+											<cfset var listStack= arrayToList(local.page.stckTrace) >
+											<cfset var getStack = listRemoveDuplicates(listStack,",",true) >
+											<cfset local.page.stckTrace = listToArray(getStack)>
 											<table>
-												<cfloop array="#page.stckTrace#" index="i">
+												<cfloop array="#local.page.stckTrace#" index="i">
 													<tr>
 														<td>
 														<font color="#sStyle#">

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -727,6 +727,7 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 		<cfargument name="debugging" required="true" type="struct" />
 		<cfargument name="context" type="string" default="web" />
 		<cfsilent>
+			<cfset local.debuggingRenderingTime=getTickCount()>
 			<cfset local.stStats = filterByTemplates(arguments.debugging)>
 			<cfset arguments.debugging.minimal          = arguments.custom.minimal ?: 0>
 			<cfset arguments.debugging.highlight        = arguments.custom.highlight ?: 250000>
@@ -744,13 +745,9 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 			<!--- <cfset arguments.custom.sort_charts 		= (arguments.custom.sort_charts ?: '1,2,3,4')> --->
 			<cfif isNull(arguments.custom.scopesList)><cfset arguments.custom.scopesList=""></cfif>
 
-
-			
-
-
 			<cfset var _cgi=isNull(arguments.debugging.scope.cgi)?cgi:arguments.debugging.scope.cgi />
-			<cfset var pages=arguments.debugging.pages />
-			<cfset var queries=arguments.debugging.queries />
+			<cfset var pages=duplicate(arguments.debugging.pages) />
+			<cfset var queries=arguments.debugging.queries/>
 			<cfif not isDefined('arguments.debugging.timers')>
 				<cfset arguments.debugging.timers=queryNew('label,time,template') />
 			</cfif>
@@ -1722,6 +1719,8 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 					</tr>
 				</table>
 			</cfif>
+			<br />
+			<p class="cfdebug">Debug Rendering Time: #LsNumberFormat(getTickCount()-local.debuggingRenderingTime)#ms</p>
 			</cfoutput>
 		</div>
 	</cffunction>

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -411,7 +411,7 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 								}
 							}
 						};
-						var ajaxURL = "/lucee/appLogs/readDebug.cfm?id=#debugging.id#&TAB="+section;
+						var ajaxURL = "/lucee/appLogs/readDebug.cfm?id=#arguments.debugging.id#&TAB="+section;
 						<cfif structKeyExists(request, "fromAdmin") AND request.fromAdmin EQ true>
 							ajaxURL += "&fromAdmin=true";
 						</cfif>
@@ -1957,17 +1957,18 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 	</cffunction>
 
 	<cffunction name="loadCharts" output="true">
-
 		<cfargument name="chartStruct">
-		<cfset chartsLabel = structNew("linked")>
+		<cfset var i = 0>
+		<cfset var chartsLabel = structNew("linked")>
+		
 		<cfset chartsLabel.HeapChart = "Heap Memory">
 		<cfset chartsLabel.NonHeapChart = "Non Heap Memory">
 		<cfset chartsLabel.WholeSystem = "System CPU VS Lucee CPU">
 
 		<cfif structKeyExists(request, "fromAdmin") AND request.fromAdmin EQ true>
-			<cfset chartClass = "twoCharts">
+			<cfset var chartClass = "twoCharts">
 		<cfelse>
-			<cfset chartClass = "fourCharts">
+			<cfset var chartClass = "fourCharts">
 		</cfif>
 
 		<cfloop item="i" collection="#chartsLabel#">

--- a/core/src/main/java/resource/context/applogs/readDebug.cfm
+++ b/core/src/main/java/resource/context/applogs/readDebug.cfm
@@ -11,25 +11,13 @@
 		// TODO check for lucee admin login
 		return false;
 	}
-	
-	try {
-		admin
-			action="getLoggedDebugData"
-			type="web"
-			id=url.id
-			returnVariable="log";
-	} catch(e){
-		//if (not isLoggedInAdmin())
-			rethrow(e);
-		/*
-		// TODO possible fall back for debugging debugging, show last log
-		admin
-			action="getLoggedDebugData"
-			type="web"
-			returnVariable="all";
-		log = all[all.len()];
-		*/
-	}
+		
+	admin
+		action="getLoggedDebugData"
+		type="web"
+		id=url.id
+		returnVariable="log";
+			
 	if (not isLoggedInAdmin()){
 		// access control, should the user be able to see this debug entry?	
 		logCookies = {};
@@ -54,7 +42,7 @@
 			echo("Debugging Log Access Denied");
 			cflog(text="Debugging Log Access Denied - id: #htmleditFormat(url.id)#", type="warning");
 			abort;
-		}	
+		}			
 	}
 
 	admin

--- a/core/src/main/java/resource/context/applogs/readDebug.cfm
+++ b/core/src/main/java/resource/context/applogs/readDebug.cfm
@@ -1,6 +1,7 @@
 <cfscript>	
 	setting showdebugoutput=true;
 	param name="url.id" default="";
+	param name="url.tab" default="debug";
 	if (url.id eq ""){
 		header statustext="Debugging log id is required" statusCode="404";
 		echo("Debugging log id is required");		
@@ -9,15 +10,30 @@
 
 	function isLoggedInAdmin(){
 		// TODO check for lucee admin login
+		/*
+		this doesn't work coz of the session scope for admin being different
+
+		if (structKeyExists(session, "passwordweb")){
+			admin action="connect"
+				type="web"
+				password="#session.passwordweb#";
+		} else if (structKeyExists(session, "passwordserver")){
+			admin action="connect"
+				type="web"
+				password="#session.passwordserver#";
+		} else {
+			return false;
+		}
+		*/
 		return false;
 	}
-		
+	
 	admin
 		action="getLoggedDebugData"
 		type="web"
 		id=url.id
 		returnVariable="log";
-			
+
 	if (not isLoggedInAdmin()){
 		// access control, should the user be able to see this debug entry?	
 		logCookies = {};
@@ -42,7 +58,7 @@
 			echo("Debugging Log Access Denied");
 			cflog(text="Debugging Log Access Denied - id: #htmleditFormat(url.id)#", type="warning");
 			abort;
-		}			
+		}	
 	}
 
 	admin

--- a/core/src/main/java/resource/context/applogs/readDebug.cfm
+++ b/core/src/main/java/resource/context/applogs/readDebug.cfm
@@ -2,16 +2,21 @@
 	setting showdebugoutput=true;
 	param name="url.id" default="";
 	param name="url.tab" default="debug";
+	
+
 	if (url.id eq ""){
 		header statustext="Debugging log id is required" statusCode="404";
 		echo("Debugging log id is required");		
 		abort;
-	}
+	} 
 
 	function isLoggedInAdmin(){
 		// TODO check for lucee admin login
 		/*
 		this doesn't work coz of the session scope for admin being different
+
+		best workaround would be include this file from a file under admin to catch the admin cookies,
+		i.e. /lucee/admin/debugging.view.cfm 
 
 		if (structKeyExists(session, "passwordweb")){
 			admin action="connect"
@@ -26,8 +31,7 @@
 		}
 		*/
 		return false;
-	}
-	
+	}	
 	admin
 		action="getLoggedDebugData"
 		type="web"
@@ -43,7 +47,7 @@
 
 		cookiesMatch={};
 		// TODO auth needs to respect JSESSIONID vs CF sessions
-		loop list="JSESSIONID,CFID,cftoken" item="c" delimiters=","{
+		loop list="JSESSIONID,cftoken" item="c" delimiters=","{
 			if (structKeyExists(logCookies, c) 
 					and structKeyExists(cookie, c) 
 					and len(trim(cookie[c])) gt 0
@@ -52,7 +56,7 @@
 			}
 		}
 
-		if (not cookiesMatch.len() eq 3){
+		if (cookiesMatch.len() eq 0){
 			// TODO check for lucee admin login
 			header statustext="Access Denied" statusCode="403";
 			echo("Debugging Log Access Denied");
@@ -121,8 +125,8 @@
 	function ComponentListPackageAsStruct(string package, cfcNames=structnew("linked")){
 		try{
 			local._cfcNames=ComponentListPackage(package);
-			loop array=_cfcNames index="i" item="el" {
-				cfcNames[el]=package&"."&el;
+			loop array=_cfcNames index="local.i" item="local.el" {
+				cfcNames[local.el]=package&"."&local.el;
 			}
 		}
 		catch(e){}

--- a/core/src/main/java/resource/context/applogs/readDebug.cfm
+++ b/core/src/main/java/resource/context/applogs/readDebug.cfm
@@ -9,61 +9,12 @@
 		echo("Debugging log id is required");		
 		abort;
 	} 
-
-	function isLoggedInAdmin(){
-		// TODO check for lucee admin login
-		/*
-		this doesn't work coz of the session scope for admin being different
-
-		best workaround would be include this file from a file under admin to catch the admin cookies,
-		i.e. /lucee/admin/debugging.view.cfm 
-
-		if (structKeyExists(session, "passwordweb")){
-			admin action="connect"
-				type="web"
-				password="#session.passwordweb#";
-		} else if (structKeyExists(session, "passwordserver")){
-			admin action="connect"
-				type="web"
-				password="#session.passwordserver#";
-		} else {
-			return false;
-		}
-		*/
-		return false;
-	}	
+	
 	admin
 		action="getLoggedDebugData"
 		type="web"
 		id=url.id
 		returnVariable="log";
-
-	if (not isLoggedInAdmin()){
-		// access control, should the user be able to see this debug entry?	
-		logCookies = {};
-		loop list="#log.scope.cgi.http_cookie#" item="c" delimiters=";"{		
-			logCookies[trim(listFirst(c,"="))]=trim(listLast(c,"="));
-		}
-
-		cookiesMatch={};
-		// TODO auth needs to respect JSESSIONID vs CF sessions
-		loop list="JSESSIONID,cftoken" item="c" delimiters=","{
-			if (structKeyExists(logCookies, c) 
-					and structKeyExists(cookie, c) 
-					and len(trim(cookie[c])) gt 0
-					and logCookies[c] eq cookie[c]){
-				cookiesMatch[c] = true;
-			}
-		}
-
-		if (cookiesMatch.len() eq 0){
-			// TODO check for lucee admin login
-			header statustext="Access Denied" statusCode="403";
-			echo("Debugging Log Access Denied");
-			cflog(text="Debugging Log Access Denied - id: #htmleditFormat(url.id)#", type="warning");
-			abort;
-		}	
-	}
 
 	admin
 		action="getDebugEntry"


### PR DESCRIPTION
- classic and comment templates no longer worked (just defaulted to modern)
- no access control, anyone can read a debug log if they know the log id, does cookie matching between the request and the log. Switching to a guid fixes this. See patch #723
- no guarantee that the correct debugging log was being displayed (fell back to last log if not found)
- updated the comment and classic templates to implement readDebug method like the modern template
- improved exception information for debug.cfc for unimplemented methods (getId, getLabel, getDescription) which the admin configure template interface relies on
- show problem template path in exception message for unimplemented methods in Debug.cfc
- show the debug execution time for the modern template (it's slow)
- duplicate the debug log pages data, as the modern template modifies the query and subsequent views of the logs via admin included the changes from the last view, resulting in very wrong statistics

https://luceeserver.atlassian.net/browse/LDEV-2364