### PR TITLE
Adapt ByteCode to handle interrupted thread in compute loop LDEV-2573 

### DIFF
--- a/core/src/main/java/lucee/transformer/bytecode/statement/DoWhile.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/DoWhile.java
@@ -95,7 +95,7 @@ public final class DoWhile extends StatementBaseNoFinal implements FlowControlBr
 		Label endPreempt = new Label();
 		// Check if the thread is interrupted
 		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
-		// Thread hasn't been interrupted, go to afterUpdate
+		// Thread hasn't been interrupted, go to endPreempt
 		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
 		// Thread interrupted, throw Interrupted Exception
 		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");

--- a/core/src/main/java/lucee/transformer/bytecode/statement/DoWhile.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/DoWhile.java
@@ -92,6 +92,15 @@ public final class DoWhile extends StatementBaseNoFinal implements FlowControlBr
 
 		adapter.visitLabel(end);
 
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		adapter.visitLabel(endPreempt);
 	}
 
 	@Override

--- a/core/src/main/java/lucee/transformer/bytecode/statement/For.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/For.java
@@ -125,7 +125,7 @@ public final class For extends StatementBaseNoFinal implements FlowControlBreak,
 
 		// Check if the thread is interrupted
 		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
-		// Thread hasn't been interrupted, go to afterUpdate
+		// Thread hasn't been interrupted, go to endPreempt
 		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
 		// Thread interrupted, throw Interrupted Exception
 		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");

--- a/core/src/main/java/lucee/transformer/bytecode/statement/For.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/For.java
@@ -78,6 +78,7 @@ public final class For extends StatementBaseNoFinal implements FlowControlBreak,
 		Label beforeInit = new Label();
 		Label afterInit = new Label();
 		Label afterUpdate = new Label();
+		Label endPreempt = new Label();
 		adapter.push(0);
 		adapter.storeLocal(toIt, Type.INT_TYPE);
 		
@@ -122,6 +123,14 @@ public final class For extends StatementBaseNoFinal implements FlowControlBreak,
 		// ExpressionUtil.visitLine(bc, getEndLine());
 		adapter.visitLabel(end);
 
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		adapter.visitLabel(endPreempt);
 	}
 
 	@Override

--- a/core/src/main/java/lucee/transformer/bytecode/statement/ForEach.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/ForEach.java
@@ -87,7 +87,7 @@ public final class ForEach extends StatementBase implements FlowControlBreak, Fl
 		GeneratorAdapter adapter = bc.getAdapter();
 		final int toIt = adapter.newLocal(Types.ITERATOR);
 		final int it = adapter.newLocal(Types.ITERATOR);
-		final int item = adapter.newLocal(Types.REFERENCE);
+		final int item = adapter.newLocal(Types.REFERENCE);		
 		adapter.push(0);
 		adapter.storeLocal(toIt, Type.INT_TYPE);
 		
@@ -157,6 +157,17 @@ public final class ForEach extends StatementBase implements FlowControlBreak, Fl
 
 
 		adapter.visitLabel(end);
+
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		adapter.visitLabel(endPreempt);
+
 		tfv.visitTryEnd(bc);
 
 	}

--- a/core/src/main/java/lucee/transformer/bytecode/statement/ForEach.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/ForEach.java
@@ -161,7 +161,7 @@ public final class ForEach extends StatementBase implements FlowControlBreak, Fl
 		Label endPreempt = new Label();
 		// Check if the thread is interrupted
 		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
-		// Thread hasn't been interrupted, go to afterUpdate
+		// Thread hasn't been interrupted, go to endPreempt
 		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
 		// Thread interrupted, throw Interrupted Exception
 		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");

--- a/core/src/main/java/lucee/transformer/bytecode/statement/While.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/While.java
@@ -43,6 +43,10 @@ public final class While extends StatementBaseNoFinal implements FlowControlBrea
 	private Label end = new Label();
 	private String label;
 
+	private final static Type TYPE_THREAD = Type.getType(Thread.class);
+	private final static Type TYPE_EXCEPTION = Type.getType(InterruptedException.class);
+	private final static Method METHOD_INTERRUPTED = new Method("interrupted", Type.BOOLEAN_TYPE, new Type[] {});
+
 	/**
 	 * Constructor of the class
 	 * 
@@ -82,19 +86,20 @@ public final class While extends StatementBaseNoFinal implements FlowControlBrea
 
 		body.writeOut(bc);
 
+		// Check Once every 10K iteration
 		adapter.iinc(toIt, 1);
 		adapter.loadLocal(toIt);
-		adapter.push(1000);
-		// Check if the thread is interrupted
+		adapter.push(10000);
 		adapter.ifICmp(Opcodes.IFLT, begin);
-		adapter.invokeStatic(Type.getType(Thread.class), new Method("interrupted", Type.BOOLEAN_TYPE, new Type[] {}));
 		// reset counter
 		adapter.push(0);
 		adapter.storeLocal(toIt);
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
 		// Thread hasn't been interrupted, go to begin
 		adapter.ifZCmp(Opcodes.IFEQ, begin);
 		// Thread interrupted, throw Interrupted Exception
-		adapter.throwException(Type.getType(InterruptedException.class), "");
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in While loop");
 
 		adapter.visitLabel(end);
 	}

--- a/core/src/main/java/lucee/transformer/bytecode/statement/While.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/While.java
@@ -102,6 +102,16 @@ public final class While extends StatementBaseNoFinal implements FlowControlBrea
 		adapter.throwException(TYPE_EXCEPTION, "Timeout in While loop");
 
 		adapter.visitLabel(end);
+
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		adapter.visitLabel(endPreempt);		
 	}
 
 	@Override

--- a/core/src/main/java/lucee/transformer/bytecode/statement/While.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/While.java
@@ -106,7 +106,7 @@ public final class While extends StatementBaseNoFinal implements FlowControlBrea
 		Label endPreempt = new Label();
 		// Check if the thread is interrupted
 		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
-		// Thread hasn't been interrupted, go to afterUpdate
+		// Thread hasn't been interrupted, go to endPreempt
 		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
 		// Thread interrupted, throw Interrupted Exception
 		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");

--- a/core/src/main/java/lucee/transformer/bytecode/statement/tag/TagLoop.java
+++ b/core/src/main/java/lucee/transformer/bytecode/statement/tag/TagLoop.java
@@ -137,6 +137,10 @@ public final class TagLoop extends TagGroup implements FlowControlBreak, FlowCon
 	private static final Method GET_KEY = new Method("getKey", Types.OBJECT, new Type[] {});
 	private static final Method GET_VALUE = new Method("getValue", Types.OBJECT, new Type[] {});
 
+	private final static Type TYPE_THREAD = Type.getType(Thread.class);
+	private final static Type TYPE_EXCEPTION = Type.getType(InterruptedException.class);
+	private final static Method METHOD_INTERRUPTED = new Method("interrupted", Type.BOOLEAN_TYPE, new Type[] {});
+
 	private int type;
 	private LoopVisitor loopVisitor;
 	private String label;
@@ -299,6 +303,9 @@ public final class TagLoop extends TagGroup implements FlowControlBreak, FlowCon
 
 		adapter.storeLocal(it);
 
+		final int toIt = adapter.newLocal(Types.ITERATOR);
+		adapter.push(0);
+		adapter.storeLocal(toIt, Type.INT_TYPE);
 		// while(it.hasNext()) {
 		whileVisitor.visitBeforeExpression(bc);
 		adapter.loadLocal(it);
@@ -341,11 +348,34 @@ public final class TagLoop extends TagGroup implements FlowControlBreak, FlowCon
 			adapter.pop();
 		}
 		getBody().writeOut(bc);
+		// Check Once every 10K iteration
+		adapter.iinc(toIt, 1);
+		adapter.loadLocal(toIt);
+		adapter.push(10000);
+		adapter.ifICmp(Opcodes.IFLT, whileVisitor.getContinueLabel());
+		// reset counter
+		adapter.push(0);
+		adapter.storeLocal(toIt);
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to begin
+		adapter.ifZCmp(Opcodes.IFEQ, whileVisitor.getContinueLabel());
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in While loop");		
 		whileVisitor.visitAfterBody(bc, getEnd());
 
 		// Reset
 		adapter.loadLocal(it);
 		adapter.invokeStatic(ForEach.FOR_EACH_UTIL, ForEach.RESET);
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to endPreempt
+		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		adapter.visitLabel(endPreempt);
 	}
 
 	/**

--- a/core/src/main/java/lucee/transformer/bytecode/visitor/ForDoubleVisitor.java
+++ b/core/src/main/java/lucee/transformer/bytecode/visitor/ForDoubleVisitor.java
@@ -21,6 +21,8 @@ package lucee.transformer.bytecode.visitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
 
 import lucee.transformer.Position;
 import lucee.transformer.bytecode.BytecodeContext;
@@ -33,6 +35,10 @@ public final class ForDoubleVisitor implements Opcodes, LoopVisitor {
 	public Label beforeExpr = new Label(), afterExpr = new Label();
 	public Label beforeBody = new Label(), afterBody = new Label();
 	public Label beforeUpdate = new Label(), afterUpdate = new Label();
+	private final static Type TYPE_THREAD = Type.getType(Thread.class);
+	private final static Type TYPE_EXCEPTION = Type.getType(InterruptedException.class);
+	private final static Method METHOD_INTERRUPTED = new Method("interrupted", Type.BOOLEAN_TYPE, new Type[] {});
+	private int toIt;	
 	public int i;
 
 	public int visitBeforeExpression(GeneratorAdapter adapter, int start, int step, boolean isLocal) {
@@ -59,9 +65,23 @@ public final class ForDoubleVisitor implements Opcodes, LoopVisitor {
 		ExpressionUtil.visitLine(bc, line);
 		bc.getAdapter().visitLabel(afterBody);
 		// adapter.visitLocalVariable("i", "I", null, beforeInit, afterBody, i);
+
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		bc.getAdapter().invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		bc.getAdapter().ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		bc.getAdapter().throwException(TYPE_EXCEPTION, "Timeout in ForInt loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		bc.getAdapter().visitLabel(endPreempt);
 	}
 
 	public void forInit(GeneratorAdapter adapter, int start, boolean isLocal) {
+		toIt = adapter.newLocal(Types.ITERATOR);
+		adapter.push(0);
+		adapter.storeLocal(toIt, Type.INT_TYPE);
+
 		i = adapter.newLocal(Types.DOUBLE_VALUE);
 		if (isLocal) adapter.loadLocal(start, Types.DOUBLE_VALUE);
 		else adapter.push((double) start);
@@ -69,6 +89,7 @@ public final class ForDoubleVisitor implements Opcodes, LoopVisitor {
 	}
 
 	public void forUpdate(GeneratorAdapter adapter, int step, boolean isLocal) {
+		Label loopPreemptEnd= new Label();
 		if (isLocal) {
 			adapter.visitVarInsn(DLOAD, i);
 			adapter.loadLocal(step);
@@ -76,6 +97,22 @@ public final class ForDoubleVisitor implements Opcodes, LoopVisitor {
 			adapter.visitVarInsn(DSTORE, i);
 		}
 		else adapter.visitIincInsn(i, step);
+
+		// Check Once every 10K iteration
+		adapter.iinc(toIt, 1);
+		adapter.loadLocal(toIt);
+		adapter.push(10000);
+		adapter.ifICmp(Opcodes.IFLT, loopPreemptEnd);
+		// reset counter
+		adapter.push(0);
+		adapter.storeLocal(toIt);
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to begin
+		adapter.ifZCmp(Opcodes.IFEQ, loopPreemptEnd);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in While loop");
+		adapter.visitLabel(loopPreemptEnd);
 	}
 
 	/**

--- a/core/src/main/java/lucee/transformer/bytecode/visitor/ForIntVisitor.java
+++ b/core/src/main/java/lucee/transformer/bytecode/visitor/ForIntVisitor.java
@@ -66,7 +66,6 @@ public final class ForIntVisitor implements Opcodes, LoopVisitor {
 		bc.getAdapter().visitLabel(afterBody);
 		// adapter.visitLocalVariable("i", "I", null, beforeInit, afterBody, i);
 
-		//adapter.visitLocalVariable("i", "I", null, l1, lend, i);
 		Label endPreempt = new Label();
 		// Check if the thread is interrupted
 		bc.getAdapter().invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);

--- a/core/src/main/java/lucee/transformer/bytecode/visitor/ForIntVisitor.java
+++ b/core/src/main/java/lucee/transformer/bytecode/visitor/ForIntVisitor.java
@@ -21,6 +21,8 @@ package lucee.transformer.bytecode.visitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
 
 import lucee.transformer.Position;
 import lucee.transformer.bytecode.BytecodeContext;
@@ -33,6 +35,10 @@ public final class ForIntVisitor implements Opcodes, LoopVisitor {
 	private Label beforeExpr = new Label(), afterExpr = new Label();
 	private Label beforeBody = new Label(), afterBody = new Label();
 	private Label beforeUpdate = new Label(), afterUpdate = new Label();
+	private final static Type TYPE_THREAD = Type.getType(Thread.class);
+	private final static Type TYPE_EXCEPTION = Type.getType(InterruptedException.class);
+	private final static Method METHOD_INTERRUPTED = new Method("interrupted", Type.BOOLEAN_TYPE, new Type[] {});
+	private int toIt;
 	private int i;
 
 	public int visitBeforeExpression(GeneratorAdapter adapter, int start, int step, boolean isLocal) {
@@ -59,9 +65,24 @@ public final class ForIntVisitor implements Opcodes, LoopVisitor {
 		ExpressionUtil.visitLine(bc, line);
 		bc.getAdapter().visitLabel(afterBody);
 		// adapter.visitLocalVariable("i", "I", null, beforeInit, afterBody, i);
+
+		//adapter.visitLocalVariable("i", "I", null, l1, lend, i);
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		bc.getAdapter().invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		bc.getAdapter().ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		bc.getAdapter().throwException(TYPE_EXCEPTION, "Timeout in ForInt loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		bc.getAdapter().visitLabel(endPreempt);
 	}
 
 	private void forInit(GeneratorAdapter adapter, int start, boolean isLocal) {
+		toIt = adapter.newLocal(Types.ITERATOR);
+		adapter.push(0);
+		adapter.storeLocal(toIt, Type.INT_TYPE);
+
 		i = adapter.newLocal(Types.INT_VALUE);
 		if (isLocal) adapter.loadLocal(start, Types.INT_VALUE);
 		else adapter.push(start);
@@ -69,6 +90,7 @@ public final class ForIntVisitor implements Opcodes, LoopVisitor {
 	}
 
 	private void forUpdate(GeneratorAdapter adapter, int step, boolean isLocal) {
+		Label loopPreemptEnd= new Label();
 		if (isLocal) {
 			adapter.visitVarInsn(ILOAD, i);
 			adapter.loadLocal(step);
@@ -76,6 +98,21 @@ public final class ForIntVisitor implements Opcodes, LoopVisitor {
 			adapter.visitVarInsn(ISTORE, i);
 		}
 		else adapter.visitIincInsn(i, step);
+		// Check Once every 10K iteration
+		adapter.iinc(toIt, 1);
+		adapter.loadLocal(toIt);
+		adapter.push(10000);
+		adapter.ifICmp(Opcodes.IFLT, loopPreemptEnd);
+		// reset counter
+		adapter.push(0);
+		adapter.storeLocal(toIt);
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to begin
+		adapter.ifZCmp(Opcodes.IFEQ, loopPreemptEnd);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in While loop");
+		adapter.visitLabel(loopPreemptEnd);		
 	}
 
 	/**

--- a/core/src/main/java/lucee/transformer/bytecode/visitor/ForVisitor.java
+++ b/core/src/main/java/lucee/transformer/bytecode/visitor/ForVisitor.java
@@ -21,6 +21,8 @@ package lucee.transformer.bytecode.visitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
 
 import lucee.transformer.Position;
 import lucee.transformer.bytecode.BytecodeContext;
@@ -36,6 +38,10 @@ public final class ForVisitor implements Opcodes, LoopVisitor {
 	private int i;
 	private Label lend = new Label();
 	private Label lbegin = new Label();
+	private final static Type TYPE_THREAD = Type.getType(Thread.class);
+	private final static Type TYPE_EXCEPTION = Type.getType(InterruptedException.class);
+	private final static Method METHOD_INTERRUPTED = new Method("interrupted", Type.BOOLEAN_TYPE, new Type[] {});
+	private int toIt;
 
 	public int visitBegin(GeneratorAdapter adapter, int start, boolean isLocal) {
 		adapter.visitLabel(l0);
@@ -66,11 +72,37 @@ public final class ForVisitor implements Opcodes, LoopVisitor {
 		adapter.visitLabel(lend);
 
 		// adapter.visitLocalVariable("i", "I", null, l1, lend, i);
+		Label endPreempt = new Label();
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to afterUpdate
+		adapter.ifZCmp(Opcodes.IFEQ, endPreempt);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in For loop");
+		// ExpressionUtil.visitLine(bc, getStartLine());
+		adapter.visitLabel(endPreempt);
 
 	}
 
 	private void forUpdate(GeneratorAdapter adapter) {
+		Label loopPreemptEnd= new Label();
 		adapter.visitIincInsn(i, 1);
+		// Check Once every 10K iteration
+		adapter.iinc(toIt, 1);
+		adapter.loadLocal(toIt);
+		adapter.push(10000);
+		adapter.ifICmp(Opcodes.IFLT, loopPreemptEnd);
+		// reset counter
+		adapter.push(0);
+		adapter.storeLocal(toIt);
+		// Check if the thread is interrupted
+		adapter.invokeStatic(TYPE_THREAD, METHOD_INTERRUPTED);
+		// Thread hasn't been interrupted, go to begin
+		adapter.ifZCmp(Opcodes.IFEQ, loopPreemptEnd);
+		// Thread interrupted, throw Interrupted Exception
+		adapter.throwException(TYPE_EXCEPTION, "Timeout in While loop");
+		adapter.visitLabel(loopPreemptEnd);
+
 	}
 
 	private void forInit(GeneratorAdapter adapter, int start, boolean isLocal) {
@@ -78,6 +110,10 @@ public final class ForVisitor implements Opcodes, LoopVisitor {
 		if (isLocal) adapter.loadLocal(start);
 		else adapter.push(start);
 		adapter.visitVarInsn(ISTORE, i);
+
+		toIt = adapter.newLocal(Types.ITERATOR);
+		adapter.push(0);
+		adapter.storeLocal(toIt, Type.INT_TYPE);
 	}
 
 	/**


### PR DESCRIPTION
This is a quite aggressive approach to allow loops to be cooperatively pre-empted.

Not sure it's ideal, the bytecode can more than probably be optimized, and the "tick" frequency should be adjusted.

This allows to escape from computationaly heavy loops and avoid the stop() call.

without this approach, a simple
```
<cfscript>
local.a=2
do {
local.a=local.a;
} while(true);
</cfscript>
```

Would kill the server for hours.

I'm open for suggestion on how to make this more efficient.