### PR TITLE
right align timing columns for the debug log lists

### DIFF
--- a/core/src/main/cfml/context/admin/debugging.logs.list.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.list.cfm
@@ -125,9 +125,9 @@
 								<tr>
 									<td><a href="#request.self#?action=#url.action#&action2=detail&id=#hash(el.id&":"&el.startTime)#">#_path#</a></td>
 									<td>#LSDateFormat(el.starttime)# #LSTimeFormat(el.starttime)#</td>
-									<td nowrap>#formatUnit(_query)#</td>
-									<td nowrap>#formatUnit(_app)#</td>
-									<td nowrap>#formatUnit(_total)#</td>
+									<td nowrap align="right">#formatUnit(_query)#</td>
+									<td nowrap align="right">#formatUnit(_app)#</td>
+									<td nowrap align="right">#formatUnit(_total)#</td>
 								</tr>
 							</cfif>
 						</cfloop>


### PR DESCRIPTION
it's much easier to read right aligned numbers