### PR TITLE
LDEV-2515 Prevent unwanted OSGi Downloads

### DIFF
--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -3,17 +3,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 package lucee.runtime.osgi;
 
@@ -109,7 +109,7 @@ public class OSGiUtil {
 	/**
 	 * only installs a bundle, if the bundle does not already exist, if the bundle exists the existing
 	 * bundle is unloaded first.
-	 * 
+	 *
 	 * @param factory
 	 * @param context
 	 * @param bundle
@@ -131,7 +131,7 @@ public class OSGiUtil {
 
 	/**
 	 * does not check if the bundle already exists!
-	 * 
+	 *
 	 * @param context
 	 * @param path
 	 * @param is
@@ -162,7 +162,7 @@ public class OSGiUtil {
 	/**
 	 * only installs a bundle, if the bundle does not already exist, if the bundle exists the existing
 	 * bundle is unloaded first. the bundle is not stored physically on the system.
-	 * 
+	 *
 	 * @param factory
 	 * @param context
 	 * @param bundle
@@ -275,7 +275,7 @@ public class OSGiUtil {
 
 	/**
 	 * tries to load a class with ni bundle definition
-	 * 
+	 *
 	 * @param name
 	 * @param version
 	 * @param id
@@ -566,6 +566,10 @@ public class OSGiUtil {
 	}
 
 	private static Resource downloadBundle(CFMLEngineFactory factory, final String symbolicName, String symbolicVersion, Identification id) throws IOException, BundleException {
+		String allowBundleDownload = System.getProperty( "lucee.enable.bundle.download" );
+		if ( "false".equals( allowBundleDownload ) ) {
+			throw( new RuntimeException( "Lucee is missing the Bundle jar, " + symbolicName + ":" + symbolicVersion + ", and has been prevented from downloading it. If this jar is not a core jar, it will need to be manually downloaded and placed in the {{lucee-server}}/context/bundles directory." ) );
+		}
 
 		final Resource jarDir = ResourceUtil.toResource(factory.getBundleDirectory());
 		final URL updateProvider = factory.getUpdateLocation();
@@ -701,7 +705,7 @@ public class OSGiUtil {
 
 	/**
 	 * this should be used when you not want to load a Bundle to the system
-	 * 
+	 *
 	 * @param name
 	 * @param version
 	 * @param id only necessary if downloadIfNecessary is set to true
@@ -742,7 +746,7 @@ public class OSGiUtil {
 
 	/**
 	 * check left value against right value
-	 * 
+	 *
 	 * @param left
 	 * @param right
 	 * @return returns if right is newer than left
@@ -963,7 +967,7 @@ public class OSGiUtil {
 
 	/**
 	 * get all local bundles (even bundles not loaded/installed)
-	 * 
+	 *
 	 * @param name
 	 * @param version
 	 * @return
@@ -1055,7 +1059,7 @@ public class OSGiUtil {
 
 	/**
 	 * get local bundle, but does not download from update provider!
-	 * 
+	 *
 	 * @param name
 	 * @param version
 	 * @return
@@ -1635,7 +1639,7 @@ public class OSGiUtil {
 
 		/**
 		 * only return a bundle if already loaded, does not load the bundle
-		 * 
+		 *
 		 * @return
 		 */
 		public Bundle getLoadedBundle() {
@@ -1644,7 +1648,7 @@ public class OSGiUtil {
 
 		/**
 		 * get Bundle, also load if necessary from local or remote
-		 * 
+		 *
 		 * @return
 		 * @throws BundleException
 		 * @throws StartFailedException
@@ -1754,7 +1758,7 @@ public class OSGiUtil {
 
 	/**
 	 * value can be a String (for a single entry) or a List<String> for multiple entries
-	 * 
+	 *
 	 * @param b
 	 * @return
 	 */

--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -578,7 +578,7 @@ public class OSGiUtil {
 				+ (id == null ? "?" : "&") + "allowRedirect=true"
 
 		);
-		log(Logger.LOG_DEBUG, "download bundle [" + symbolicName + ":" + symbolicVersion + "] ");
+		log(Logger.LOG_WARNING, "Downloading bundle [" + symbolicName + ":" + symbolicVersion + "] from " + updateUrl + " and copying to " + jar );
 
 		int code;
 		HttpURLConnection conn;

--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -578,7 +578,7 @@ public class OSGiUtil {
 				+ (id == null ? "?" : "&") + "allowRedirect=true"
 
 		);
-		log(Logger.LOG_WARNING, "Downloading bundle [" + symbolicName + ":" + symbolicVersion + "] from " + updateUrl + " and copying to " + jar );
+		log(Logger.LOG_WARNING, "Downloading bundle [" + symbolicName + ":" + symbolicVersion + "] from " + updateUrl );
 
 		int code;
 		HttpURLConnection conn;

--- a/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
+++ b/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
@@ -702,7 +702,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 				+ (id == null ? "?" : "&") + "allowRedirect=true&jv=" + System.getProperty("java.version")
 
 		);
-		log(Logger.LOG_DEBUG, "download bundle [" + symbolicName + ":" + symbolicVersion + "] from " + updateUrl + " and copy to " + jar);
+		log(Logger.LOG_WARNING, "Downloading bundle [" + symbolicName + ":" + symbolicVersion + "] from " + updateUrl + " and copying to " + jar );
 
 		int code;
 		HttpURLConnection conn;

--- a/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
+++ b/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 package lucee.loader.engine;
 
@@ -147,7 +147,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 	/**
 	 * returns instance of this factory (singelton = always the same instance) do auto update when
 	 * changes occur
-	 * 
+	 *
 	 * @param config
 	 * @return Singelton Instance of the Factory
 	 * @throws ServletException
@@ -175,7 +175,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 	/**
 	 * returns instance of this factory (singelton = always the same instance) do auto update when
 	 * changes occur
-	 * 
+	 *
 	 * @return Singelton Instance of the Factory
 	 * @throws RuntimeException
 	 */
@@ -191,7 +191,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * returns instance of this factory (singelton always the same instance)
-	 * 
+	 *
 	 * @param config
 	 * @param listener
 	 * @return Singelton Instance of the Factory
@@ -247,7 +247,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * adds a listener to the factory that will be informed when a new engine will be loaded.
-	 * 
+	 *
 	 * @param listener
 	 */
 	private void addListener(final EngineChangeListener listener) {
@@ -550,7 +550,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 	/**
 	 * method to initialize an update of the CFML Engine. checks if there is a new Version and update it
 	 * when a new version is available
-	 * 
+	 *
 	 * @param password
 	 * @return has updated
 	 * @throws IOException
@@ -564,7 +564,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * restart the cfml engine
-	 * 
+	 *
 	 * @param password
 	 * @return has updated
 	 * @throws IOException
@@ -578,7 +578,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * restart the cfml engine
-	 * 
+	 *
 	 * @param password
 	 * @return has updated
 	 * @throws IOException
@@ -593,7 +593,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * restart the cfml engine
-	 * 
+	 *
 	 * @param password
 	 * @return has updated
 	 * @throws IOException
@@ -615,7 +615,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * updates the engine when an update is available
-	 * 
+	 *
 	 * @return has updated
 	 * @throws IOException
 	 * @throws ServletException
@@ -797,7 +797,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 				// adding bundle
 				File trg = new File(bundleDirectory, osgiFileName);
-				temp.renameTo(trg);
+				Util.fileMove(temp, trg);
 				log(Logger.LOG_DEBUG, "adding bundle [" + symbolicName + "] in version [" + symbolicVersion + "] to [" + trg + "]");
 				return trg;
 			}
@@ -1063,7 +1063,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 	/**
 	 * method to initialize an update of the CFML Engine. checks if there is a new Version and update it
 	 * when a new version is available
-	 * 
+	 *
 	 * @param password
 	 * @return has updated
 	 * @throws IOException
@@ -1077,7 +1077,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 	/**
 	 * method to initialize an update of the CFML Engine. checks if there is a new Version and update it
 	 * when a new version is available
-	 * 
+	 *
 	 * @param password
 	 * @return has updated
 	 * @throws IOException
@@ -1090,7 +1090,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * updates the engine when an update is available
-	 * 
+	 *
 	 * @return has updated
 	 * @throws IOException
 	 * @throws ServletException
@@ -1136,7 +1136,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * call all registered listener for update of the engine
-	 * 
+	 *
 	 * @param engine
 	 */
 	private void callListeners(final CFMLEngine engine) {
@@ -1172,7 +1172,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * return directory to lucee resource root
-	 * 
+	 *
 	 * @return lucee root directory
 	 * @throws IOException
 	 */
@@ -1370,7 +1370,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * returns the path where the classloader is located
-	 * 
+	 *
 	 * @param cl ClassLoader
 	 * @return file of the classloader root
 	 */
@@ -1405,7 +1405,7 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 
 	/**
 	 * Load CFMl Engine Implementation (lucee.runtime.engine.CFMLEngineImpl) from a Classloader
-	 * 
+	 *
 	 * @param bundle
 	 * @return
 	 * @throws ClassNotFoundException

--- a/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
+++ b/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
@@ -688,6 +688,11 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 			log(Logger.LOG_INFO, jar + " should exist but does not (exist?" + jar.exists() + ";file?" + jar.isFile() + ";hidden?" + jar.isHidden() + ")");
 		}
 
+		String allowBundleDownload = System.getProperty( "lucee.enable.bundle.download" );
+		if ( "false".equals( allowBundleDownload ) ) {
+			throw( new RuntimeException( "Lucee is missing the Bundle jar, " + symbolicName + ":" + symbolicVersion + ", and has been prevented from downloading it. If this jar is not a core jar, it will need to be manually downloaded and placed in the {{lucee-server}}/context/bundles directory." ) );
+		}
+
 		jar = new File(jarDir, symbolicName.replace('.', '-') + "-" + symbolicVersion.replace('.', '-') + (".jar"));
 
 		final URL updateProvider = getUpdateLocation();

--- a/loader/src/main/java/lucee/loader/util/Util.java
+++ b/loader/src/main/java/lucee/loader/util/Util.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 package lucee.loader.util;
 
@@ -88,6 +88,18 @@ public class Util {
 
 		if (closeIS) closeEL(in);
 		if (closeOS) closeEL(out);
+	}
+
+	public final static void fileMove( File src, File dest ) throws IOException {
+		Boolean moved = src.renameTo( dest );
+		if ( !moved ) {
+			BufferedInputStream  is = new BufferedInputStream( new FileInputStream( src ) );
+			BufferedOutputStream os = new BufferedOutputStream( new FileOutputStream( dest ) );
+
+			copy( is, os, true, true );
+
+			src.delete();
+		}
 	}
 
 	/**
@@ -229,7 +241,7 @@ public class Util {
 
 	/**
 	 * check if string is empty (null or "")
-	 * 
+	 *
 	 * @param str
 	 * @return is empty or not
 	 */
@@ -239,7 +251,7 @@ public class Util {
 
 	/**
 	 * check if string is empty (null or "")
-	 * 
+	 *
 	 * @param str
 	 * @return is empty or not
 	 */
@@ -350,10 +362,10 @@ public class Util {
 	/**
 	 * @deprecated no replacement Returns the canonical form of this abstract pathname.
 	 * @param file file to get canonical form from it
-	 * 
+	 *
 	 * @return The canonical pathname string denoting the same file or directory as this abstract
 	 *         pathname
-	 * 
+	 *
 	 * @throws SecurityException If a required system property value cannot be accessed.
 	 */
 	@Deprecated
@@ -482,7 +494,7 @@ public class Util {
 
 	/**
 	 * check left value against right value
-	 * 
+	 *
 	 * @param left
 	 * @param right
 	 * @return returns if right is newer than left

--- a/loader/src/main/java/lucee/loader/util/Util.java
+++ b/loader/src/main/java/lucee/loader/util/Util.java
@@ -20,6 +20,8 @@ package lucee.loader.util;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;


### PR DESCRIPTION
This PR does three things:

1. Fixes an issue that leads to OSGi bundles needlessly being downloaded when they already exist in the Lucee core jar (this is the change around `.renameTo()` which silently fails in some situations)
2. Adds a flag to Lucee to allow administrators to stop Lucee from downloading Bundle files at all, `-Dlucee.enable.bundle.download=false`.
3. Upgrades logs about downloading bundles from DEBUG to WARN (and tweaks the language a little)

It changes the Loader. Yes. Unfortunately there is nothing we can do about that, the bug is in the Loader logic.