### PR TITLE
queryAddRow with a struct of column keys, handles arrays wrong LDEV-1206

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/query/QueryNew.java
+++ b/core/src/main/java/lucee/runtime/functions/query/QueryNew.java
@@ -106,7 +106,7 @@ public final class QueryNew extends BIF {
 			if (qry.getColumn(e.getKey(), null) != null) {
 				v = e.getValue();
 				arr = Caster.toArray(v, null);
-				if (arr == null) arr = new ArrayImpl(new Object[] { v });
+				arr = new ArrayImpl(new Object[] { v });
 				populateColumn(qry, e.getKey(), arr, rows);
 			}
 		}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-1206