### PR TITLE
Added from email address to UI for sending test emails

### DIFF
--- a/core/src/main/cfml/context/admin/services.mail.cfm
+++ b/core/src/main/cfml/context/admin/services.mail.cfm
@@ -195,7 +195,7 @@ Defaults --->
 			<cftry>
 				<cfset data = queryRowData(ms,url.row)>
 				<!--- <cfdump var="#data#" /><cfabort /> --->
-				<cfmail from="#data.username#" to="#form.toMail#" subject="Test email from Lucee" server="#data.hostname#" username="#data.username#" password="#data.password#" port="#data.port#" usetls="#data.tls#" usessl="#data.ssl#">
+				<cfmail from="#form.fromMail#" to="#form.toMail#" subject="Test email from Lucee" server="#data.hostname#" username="#data.username#" password="#data.password#" port="#data.port#" usetls="#data.tls#" usessl="#data.ssl#">
 					Hi this is a test email from your lucee server instance.
 				</cfmail>
 				<cfset stVeritfyMessages[data.hostname].Label = "OK">

--- a/core/src/main/cfml/context/admin/services.mail.sendTestmail.cfm
+++ b/core/src/main/cfml/context/admin/services.mail.sendTestmail.cfm
@@ -7,9 +7,15 @@
 	<table class="maintbl">
 		<tbody>
 			<tr>
-				<th scope="row">Email</th>
+				<th scope="row">To Email</th>
 				<td>
 					<cfinputClassic type="text" name="toMail" value="" class="medium" required="yes" message="Please enter a valid email, to where you need to send the test email.">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">From Email</th>
+				<td>
+					<cfinputClassic type="text" name="fromMail" value="" class="medium" required="yes" message="Please enter a valid email.">
 				</td>
 			</tr>
 		</tbody>


### PR DESCRIPTION
On the web.cfm -> email - mail server connections,
added code to use a user defined from email address in the send test email user interface.
Then added code to the send test email to use this new fromMail value.