### PR TITLE
Add Support for elastic apm agent - LDEV-2572

### DIFF
--- a/core/src/main/java/default.properties
+++ b/core/src/main/java/default.properties
@@ -36,7 +36,8 @@ org.osgi.framework.bootdelegation= \
  org.osgi.*,\
  org.w3c.dom,org.w3c.dom.*,\
  org.xml.sax,org.xml.sax.*,\
- sun.*,sun.misc
+ sun.*,sun.misc,\
+ co.elastic.apm.agent.*
 
 # necessary only for the maven build, no clue why atm
 org.osgi.framework.system.packages= \


### PR DESCRIPTION
This simply allows https://github.com/elastic/apm-agent-java to work correctly,

see bug : 

https://github.com/elastic/apm-agent-java/issues/885

We're currently working on an agent plugin