### PR TITLE
fix [LUCEE_FIX_1], [LUCEE_FIX_2]

### DIFF
--- a/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
+++ b/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
@@ -308,7 +308,7 @@ public class DatasourceConnectionPool {
 	}
 
 	private DCStack getDCStack(DataSource datasource, String user, String pass) {
-		String id = createId(datasource, user, pass);
+		String id = createId(datasource, user, pass).intern();
 		synchronized (id) {
 			DCStack stack = dcs.get(id);
 

--- a/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
+++ b/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
@@ -150,15 +150,20 @@ public class DatasourceConnectionPool {
 
 		DCStack stack = getDCStack(dc.getDatasource(), dc.getUsername(), dc.getPassword());
 		synchronized (stack) {
-			if (closeIt) IOUtil.closeEL(dc.getConnection());
-			else stack.add(dc);
-
-			int max = dc.getDatasource().getConnectionLimit();
-			if (max != -1) {
-				_dec(stack, dc.getDatasource(), dc.getUsername(), dc.getPassword());
-				SystemUtil.notify(waiter);
+			try {
+				if (closeIt) IOUtil.closeEL(dc.getConnection());
+				else stack.add(dc);
 			}
-			else _dec(stack, dc.getDatasource(), dc.getUsername(), dc.getPassword());
+			finally {
+				int max = dc.getDatasource().getConnectionLimit();
+				if (max != -1) {
+					_dec(stack, dc.getDatasource(), dc.getUsername(), dc.getPassword());
+					SystemUtil.notify(waiter);
+				}
+				else {
+					_dec(stack, dc.getDatasource(), dc.getUsername(), dc.getPassword());
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
[LUCEE_FIX_1](https://github.com/piotr87/Lucee/wiki/%5BLUCEE_FIX_1%5D-Decreasing-counter-of-DB-connection-does-not-occur-when-ThreadDeath-Exception-in-DatasourceConnectionPool.releaseDatasourceConnection-occurs)
[LUCEE_FIX_2](https://github.com/piotr87/Lucee/wiki/%5BLUCEE_FIX_2%5D-Obtain-id-of-DCStack-from-the-pool-of-strings-in-DatasourceConnectionPool.getDCStack())