### PR TITLE
admin, show settings, export Application.cfc code by default

### DIFF
--- a/core/src/main/cfml/context/admin/resources/css/style42b.css.cfm
+++ b/core/src/main/cfml/context/admin/resources/css/style42b.css.cfm
@@ -433,6 +433,7 @@ div.ok {
 .coding-tip code {
 
 	white-space: pre-wrap;
+	word-wrap: break-word;
 	tab-size: 4;
 	margin: 0.5em;
 	padding: 0.5em;

--- a/core/src/main/cfml/context/admin/server.export.cfm
+++ b/core/src/main/cfml/context/admin/server.export.cfm
@@ -278,6 +278,6 @@ this.mappings["#mappings.virtual#"]=<cfif len(mappings.strPhysical) && !len(mapp
 </cfformClassic>
 
 
-<cfset renderCodingTip( codeSample,false, false )>
+<cfset renderCodingTip( codeSample,false, true )>
 
 </cfoutput>


### PR DESCRIPTION
there's no need for it to be hidden by default

Before
![image](https://user-images.githubusercontent.com/426404/79066819-08684080-7cbb-11ea-9799-09b64f42eef6.png)

After
![image](https://user-images.githubusercontent.com/426404/79066831-2635a580-7cbb-11ea-9671-2244510799b1.png)

