### PR TITLE
allow choosing debug template from admin log viewer LDEV-2451

### DIFF
--- a/core/src/main/cfml/context/admin/debugging.logs.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.cfm
@@ -109,7 +109,7 @@
             <cfif isNumeric(trim(form.query))><cfset session.debugFilter.query=form.query><cfelse><cfset session.debugFilter.query=""></cfif>
             <cfif isNumeric(trim(form.app))><cfset session.debugFilter.app=form.app><cfelse><cfset session.debugFilter.app=""></cfif>
             <cfif isNumeric(trim(form.total))><cfset session.debugFilter.total=form.total><cfelse><cfset session.debugFilter.total=""></cfif>
-			</cfcase>
+		</cfcase>
         
         #stText.Debug.filter#
 	</cfswitch>

--- a/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
@@ -1,59 +1,97 @@
 <script type="text/javascript">disableBlockUI=true;</script>
-<cfoutput>
-	<!--- load available drivers --->
-	<cfset driverNames=structnew("linked")>
-	<cfset driverNames=ComponentListPackageAsStruct("lucee-server.admin.debug",driverNames)>
-	<cfset driverNames=ComponentListPackageAsStruct("lucee.admin.debug",driverNames)>
-	<cfset driverNames=ComponentListPackageAsStruct("debug",driverNames)>
 
-	<cfset drivers={}>
-	<cfloop collection="#driverNames#" index="n" item="fn">
-		<cfif n EQ "Debug" or n EQ "Field" or n EQ "Group">
-			<cfcontinue>
-		</cfif>
-		<cfset tmp=createObject('component',fn)>
-		<cfset drivers[trim(tmp.getId())]=tmp>
-	</cfloop>
-	<cfset template ="" >
-	<cfif IsEmpty(entries.type) or not StructKeyExists(drivers, entries.type)>
-		<cfset driver=drivers["lucee-modern"]>
-		<cfset template= "lucee-modern">
-	<cfelse>
-		<cfset driver=drivers["#entries.type#"]>
-	</cfif>
-		<cfset entry={}>
-		<cfloop query="entries">
-			<cfif entries.type EQ "lucee-modern" OR entries.type EQ "lucee-classic" OR entries.type EQ "lucee-comment">
-				<cfset entry=querySlice(entries, entries.currentrow ,1)>
-				<cfset  template= entry.type>
-			</cfif>    
-		</cfloop>
-					
-		<!--- get matching log entry --->
-		<cfset log="">
-		<cfloop from="1" to="#arrayLen(logs)#" index="i">
-			<cfset el=logs[i]>
-			<cfset id=hash(el.id&":"&el.startTime)>
-			<cfif url.id EQ id>
-				<cfset log=el>
-			</cfif>
-		</cfloop>
-		<table width="100%">
+<cfscript>
+	//  load available drivers (i.e debug templates) 
+	driverNames=structnew("linked");
+	driverNames=ComponentListPackageAsStruct("lucee-server.admin.debug",driverNames);
+	driverNames=ComponentListPackageAsStruct("lucee.admin.debug",driverNames);
+	driverNames=ComponentListPackageAsStruct("debug",driverNames);
+
+	drivers={};
+	loop collection="#driverNames#" index="n" item="fn" {
+		if ( n == "Debug" || n == "Field" || n == "Group" ) {
+			continue;
+		}
+		tmp=createObject('component',fn);
+		drivers[trim(tmp.getId())]=tmp;
+	}
+	
+	//  determine which debug template to use
+	template ="";
+	if  (structKeyExists(url, "template") and StructKeyExists(drivers, url.template)) {
+		driver=drivers[url.template];
+		template=url.template;
+	} else if ( IsEmpty(entries.type) || !StructKeyExists(drivers, entries.type) ) {
+		driver=drivers["lucee-modern"];
+		template= "lucee-modern";
+	} else {
+		driver=drivers["#entries.type#"];
+		template=entries.type;
+	}
+	entry={};
+	
+	// this is a lucky dip
+	loop query="entries" {
+		if (entries.type EQ template) {
+			entry = querySlice(entries, entries.currentrow ,1);
+			template = entry.type;
+			break;
+		}
+	}
+
+	//  get matching log entry 
+	log="";
+	for ( i=1 ; i<=arrayLen(logs) ; i++ ) {
+		el=logs[i];
+		id=hash(el.id & ":" & el.startTime);
+		if ( url.id == id ) {
+			log=el;
+		}
+	}
+</cfscript>
+<cfoutput>
+	<table width="100%">
+	<cfif !isSimpleValue(log) && structCount(drivers)>
 		<tr>
-			<td>
-				<!--- <cfset log = logs[1]> --->
-				<cfset request.fromAdmin = true>
-				<cfif !isSimpleValue(log)>
-					<cfif NOT isDebugMode()>
-						<cfset c ={callStack:"Enabled",colorHighlight:"Enabled",displayPercentages:"Enabled",expression:"Enabled",general:"Enabled",highlight:"0",metrics_charts:"HeapChart,NonHeapChart,WholeSystem",minimal:"0",sessionSize:"100",size:"medium",Tab_Debug:"Enabled",tab_Metrics:"Enabled",tab_Reference:"Enabled"} >
-					<cfelse>
-						<cfset c=structKeyExists(entry,'custom')?entry.custom:{}>
+			<td>				
+				<form action="?" name="selectTemplate" method="GET">
+				<cfloop collection="#drivers#" item="fn">
+					<label>
+						<input name="template" type="radio" value="#drivers[fn].getId()#" class="select-template"
+							<cfif template eq drivers[fn].getId()>checked</cfif>
+						>
+						#drivers[fn].getLabel()#
+					</label>
+				</cfloop>
+				<cfloop collection="#url#" item="u">
+					<cfif u neq "template">
+						<input type="hidden" name="#u#" value="#encodeForHtml(url[u])#">
 					</cfif>
-				<cfset c.scopes=false>
-				<cfset driver.output(c,log,"admin")><cfelse>Data no longer available</cfif> </td>
+				</cfloop>				
+				<input type="submit">
+				</form>				
+			</td>
 		</tr>
-		</table>
-		
+	</cfif>
+	<tr>
+		<td>
+			<!--- <cfset log = logs[1]> --->
+			<cfset request.fromAdmin = true>
+			<cfif !isSimpleValue(log)>
+				<cfif NOT isDebugMode()>
+					<cfset c ={callStack:"Enabled",colorHighlight:"Enabled",displayPercentages:"Enabled",expression:"Enabled",general:"Enabled",highlight:"0",metrics_charts:"HeapChart,NonHeapChart,WholeSystem",minimal:"0",sessionSize:"100",size:"medium",Tab_Debug:"Enabled",tab_Metrics:"Enabled",tab_Reference:"Enabled"} >
+				<cfelse>
+					<cfset c=structKeyExists(entry,'custom')?entry.custom:{}>
+				</cfif>
+				<cfset c.scopes=false>
+				<cfset driver.output(c,log,"admin")>
+			<cfelse>
+				Debug Data no longer available
+			</cfif> 
+		</td>
+	</tr>
+	</table>
+	
 	<table class="tbl" width="740">
 	<cfformClassic onerror="customError" action="#request.self#?action=#url.action#" method="post" name="debug_settings">
 	<tr>

--- a/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
@@ -1,5 +1,5 @@
 <script type="text/javascript">disableBlockUI=true;</script>
-
+<cfparam name="session.debug.template" default="">
 <cfscript>
 	//  load available drivers (i.e debug templates) 
 	driverNames=structnew("linked");
@@ -21,6 +21,10 @@
 	if  (structKeyExists(url, "template") and StructKeyExists(drivers, url.template)) {
 		driver=drivers[url.template];
 		template=url.template;
+		session.debug.template = url.template;
+	} else if (len(session.debug.template)){
+		driver=drivers[session.debug.template];
+		template=session.debug.template;		
 	} else if ( IsEmpty(entries.type) || !StructKeyExists(drivers, entries.type) ) {
 		driver=drivers["lucee-modern"];
 		template= "lucee-modern";
@@ -50,13 +54,15 @@
 	}
 </cfscript>
 <cfoutput>
-	<table width="100%">
 	<cfif !isSimpleValue(log) && structCount(drivers)>
+		<cfformClassic onerror="customError" action="?" method="get" name="debug_select_template">
+		<table class="maintbl">
+			<tbody>
 		<tr>
+					<th scope="row">#stText.debug.selectDebugTemplate#</th>
 			<td>				
-				<form action="?" name="selectTemplate" method="GET">
 				<cfloop collection="#drivers#" item="fn">
-					<label>
+							<label title="#encodeForHTMLAttribute(drivers[fn].getDescription())#" style="margin-right:15px;">
 						<input name="template" type="radio" value="#drivers[fn].getId()#" class="select-template"
 							<cfif template eq drivers[fn].getId()>checked</cfif>
 						>
@@ -68,11 +74,14 @@
 						<input type="hidden" name="#u#" value="#encodeForHtml(url[u])#">
 					</cfif>
 				</cfloop>				
-				<input type="submit">
-				</form>				
+						<input type="submit" value="#stText.debug.switchTemplate#" class="bs button submit">
 			</td>
 		</tr>
+			</tbody>
+		</table>
+		</cfformClassic>
 	</cfif>
+	<table width="100%">	
 	<tr>
 		<td>
 			<!--- <cfset log = logs[1]> --->

--- a/core/src/main/cfml/context/admin/resources/language/de.xml
+++ b/core/src/main/cfml/context/admin/resources/language/de.xml
@@ -663,6 +663,9 @@ Diese werden dann am Ende eines Request ausgegeben, falls sie ein Debug Template
 	<data key="debug.settings.timerDesc">Select this option to show timer event information. Timers let a developer track the execution time of the code between the start and end tags of the CFTIMER tag.</data>
 	<data key="debug.settings.implicitAccess">Implicit variable Access</data>
 	<data key="debug.settings.implicitAccessDesc">Select this option to log all accesses to scopes, queries and threads that happens implicit (cascaded).</data>
+	<data key="debug.switchTemplate">Switch Debug Template</data>
+	<data key="debug.selectDebugTemplate">Select Debug Template</data>
+
 	<data key="general.enabled">Enabled</data>
 
 	<data key="compiler.nullSupport">Null Support</data>

--- a/core/src/main/cfml/context/admin/resources/language/en.xml
+++ b/core/src/main/cfml/context/admin/resources/language/en.xml
@@ -742,7 +742,7 @@ you can see the log result at the end of every request, if a debug template is d
 	<data key="debug.pathRestriction">Path Restriction</data>
 	<data key="debug.pathRestrictionDesc">Path that should not be outputted, seperated path by line break.</data>
 	<data key="debug.settingTitle">Settings</data>
-	<data key="debug.settingDesc">Define how Lucee Log the debugging information.</data>
+	<data key="debug.settingDesc">Configure the size of the debug logs.</data>
 	<data key="debug.outputTitle">Output</data>
 	<data key="debug.outputDesc">Debugging information logged by Lucee.</data>
 	<data key="debug.filter">Filter</data>
@@ -750,6 +750,8 @@ you can see the log result at the end of every request, if a debug template is d
 	<data key="debug.filterPath">Only Outputs records where the path match the following pattern.</data>
 	<data key="debug.detailTitle">Detail</data>
 	<data key="debug.detailDesc">Detailed information about a single Request</data>
+	<data key="debug.switchTemplate">Switch Debug Template</data>
+	<data key="debug.selectDebugTemplate">Select Debug Template</data>
 
 	<!-- debugging.settings.cfm -->
 	<data key="debug.settings.desc">Enable certain logging options for Lucee</data>

--- a/core/src/main/java/resource/context/admin/debug/Classic.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Classic.cfc
@@ -59,8 +59,6 @@ void function onBeforeUpdate(struct custom){
 	throwWhenNotNumeric(custom,"highlight");
 }
 
-
-
 private void function throwWhenEmpty(struct custom, string name){
 	if(!structKeyExists(custom,name) or len(trim(custom[name])) EQ 0)
 		throw "value for ["&name&"] is not defined";
@@ -75,7 +73,6 @@ private function isColumnEmpty(query query, string columnName){
 	if(!QueryColumnExists(query,columnName)) return true;
 	return !len(ArrayToList(QueryColumnData(query,columnName),'')); 
 }
-
 
 </cfscript>   
     
@@ -133,7 +130,7 @@ millisecond:"ms"
 <tr>
 	<td>
  <!--- General --->
-    <cfif structKeyExists(custom,"general") and custom.general>
+    <cfif isEnabled(custom,"general")>
 		<p class="cfdebug"><hr/>
 		<b class="cfdebuglge"><a name="cfdebug_top">Debugging Information</a></b>
 		<table class="cfdebug">

--- a/core/src/main/java/resource/context/admin/debug/Comment.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Comment.cfc
@@ -57,8 +57,7 @@ component extends="Debug" {
 	*/
 	function onBeforeUpdate(struct custom) {
 		
-	}
-	
+	}	
 	
 	/**
 	* output the debugging information
@@ -66,13 +65,14 @@ component extends="Debug" {
 	*/
 	function output(struct custom, struct debugging, string context="web") {
 		var NL=variables.NL;
+		if (not StructKeyExists(arguments.custom, "unit"))
+		 	arguments.custom["unit"] = "millisecond";
 		writeOutput("<!--"&NL);
  		echo("=================================================================================="&NL);
         echo("=========================== LUCEE DEBUGGING INFORMATION =========================="&NL);
- 		echo("=================================================================================="&NL&NL);
-        
+ 		echo("=================================================================================="&NL&NL);		
 	// GENERAL
- 		if(structKeyExists(custom,"general") && custom.general) {
+		if( isEnabled(custom,"general") ) {
 			echo(server.coldfusion.productname);
 			if(StructKeyExists(server.lucee,'versionName'))
 				echo('('&server.lucee.versionName&')');

--- a/core/src/main/java/resource/context/admin/debug/Debug.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Debug.cfc
@@ -1,64 +1,42 @@
-<cfcomponent>
-	
-    <cfset fields=array()>
+component {
+	fields=array();
 
-	<cffunction name="field" returntype="component" access="private" output="no">
-		<cfargument name="displayName" required="true" type="string">
-		<cfargument name="name" required="true" type="string">
-		<cfargument name="defaultValue" required="false" type="string" default="">
-		<cfargument name="required" required="false" type="boolean" default="no">
-		<cfargument name="description" required="false" type="any" default="">
-		<cfargument name="type" required="false" type="string" default="text">
-		<cfargument name="values" required="false" type="string" default="">
-		<cfreturn createObject("component","Field").init(	arguments.displayName,
+	private component function field(required string displayName, required string name, string defaultValue="", boolean required="no", any description="", string type="text", string values="") output=false {
+		return createObject("component","Field").init(	arguments.displayName,
 															arguments.name,
 															arguments.defaultValue,
 															arguments.required,
 															arguments.description,
 															arguments.type,
-															arguments.values)>
-	</cffunction>
-	<cffunction name="group" returntype="component" access="private" output="no">
-		<cfargument name="displayName" required="true" type="string">
-		<cfargument name="description" required="false" type="string" default="">
-		<cfargument name="level" required="false" type="numeric" default="2">
-		<cfreturn createObject("component","Group").init(arguments.displayName,arguments.description,arguments.level)>
-	</cffunction>
+															arguments.values);
+	}
 
-	<cffunction name="getCustomFields" returntype="array">
-    	<cfreturn fields>
-    </cffunction>
-    
-    
-	<cffunction name="onBeforeUpdate" returntype="void" output="false">
-		<cfargument name="custom" required="true" type="struct">
-        
-	</cffunction>
-	
-	<cffunction name="onBeforeError" returntype="void" output="no">
-		<cfargument name="cfcatch" required="true" type="struct">
-	</cffunction>    
-    
-	<cffunction name="getId" returntype="string">
-		<cfthrow message="debug templates must implement function getID():string"
-		detail="#getCurrentTemplatePath()#">
-	</cffunction>
-	
-	<cffunction name="getDescription" returntype="string">
-		<cfthrow message="debug templates must implement function getDescription():string"
-			detail="#getCurrentTemplatePath()#">
-	</cffunction>
+	private component function group(required string displayName, string description="", numeric level="2") output=false {
+		return createObject("component","Group").init(arguments.displayName,arguments.description,arguments.level);
+	}
 
-	<cffunction name="getLabel" returntype="string">
-		<cfthrow message="debug templates must implement function getLabel():string"
-			detail="#getCurrentTemplatePath()#">
-	</cffunction>	
-	
-	<cffunction name="output" returntype="string">
-		<cfargument name="custom" required="true" type="struct">
-		<cfargument name="debugging" required="true" type="struct">
-		<cfthrow message="debug templates must implement function output():string"
-			detail="#getCurrentTemplatePath()#">
-    </cffunction>
-    
-</cfcomponent>
+	public array function getCustomFields() {
+		return fields;
+	}
+
+	public void function onBeforeUpdate(required struct custom) output=false {
+	}
+
+	public void function onBeforeError(required struct cfcatch) output=false {
+	}
+
+	public string function getId() {
+		throw( message="implement function getID():string" );
+	}
+
+	public string function output(required struct custom, required struct debugging) {
+		throw( message="implement function output():string" );
+	}
+
+	function isEnabled( custom, key ) {
+		return structKeyExists( arguments.custom, arguments.key ) 
+			&& ( arguments.custom[ arguments.key ] == "Enabled" 
+				|| arguments.custom[ arguments.key ] == "true" 
+		);
+	}
+}

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -69,11 +69,6 @@ group("Debugging Tab","Debugging tag includes execution time,Custom debugging ou
 				return false;
 			}
 		}
-
-		function isEnabled( custom, key ) {
-			return structKeyExists( arguments.custom, arguments.key ) && ( arguments.custom[ arguments.key ] == "Enabled" || arguments.custom[ arguments.key ] == "true" );
-		}
-
 		variables.cookieName_debugging   = "lucee_debug_modern";
 		variables.cookieSortOrder       = "lucee_debug_modern_sort";
 		variables.cookieFilterTemplates = "lucee_debug_modern_filter";


### PR DESCRIPTION
- added a selector to choose debug template to use when viewing a log
- converted debugging.logs.detail.cfm from tag to script

- convert debug.cfc to script
- move isEnabled from Modern.cfc to debug.cfc
- fixed comments and classic to use isEnabled

https://luceeserver.atlassian.net/browse/LDEV-2451