### PR TITLE
use interrupt instead of stop to avoid thread leak - LDEV-2573

### DIFF
--- a/core/src/main/java/lucee/commons/io/SystemUtil.java
+++ b/core/src/main/java/lucee/commons/io/SystemUtil.java
@@ -1712,7 +1712,7 @@ class MacAddressWrap implements ObjectWrap, Castable, Serializable {
 
 	@Override
 	public Object getEmbededObject() throws PageException {
-		try {	
+		try {
 			return SystemUtil.getMacAddress();
 		}
 		catch (Exception e) {

--- a/core/src/main/java/lucee/commons/io/SystemUtil.java
+++ b/core/src/main/java/lucee/commons/io/SystemUtil.java
@@ -1706,7 +1706,7 @@ class MacAddressWrap implements ObjectWrap, Castable, Serializable {
 
 	@Override
 	public Object getEmbededObject() throws PageException {
-		try {
+		try {	
 			return SystemUtil.getMacAddress();
 		}
 		catch (Exception e) {

--- a/core/src/main/java/lucee/commons/io/SystemUtil.java
+++ b/core/src/main/java/lucee/commons/io/SystemUtil.java
@@ -1696,7 +1696,13 @@ class StopThread extends Thread {
 
 	@Override
 	public void run() {
-		SystemUtil.stop(pc, pc.getThread());
+		PageContextImpl pci = (PageContextImpl) pc;
+		Thread thread = pc.getThread();
+		if (thread == null) return;
+		if (thread.isAlive()) {
+			pci.setTimeoutStackTrace();
+			thread.interrupt();
+		}
 	}
 }
 


### PR DESCRIPTION
This uses the interrupt thread method that will allow the thread to leave the io blocking task instead of the deprecated stop();

this seems to avoid the thread leak.