### PR TITLE
test for Mixed-orientation PDF support LDEV-2528

### DIFF
--- a/test/tags/PDF.cfc
+++ b/test/tags/PDF.cfc
@@ -58,6 +58,24 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		}
 	}
 
+	public void function testPDFOrientation(){
+		document pagetype="letter" orientation="landscape" filename="test-orientation.pdf" overwrite="true" {
+			documentsection { echo("I am landscape"); }
+			documentsection orientation="portrait" { echo("I am portrait"); }
+			documentsection orientation="landscape" { echo("I am landscape"); }
+		}
+		assertTrue(isPDFFile("test-orientation.pdf"));
+
+		pageSizes = getPageSizes(ExpandPath('./test-orientation.pdf'));
+
+		expected = [
+			{ height: 612, width: 792 },
+			{ height: 792, width: 612 },
+			{ height: 612, width: 792 }
+		];
+
+		assertEquals(expected, pageSizes);
+	}
 
 	public void function testPDFOpen(){
 		try {
@@ -73,5 +91,24 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 			if(fileExists("test-unprotect.pdf"))fileDelete("test-unprotect.pdf");
 		}
 	}
-} 
+
+	private array function getPageSizes (required string path) {
+		pageSizes = [];
+		try {
+			pdDocument = CreateObject("java", "org.apache.pdfbox.pdmodel.PDDocument").load(arguments.path);
+			pageIterator = pdDocument.getDocumentCatalog().getPages().getKids().iterator();
+
+			while (pageIterator.hasNext()) {
+				objPage = pageIterator.next();
+				pageSizes.append({
+					width: objPage.getTrimBox().getWidth(),
+					height: objPage.getTrimBox().getHeight()
+				});
+			}
+		} finally {
+			pdDocument.close();
+		}
+		return pageSizes;
+	}
+}
 </cfscript>


### PR DESCRIPTION
This test is currently failing, because https://github.com/lucee/extension-pdf/pull/7
has not yet been merged.

This test code can be simplified significantly when https://github.com/lucee/extension-pdf/pull/6 is merged.

https://luceeserver.atlassian.net/browse/LDEV-2528