### PR TITLE
fix isValid("email", "error@domain.com 😄") with UTF-8 encoding pages LDEV-2491

### DIFF
--- a/core/src/main/java/lucee/runtime/net/mail/MailUtil.java
+++ b/core/src/main/java/lucee/runtime/net/mail/MailUtil.java
@@ -213,8 +213,13 @@ public final class MailUtil {
 		if (pos > 0 && pos < addr.length() - 1) {
 			String domain = addr.substring(pos + 1);
 			if (!StringUtil.isAscii(domain)) {
-				domain = IDN.toASCII(domain);
-				return addr.substring(0, pos) + "@" + domain;
+				try {
+					domain = IDN.toASCII(domain);
+					return addr.substring(0, pos) + "@" + domain;
+				}
+				catch(IllegalArgumentException e) {
+					return "false";
+				}
 			}
 		}
 		return addr;


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-2491