### PR TITLE
fix typo for cfimport taglib

### DIFF
--- a/core/src/main/java/resource/tld/core-base.tld
+++ b/core/src/main/java/resource/tld/core-base.tld
@@ -3951,7 +3951,10 @@ To use cached data, the tag must be called with the exact same arguments.</descr
 			<name>taglib</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description>Path to a custom tag library or a jsp tld</description>
+			<description>Path to a custom tag library or a jsp tld
+				
+As cfimport is a compiler directive, Application.cfc mappings won't work, but mappings configured via the web admin will.
+</description>
 		</attribute>
 		<attribute>
 			<type>string</type>

--- a/core/src/main/java/resource/tld/core-base.tld
+++ b/core/src/main/java/resource/tld/core-base.tld
@@ -3951,7 +3951,7 @@ To use cached data, the tag must be called with the exact same arguments.</descr
 			<name>taglib</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description>Path to a custom tag libraray or a jsp tld</description>
+			<description>Path to a custom tag library or a jsp tld</description>
 		</attribute>
 		<attribute>
 			<type>string</type>


### PR DESCRIPTION
libraray - > library

manually fixed in docs https://github.com/lucee/lucee-docs/pull/740