### PR TITLE
Performance : Fix http client connection pooling - Fixes LDEV-2199

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/Http.java
+++ b/core/src/main/java/lucee/runtime/tag/Http.java
@@ -1440,7 +1440,11 @@ public final class Http extends BodyTagImpl {
 		final SSLConnectionSocketFactory sslsf;
 		try {
 			// SSLContext sslcontext = SSLContexts.createSystemDefault();
+<<<<<<< HEAD
 			SSLContext sslcontext = SSLContext.getInstance("TLS");
+=======
+			SSLContext sslcontext = SSLContext.getInstance("TLSv1.2");
+>>>>>>> 5644ebbd6... [WS] fix
 			if (!StringUtil.isEmpty(this.clientCert)) {
 				// Use discardable connexion manager if Client certificate is used
 				if (this.clientCertPassword == null) this.clientCertPassword = "";

--- a/core/src/main/java/lucee/runtime/tag/Http.java
+++ b/core/src/main/java/lucee/runtime/tag/Http.java
@@ -665,7 +665,7 @@ public final class Http extends BodyTagImpl {
 	}
 
 
-	public void setUsePool(boolean usePool) {
+	public void setPooling(boolean usePool) {
 		this.usePool = usePool;
 	}
 

--- a/core/src/main/java/lucee/runtime/tag/Http.java
+++ b/core/src/main/java/lucee/runtime/tag/Http.java
@@ -205,6 +205,12 @@ public final class Http extends BodyTagImpl {
 	public static final short ENCODED_YES = HTTPUtil.ENCODED_YES;
 	public static final short ENCODED_NO = HTTPUtil.ENCODED_NO;
 
+	public static final int POOL_MAX_CONN = 500;
+	public static final int POOL_MAX_CONN_PER_ROUTE = 50;
+	public static final int POOL_CONN_TTL_MS = 15000;
+	public static final int POOL_CONN_INACTIVITY_DURATION = 300;
+	
+
 	static {
 		// Protocol myhttps = new Protocol("https", new EasySSLProtocolSocketFactory(), 443);
 		// Protocol.registerProtocol("https", new Protocol("https", new EasySSLProtocolSocketFactory(),
@@ -1467,14 +1473,14 @@ public final class Http extends BodyTagImpl {
 					Registry<ConnectionSocketFactory> reg = RegistryBuilder.<ConnectionSocketFactory>create().register("http", PlainConnectionSocketFactory.getSocketFactory())
 									.register("https", gsslsf).build();
 					gcm = new PoolingHttpClientConnectionManager(new DefaultHttpClientConnectionOperatorImpl(reg), null, 15000, TimeUnit.MILLISECONDS);
-					gcm.setDefaultMaxPerRoute(50);
-					gcm.setMaxTotal(500);
+					gcm.setDefaultMaxPerRoute(POOL_MAX_CONN_PER_ROUTE);
+					gcm.setMaxTotal(POOL_MAX_CONN);
 					gcm.setDefaultSocketConfig(SocketConfig.copy(SocketConfig.DEFAULT).setTcpNoDelay(true).setSoReuseAddress(true).setSoLinger(0).build());
-					gcm.setValidateAfterInactivity(300);
+					gcm.setValidateAfterInactivity(POOL_CONN_INACTIVITY_DURATION);
 				}
 				builder.setConnectionManager(gcm);
 				builder.setConnectionManagerShared(true);
-				builder.setConnectionTimeToLive(15000, TimeUnit.MILLISECONDS);
+				builder.setConnectionTimeToLive(POOL_CONN_TTL_MS, TimeUnit.MILLISECONDS);
 				builder.setConnectionReuseStrategy(new DefaultClientConnectionReuseStrategy());
 			}
 		}

--- a/core/src/main/java/lucee/runtime/tag/Http.java
+++ b/core/src/main/java/lucee/runtime/tag/Http.java
@@ -77,7 +77,7 @@ import org.apache.http.protocol.HttpContext;
 
 import lucee.commons.io.CharsetUtil;
 import lucee.commons.io.IOUtil;
-import lucee.commons.io.SystemUtil; 
+import lucee.commons.io.SystemUtil;
 import lucee.commons.io.res.Resource;
 import lucee.commons.io.res.util.ResourceUtil;
 import lucee.commons.lang.ExceptionUtil;


### PR DESCRIPTION
This is an initial PoC over http connection pooling

IMHO, next steps should be to allow connection pool / policy to be defined on application level, as should be for the TLS policy, reuse policy and probably the connection count policy.

The current patch hardcode everything, it works.

Another option for client certificates is to use an lru, allowing a reuse possibility for Client Cert requests

https://luceeserver.atlassian.net/browse/LDEV-2199