### PR TITLE
Rounding in functions is different than Coldfusion LDEV-2863

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/displayFormatting/NumberFormat.java
+++ b/core/src/main/java/lucee/runtime/functions/displayFormatting/NumberFormat.java
@@ -79,9 +79,6 @@ public final class NumberFormat implements Function {
 	public static double toNumber(PageContext pc, Object object, int digits) throws PageException {
 		double d = Caster.toDoubleValue(object, true, Double.NaN);
 		if (Decision.isValid(d)) {
-
-			if (digits < 12) d += 0.000000000001d; // adding this only influence if the binary representation is a little bit off
-			else if (digits < 15) d += 0.000000000000001d; // adding this only influence if the binary representation is a little bit off
 			return d;
 		}
 		String str = Caster.toString(object);

--- a/core/src/main/java/lucee/runtime/functions/international/LSCurrencyFormat.java
+++ b/core/src/main/java/lucee/runtime/functions/international/LSCurrencyFormat.java
@@ -94,6 +94,6 @@ public final class LSCurrencyFormat extends BIF {
 
 	public static double toDouble(Object number) throws PageException {
 		if (number instanceof String && ((String) number).length() == 0) return 0d;
-		return Caster.toDoubleValue(number) + 0.000000000001d; // adding this only influence if the binary representation is a little bit off
+		return Caster.toDoubleValue(number);
 	}
 }

--- a/core/src/main/java/lucee/runtime/functions/math/Round.java
+++ b/core/src/main/java/lucee/runtime/functions/math/Round.java
@@ -22,6 +22,7 @@
 package lucee.runtime.functions.math;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import lucee.runtime.PageContext;
 import lucee.runtime.ext.function.Function;
@@ -37,8 +38,8 @@ public final class Round implements Function {
 	public static double call(PageContext pc, double number, double precision) {
 		if (precision <= 0) return StrictMath.round(number);
 
-		BigDecimal bd = new BigDecimal(number);
-		bd = bd.setScale((int) precision, BigDecimal.ROUND_HALF_UP);
+		BigDecimal bd = new BigDecimal(Double.toString(number));
+		bd = bd.setScale((int) precision, RoundingMode.HALF_UP);
 		return bd.doubleValue();
 	}
 }

--- a/core/src/main/java/lucee/runtime/op/Caster.java
+++ b/core/src/main/java/lucee/runtime/op/Caster.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.nio.charset.Charset;
@@ -877,8 +878,9 @@ public final class Caster {
 
 	private static String toDecimal(double value, char decDel, char thsDel) {
 		// TODO Caster toDecimal bessere impl.
-		String str = new BigDecimal((StrictMath.round(value * 100) / 100D)).toString();
-		// str=toDouble(value).toString();
+		BigDecimal bd = new BigDecimal(Double.toString(value));
+		bd = bd.setScale(2, RoundingMode.HALF_UP);
+		String str = bd.toString();
 		String[] arr = str.split("\\.");
 
 		// right value
@@ -888,7 +890,6 @@ public final class Caster {
 		}
 		else {
 			rightValue = arr[1];
-			rightValue = StrictMath.round(Caster.toDoubleValue("0." + rightValue, 0) * 100) + "";
 			if (rightValue.length() < 2) rightValue = 0 + rightValue;
 		}
 

--- a/core/src/main/java/lucee/runtime/util/NumberFormat.java
+++ b/core/src/main/java/lucee/runtime/util/NumberFormat.java
@@ -18,6 +18,7 @@
  **/
 package lucee.runtime.util;
 
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.Locale;
@@ -61,13 +62,16 @@ public final class NumberFormat {
 	}
 
 	public String format(Locale locale, double number, Mask mask) throws InvalidMaskException {
+		BigDecimal bd = new BigDecimal(Double.toString(number));
+		bd = bd.setScale((int) mask.right, RoundingMode.HALF_UP);
+		number = bd.doubleValue();
 		int maskLen = mask.str.length();
 		DecimalFormat df = getDecimalFormat(locale);// (mask);
 		int gs = df.getGroupingSize();
 		df.applyPattern(mask.str);
 		df.setGroupingSize(gs);
 		df.setGroupingUsed(mask.useComma);
-		df.setRoundingMode(RoundingMode.HALF_UP);
+		df.setRoundingMode(RoundingMode.UNNECESSARY);
 		if (df.getMaximumFractionDigits() > 100) df.setMaximumFractionDigits(mask.right < 11 ? 11 : mask.right); // the if here exists because the value is acting unprecticted in
 		// some cases, so we onkly do if really necessary
 


### PR DESCRIPTION
Makes rounding compatible to ACF.

round: fixes error and change to RoundingMode as BigDecimal round is being depreceated.
numberFormat: remove influence and change to BigDecimal
decimalFormat (Caster): change to BigDecimal to fix errors in Math.round

Optional
LSCurrencyFormat: removes influence to make compatible with ACF but gives wrong rounding like ACF

https://luceeserver.atlassian.net/browse/LDEV-2863