### PR TITLE
LDEV-3042 - Query of Query performance is very bad and single threaded for complex SQL.

### DIFF
--- a/core/src/main/java/lucee/commons/lang/ParserString.java
+++ b/core/src/main/java/lucee/commons/lang/ParserString.java
@@ -112,8 +112,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Stellt den internen Zeiger auf die vorhergehnde Position. ueberlappungen ausserhalb des Index des
-	 * Textes werden ignoriert.
+	 * Stellt den internen Zeiger auf die vorhergehnde Position. ueberlappungen ausserhalb des Index
+	 * des Textes werden ignoriert.
 	 */
 	public void previous() {
 		pos--;
@@ -341,8 +341,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Stellt den Zeiger eins nach vorn, wenn das aktuelle Zeichen das selbe ist wie das Eingegebene,
-	 * gibt zurueck ob es das selbe Zeichen war oder nicht.
+	 * Stellt den Zeiger eins nach vorn, wenn das aktuelle Zeichen das selbe ist wie das
+	 * Eingegebene, gibt zurueck ob es das selbe Zeichen war oder nicht.
 	 * 
 	 * @param c char Zeichen zum Vergleich.
 	 * @return boolean
@@ -356,8 +356,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck ob das aktuelle und die folgenden Zeichen die selben sind, wie in der angegebenen
-	 * Zeichenkette.
+	 * Gibt zurueck ob das aktuelle und die folgenden Zeichen die selben sind, wie in der
+	 * angegebenen Zeichenkette.
 	 * 
 	 * @param str String Zeichen zum Vergleich.
 	 * @return boolean
@@ -371,8 +371,9 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck ob das aktuelle und die folgenden Zeichen die selben sind, wie in der angegebenen
-	 * Zeichenkette, wenn ja wird der Zeiger um die Laenge des String nach vorne gesetzt.
+	 * Gibt zurueck ob das aktuelle und die folgenden Zeichen die selben sind, wie in der
+	 * angegebenen Zeichenkette, wenn ja wird der Zeiger um die Laenge des String nach vorne
+	 * gesetzt.
 	 * 
 	 * @param str String Zeichen zum Vergleich.
 	 * @return boolean
@@ -410,8 +411,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck ob das aktuelle und die folgenden Zeichen die selben sind gefolgt nicht von einem
-	 * word character, wenn ja wird der Zeiger um die Laenge des String nach vorne gesetzt.
+	 * Gibt zurueck ob das aktuelle und die folgenden Zeichen die selben sind gefolgt nicht von
+	 * einem word character, wenn ja wird der Zeiger um die Laenge des String nach vorne gesetzt.
 	 * 
 	 * @param str String Zeichen zum Vergleich.
 	 * @return boolean
@@ -428,6 +429,24 @@ public final class ParserString {
 	public boolean forwardIfCurrentAndNoWordNumberAfter(String str) {
 		int c = pos;
 		if (forwardIfCurrent(str)) {
+			if (!isCurrentLetter() && !isCurrentLetter() && !isCurrent('_')) return true;
+		}
+		pos = c;
+		return false;
+	}
+
+	public boolean forwardIfCurrentAndNoWordNumberAfter(String str, String str2) {
+		int c = pos;
+		if (forwardIfCurrent(str, str2)) {
+			if (!isCurrentLetter() && !isCurrentLetter() && !isCurrent('_')) return true;
+		}
+		pos = c;
+		return false;
+	}
+
+	public boolean forwardIfCurrentAndNoWordNumberAfter(String str, String str2, String str3) {
+		int c = pos;
+		if (forwardIfCurrent(str, str2, str3)) {
 			if (!isCurrentLetter() && !isCurrentLetter() && !isCurrent('_')) return true;
 		}
 		pos = c;
@@ -469,8 +488,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck ob first den folgenden Zeichen entspricht, gefolgt von Leerzeichen und second, wenn
-	 * ja wird der Zeiger um die Laenge der uebereinstimmung nach vorne gestellt.
+	 * Gibt zurueck ob first den folgenden Zeichen entspricht, gefolgt von Leerzeichen und second,
+	 * wenn ja wird der Zeiger um die Laenge der uebereinstimmung nach vorne gestellt.
 	 * 
 	 * @param first Erste Zeichen zum Vergleich (Vor den Leerzeichen).
 	 * @param second Zweite Zeichen zum Vergleich (Nach den Leerzeichen).
@@ -481,6 +500,15 @@ public final class ParserString {
 		if (!forwardIfCurrent(first)) return false;
 		removeSpace();
 		boolean rtn = forwardIfCurrent(second);
+		if (!rtn) pos = start;
+		return rtn;
+	}
+
+	public boolean forwardIfCurrent(String first, String second, char third) {
+		int start = pos;
+		if (!forwardIfCurrent(first, second)) return false;
+		removeSpace();
+		boolean rtn = forwardIfCurrent(third);
 		if (!rtn) pos = start;
 		return rtn;
 	}
@@ -519,8 +547,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck ob first den folgenden Zeichen entspricht, gefolgt von Leerzeichen und second, wenn
-	 * ja wird der Zeiger um die Laenge der uebereinstimmung nach vorne gestellt.
+	 * Gibt zurueck ob first den folgenden Zeichen entspricht, gefolgt von Leerzeichen und second,
+	 * wenn ja wird der Zeiger um die Laenge der uebereinstimmung nach vorne gestellt.
 	 * 
 	 * @param first Erste Zeichen zum Vergleich (Vor den Leerzeichen).
 	 * @param second Zweite Zeichen zum Vergleich (Nach den Leerzeichen).
@@ -571,8 +599,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck ob first den folgenden Zeichen entspricht, gefolgt von Leerzeichen und second, wenn
-	 * ja wird der Zeiger um die Laenge der uebereinstimmung nach vorne gestellt.
+	 * Gibt zurueck ob first den folgenden Zeichen entspricht, gefolgt von Leerzeichen und second,
+	 * wenn ja wird der Zeiger um die Laenge der uebereinstimmung nach vorne gestellt.
 	 * 
 	 * @param first Erste Zeichen zum Vergleich (Vor den Leerzeichen).
 	 * @param second Zweite Zeichen zum Vergleich (Nach den Leerzeichen).
@@ -681,8 +709,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Stellt den internen Zeiger an den Anfang der naechsten Zeile, gibt zurueck ob eine weitere Zeile
-	 * existiert oder ob es bereits die letzte Zeile war.
+	 * Stellt den internen Zeiger an den Anfang der naechsten Zeile, gibt zurueck ob eine weitere
+	 * Zeile existiert oder ob es bereits die letzte Zeile war.
 	 * 
 	 * @return Existiert eine weitere Zeile.
 	 */
@@ -698,8 +726,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt eine Untermenge des CFMLString als Zeichenkette zurueck, ausgehend von start bis zum Ende
-	 * des CFMLString.
+	 * Gibt eine Untermenge des CFMLString als Zeichenkette zurueck, ausgehend von start bis zum
+	 * Ende des CFMLString.
 	 * 
 	 * @param start Von wo aus die Untermege ausgegeben werden soll.
 	 * @return Untermenge als Zeichenkette
@@ -721,8 +749,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt eine Untermenge des CFMLString als Zeichenkette in Kleinbuchstaben zurueck, ausgehend von
-	 * start bis zum Ende des CFMLString.
+	 * Gibt eine Untermenge des CFMLString als Zeichenkette in Kleinbuchstaben zurueck, ausgehend
+	 * von start bis zum Ende des CFMLString.
 	 * 
 	 * @param start Von wo aus die Untermenge ausgegeben werden soll.
 	 * @return Untermenge als Zeichenkette in Kleinbuchstaben.
@@ -732,8 +760,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt eine Untermenge des CFMLString als Zeichenkette in Kleinbuchstaben zurueck, ausgehend von
-	 * start mit einer maximalen Laenge count.
+	 * Gibt eine Untermenge des CFMLString als Zeichenkette in Kleinbuchstaben zurueck, ausgehend
+	 * von start mit einer maximalen Laenge count.
 	 * 
 	 * @param start Von wo aus die Untermenge ausgegeben werden soll.
 	 * @param count Wie lange die zurueckgegebene Zeichenkette maximal sein darf.
@@ -744,8 +772,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt eine Untermenge des CFMLString als CFMLString zurueck, ausgehend von start bis zum Ende des
-	 * CFMLString.
+	 * Gibt eine Untermenge des CFMLString als CFMLString zurueck, ausgehend von start bis zum Ende
+	 * des CFMLString.
 	 * 
 	 * @param start Von wo aus die Untermenge ausgegeben werden soll.
 	 * @return Untermenge als CFMLString
@@ -767,7 +795,8 @@ public final class ParserString {
 		/*
 		 * NICE die untermenge direkter ermiiteln, das problem hierbei sind die lines
 		 * 
-		 * int endPos=start+count; int LineFrom=-1; int LineTo=-1; for(int i=0;i<lines.length;i++) { if() }
+		 * int endPos=start+count; int LineFrom=-1; int LineTo=-1; for(int i=0;i<lines.length;i++) {
+		 * if() }
 		 * 
 		 * return new CFMLString( 0, String.valueOf(text,start,count).toCharArray(),
 		 * String.valueOf(lcText,start,count).toCharArray(), lines);
@@ -789,7 +818,8 @@ public final class ParserString {
 	}
 
 	/**
-	 * Setzt die Position des Zeigers innerhalb des CFMLString, ein ungueltiger index wird ignoriert.
+	 * Setzt die Position des Zeigers innerhalb des CFMLString, ein ungueltiger index wird
+	 * ignoriert.
 	 * 
 	 * @param pos Position an die der Zeiger gestellt werde soll.
 	 */
@@ -825,9 +855,9 @@ public final class ParserString {
 	}
 
 	/**
-	 * Gibt zurueck, ausgehend von der aktuellen Position, wann das naechste Zeichen folgt das gleich
-	 * ist wie die Eingabe, falls keines folgt wird -1 zurueck gegeben. Gross- und Kleinschreibung der
-	 * Zeichen werden igoriert.
+	 * Gibt zurueck, ausgehend von der aktuellen Position, wann das naechste Zeichen folgt das
+	 * gleich ist wie die Eingabe, falls keines folgt wird -1 zurueck gegeben. Gross- und
+	 * Kleinschreibung der Zeichen werden igoriert.
 	 * 
 	 * @param c gesuchtes Zeichen
 	 * @return Zeichen das gesucht werden soll.

--- a/core/src/main/java/lucee/runtime/db/QoQ.java
+++ b/core/src/main/java/lucee/runtime/db/QoQ.java
@@ -19,8 +19,9 @@
 package lucee.runtime.db;
 
 import java.sql.Types;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.Map;
 
 import lucee.commons.lang.CFTypes;
@@ -31,6 +32,7 @@ import lucee.runtime.exp.DatabaseException;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.op.Caster;
 import lucee.runtime.op.Operator;
+import lucee.runtime.sql.QueryPartitions;
 import lucee.runtime.sql.Select;
 import lucee.runtime.sql.SelectParser;
 import lucee.runtime.sql.Selects;
@@ -38,25 +40,41 @@ import lucee.runtime.sql.exp.BracketExpression;
 import lucee.runtime.sql.exp.Column;
 import lucee.runtime.sql.exp.ColumnExpression;
 import lucee.runtime.sql.exp.Expression;
+import lucee.runtime.sql.exp.Literal;
 import lucee.runtime.sql.exp.op.Operation;
 import lucee.runtime.sql.exp.op.Operation1;
 import lucee.runtime.sql.exp.op.Operation2;
 import lucee.runtime.sql.exp.op.Operation3;
+import lucee.runtime.sql.exp.op.OperationAggregate;
 import lucee.runtime.sql.exp.op.OperationN;
 import lucee.runtime.sql.exp.value.Value;
 import lucee.runtime.sql.exp.value.ValueNumber;
+import lucee.runtime.type.Array;
 import lucee.runtime.type.ArrayImpl;
 import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
+import lucee.runtime.type.KeyImpl;
 import lucee.runtime.type.Query;
 import lucee.runtime.type.QueryColumn;
+import lucee.runtime.type.QueryColumnImpl;
 import lucee.runtime.type.QueryImpl;
+import lucee.runtime.type.util.ArrayUtil;
 
 /**
  * 
  */
 public final class QoQ {
+	final static private Collection.Key paramKey = new KeyImpl("?");
 
+	/**
+	 * Execute a QofQ against a SQL object
+	 * 
+	 * @param pc
+	 * @param sql
+	 * @param maxrows
+	 * @return
+	 * @throws PageException
+	 */
 	public Query execute(PageContext pc, SQL sql, int maxrows) throws PageException {
 		try {
 			SelectParser parser = new SelectParser();
@@ -73,204 +91,421 @@ public final class QoQ {
 	 * execute a SQL Statement against CFML Scopes
 	 */
 	public QueryImpl execute(PageContext pc, SQL sql, Selects selects, int maxrows) throws PageException {
-		Column[] orders = selects.getOrderbys();
 		Select[] arrSelects = selects.getSelects();
+		boolean isUnion = (arrSelects.length > 1);
 
 		QueryImpl target = new QueryImpl(new Collection.Key[0], 0, "query", sql);
 
+		// For each select (more than one when using union)
 		for (int i = 0; i < arrSelects.length; i++) {
 			arrSelects[i].getFroms();
 			Column[] froms = arrSelects[i].getFroms();
-			if (froms.length > 1) throw new DatabaseException("can only work with single tables yet", null, sql, null);
-			executeSingle(pc, arrSelects[i], getSingleTable(pc, froms[0]), target, arrSelects.length > 1 ? -1 : maxrows, sql, orders.length > 0);
+
+			if (froms.length > 1) throw new DatabaseException("QoQ can only select from a single tables at a time.", null, sql, null);
+
+			// Lookup actual Query variable on page
+			Query source = getSingleTable(pc, froms[0]);
+			arrSelects[i].expandAsterisks(source);
+
+			// Unions don't allow operations in the order by
+			if (!isUnion) {
+				selects.calcOrderByExpressions();
+			}
+			// Run a select statement. If we have a union, we run this once per select being unioned
+			target = executeSingle(pc, arrSelects[i], getSingleTable(pc, froms[0]), target, isUnion ? -1 : maxrows, sql, selects.getOrderbys().length > 0, isUnion);
 		}
+
+		// DON'T GET THIS SOONER! We recalculate the order bys above based on the columns in the
+		// first select
+		Expression[] orders = selects.getOrderbys();
 
 		// Order By
 		if (orders.length > 0) {
-			order(target, orders);
-			if (maxrows > -1) target.cutRowsTo(maxrows);
-		}
-		// Distinct
-		if (selects.isDistinct()) {
-			order(target, selects.getDistincts()); // order to filter
-			// print.e(selects.getDistincts());
-			Key[] _keys = target.getColumnNames();
-			QueryColumn[] columns = new QueryColumn[_keys.length];
-			for (int i = 0; i < columns.length; i++) {
-				columns[i] = target.getColumn(_keys[i]);
-			}
-
-			int i;
-			Object l, r;
-			outer: for (int row = target.getRecordcount(); row > 1; row--) {
-				for (i = 0; i < columns.length; i++) {
-					l = columns[i].get(row, null);
-					r = columns[i].get(row - 1, null);
-					if (l == null || r == null) {
-						if (l != r) continue outer;
-					}
-					else if (!Operator.equals(l, r, true)) continue outer;
+			order(target, orders, isUnion, sql);
+			// Clean up extra columns that we added in just for the sorting
+			for (Collection.Key col: target.getColumnNames()) {
+				if (col.getLowerString().startsWith("__order_by_expression__")) {
+					target.removeColumn(col);
 				}
-				target.removeRow(row);
 			}
 		}
-		order(target, orders);
 
+		// If we only had a single select, but couldn't apply the top earlier, apply it now
+		if (!isUnion) {
+			ValueNumber oTop = arrSelects[0].getTop();
+			int top = -1;
+			if (oTop != null) {
+				top = (int) oTop.getValueAsDouble();
+				if (maxrows == -1 || maxrows > top) maxrows = top;
+			}
+		}
+		// Choppy chop
+		if (maxrows > -1) {
+			target.cutRowsTo(maxrows);
+		}
+
+		// New query is populated and ready to go!
 		return target;
 	}
 
-	private static void order(Query qry, Column[] columns) throws PageException {
-		Column col;
+	/**
+	 * Order the rows in a query
+	 * 
+	 * @param target Query to order
+	 * @param columns Column expressions to order on
+	 * @param isUnion Is this a union
+	 * @param sql
+	 * @throws PageException
+	 */
+	private static void order(Query target, Expression[] columns, boolean isUnion, SQL sql) throws PageException {
+		Expression col;
+		// Looping backwards over columns so they order correctly
 		for (int i = columns.length - 1; i >= 0; i--) {
 			col = columns[i];
-			qry.sort(col.getColumn(), col.isDirectionBackward() ? Query.ORDER_DESC : Query.ORDER_ASC);
+			if (!isUnion) {
+				// order by 'test' -- just ignore this
+				if (col instanceof Literal) return;
+				// order by ? -- ignore this as well
+				if (col instanceof Column && ((Column) col).getColumn().equals(paramKey)) return;
+
+				// Lookup column in query based on the index stored in the order by expression
+				target.sort(target.getColumnNames()[col.getIndex() - 1], col.isDirectionBackward() ? Query.ORDER_DESC : Query.ORDER_ASC);
+			}
+			else if (col instanceof Column) {
+				Column c = (Column) col;
+				// Lookup column in query based on name of column. unions don't allow operations in
+				// the order by
+				target.sort(c.getColumn(), col.isDirectionBackward() ? Query.ORDER_DESC : Query.ORDER_ASC);
+			}
+			else {
+				throw new DatabaseException("ORDER BY items must appear in the select list if the statement contains a UNION operator", null, sql, null);
+			}
 		}
 	}
 
-	private void executeSingle(PageContext pc, Select select, Query qr, QueryImpl target, int maxrows, SQL sql, boolean hasOrders) throws PageException {
+	/**
+	 * Process a single select statement. If this is a union, append it to the incoming "previous"
+	 * Query and return the new, combined query with all rows
+	 * 
+	 * @param pc PageContext
+	 * @param select Select instance
+	 * @param source Source query to pull data from
+	 * @param previous Previous query in case of union. May be empty if this is the first select in
+	 *            the union
+	 * @param maxrows max rows from cfquery tag. Not necessarily the same as TOP
+	 * @param sql SQL object
+	 * @param hasOrders Is this overall Selects instance ordered? This affects whether we can
+	 *            optimize maxrows or not
+	 * @param isUnion Is this select part of a union of several selects
+	 * @return
+	 * @throws PageException
+	 */
+	private QueryImpl executeSingle(PageContext pc, Select select, Query source, QueryImpl previous, int maxrows, SQL sql, boolean hasOrders, boolean isUnion)
+			throws PageException {
+
+		// Our records will be placed here to return
+		QueryImpl target = new QueryImpl(new Collection.Key[0], 0, "query", sql);
+
+		// Make max rows the smaller of the two
 		ValueNumber oTop = select.getTop();
+		int top = -1;
 		if (oTop != null) {
-			int top = (int) oTop.getValueAsDouble();
+			top = (int) oTop.getValueAsDouble();
 			if (maxrows == -1 || maxrows > top) maxrows = top;
 		}
 
-		int recCount = qr.getRecordcount();
 		Expression[] expSelects = select.getSelects();
 		int selCount = expSelects.length;
 
-		Map<Collection.Key, Object> selects = new HashMap<Collection.Key, Object>();
-		Iterator<Key> it;
-		Key k;
-		// headers
+		Map<Collection.Key, Object> expSelectsMap = new HashMap<Collection.Key, Object>();
+		// Build up the final columns we need in our target query
 		for (int i = 0; i < selCount; i++) {
 			Expression expSelect = expSelects[i];
-
-			if (expSelect.getAlias().equals("*")) {
-				it = qr.keyIterator();
-				while (it.hasNext()) {
-					k = it.next();
-					selects.put(k, k);
-					queryAddColumn(target, k, qr.getColumn(k).getType());
-				}
+			Key alias = Caster.toKey(expSelect.getAlias());
+			expSelectsMap.put(alias, expSelect);
+			int type = Types.OTHER;
+			if (expSelect instanceof ColumnExpression) {
+				ColumnExpression ce = (ColumnExpression) expSelect;
+				// A query param being selected back out uses the type other. We should probably use
+				// the query param type, but we don't actually know what param we'll bind to at this
+				// point.
+				if (!ce.isParam()) type = source.getColumn(Caster.toKey(ce.getColumnName())).getType();
 			}
-			else {
-				Key alias = Caster.toKey(expSelect.getAlias());
-
-				selects.put(alias, expSelect);
-
-				int type = Types.OTHER;
-
-				if (expSelect instanceof ColumnExpression) {
-					ColumnExpression ce = (ColumnExpression) expSelect;
-
-					if (!"?".equals(ce.getColumnName())) type = qr.getColumn(Caster.toKey(ce.getColumnName())).getType();
-				}
-
-				queryAddColumn(target, alias, type);
-			}
+			queryAddColumn(target, alias, type);
 		}
 
-		Collection.Key[] headers = selects.keySet().toArray(new Collection.Key[selects.size()]);
-
-		// loop records
-		Operation where = select.getWhere();
-
-		boolean hasMaxrow = maxrows > -1 && !hasOrders;
+		Collection.Key[] headers = expSelectsMap.keySet().toArray(new Collection.Key[expSelectsMap.size()]);
 
 		// get target columns
 		QueryColumn[] trgColumns = new QueryColumn[headers.length];
 		Object[] trgValues = new Object[headers.length];
 		for (int cell = 0; cell < headers.length; cell++) {
 			trgColumns[cell] = target.getColumn(headers[cell]);
-			trgValues[cell] = selects.get(headers[cell]);
+			trgValues[cell] = expSelectsMap.get(headers[cell]);
 		}
 
-		for (int row = 1; row <= recCount; row++) {
+		// If have a group by, a distinct, or this is part of a "union" then we partition
+		if (select.getGroupbys().length > 0 || select.isDistinct()) {
+			executeSinglePartitioned(pc, select, source, target, maxrows, sql, hasOrders, isUnion, trgColumns, trgValues, headers);
+		}
+		// This is a "normal" select with no partitioning
+		else {
+			executeSingleNonPartitioned(pc, select, source, target, maxrows, sql, hasOrders, isUnion, trgColumns, trgValues, headers);
+		}
+
+		// Top is applied to a union regardless of order. This is because you can't order the
+		// individual selects of a union. You can only order the final result. So any top on an
+		// individual select is just blindly applied to whatever order the records may be in
+		if (isUnion && top > -1) {
+			target.cutRowsTo(top);
+		}
+
+		// For a union all, we just slam all the rows together, keeping any duplicate record
+		if (isUnion && !select.isUnionDistinct()) {
+			return doUnionAll(previous, target);
+		}
+		// If this is a select following a "union" or "union distinct", then everything gets
+		// distincted. Load up the partitions with all the existing rows in the target thus far
+		else if (isUnion && select.isUnionDistinct()) {
+			return doUnionDistinct(pc, previous, target, sql);
+		}
+
+		return target;
+	}
+
+	/**
+	 * Combine two queries while retaining all rows.
+	 * 
+	 * @param previous Query from previous select to union
+	 * @param target New query to add into the previous
+	 * @return Combined Query with potential duplicate rows
+	 * @throws PageException
+	 */
+	private QueryImpl doUnionAll(QueryImpl previous, QueryImpl target) throws PageException {
+		// If this is the first select in a series of unions, just return it directly. It's column
+		// names now get set in stone as the column names the next union(s) will use!
+		if (previous.getRecordcount() == 0) {
+			return target;
+		}
+		Collection.Key[] previousColKeys = previous.getColumnNames();
+		Collection.Key[] targetColKeys = target.getColumnNames();
+		// Queries being joined need to have the same number of columns and the data is full
+		// realized, so just copy it over positionally. The column names may not match, but that's
+		// fine.
+		for (int row = 1; row <= target.getRecordcount(); row++) {
+			previous.addRow(1);
+			for (int col = 0; col < targetColKeys.length; col++) {
+				previous.setAt(previousColKeys[col], previous.getRecordcount(), target.getAt(targetColKeys[col], row));
+			}
+		}
+		return previous;
+	}
+
+	/**
+	 * Combine two queries while removing duplicate rows
+	 * 
+	 * @param pc PageContext
+	 * @param previous Query from previous select to union
+	 * @param target New query to add into the previous
+	 * @param sql SQL instance
+	 * @return Combined Query with no duplicate rows
+	 * @throws PageException
+	 */
+	private QueryImpl doUnionDistinct(PageContext pc, QueryImpl previous, QueryImpl target, SQL sql) throws PageException {
+		// If this is the first select in a series of unions, just return it directly. It's column
+		// names now get set in stone as the column names the next union(s) will use!
+		if (previous.getRecordcount() == 0) {
+			return target;
+		}
+		Collection.Key[] previousColKeys = previous.getColumnNames();
+		Collection.Key[] targetColKeys = target.getColumnNames();
+		Expression[] selectExpressions = new Expression[previousColKeys.length];
+		// We want the exact columns from the previous query, but not necessarily all the data. Make
+		// a new target and copy the columns
+		QueryImpl newTarget = new QueryImpl(new Collection.Key[0], 0, "query", sql);
+		for (int col = 0; col < previousColKeys.length; col++) {
+			newTarget.addColumn(previousColKeys[col], new ArrayImpl(), previous.getColumn(previousColKeys[col]).getType());
+			// While we're looping, build up a handy array of expressions from the previous query.
+			selectExpressions[col] = new ColumnExpression(previousColKeys[col].getString(), 0);
+		}
+
+		// Initialize our object to track the partitions
+		QueryPartitions queryPartitions = new QueryPartitions(sql, selectExpressions, new Expression[0], newTarget, new HashSet<String>(), this);
+
+		// Add in all the rows from our previous work
+		for (int row = 1; row <= previous.getRecordcount(); row++) {
+			queryPartitions.addRow(pc, previous, row, true);
+		}
+		// ...and all of the new rows
+		for (int row = 1; row <= target.getRecordcount(); row++) {
+			queryPartitions.addRow(pc, target, row, true);
+		}
+
+		QueryImpl sourcePartition;
+		// Loop over the partitions and take one from each and add to our new target question for a
+		// distinct result
+		for (String partionKey: queryPartitions.getPartitions().keySet().toArray(new String[queryPartitions.getPartitions().size()])) {
+			sourcePartition = queryPartitions.getPartitions().get(partionKey);
+			newTarget.addRow(1);
+
+			for (int col = 0; col < targetColKeys.length; col++) {
+				newTarget.setAt(previousColKeys[col], newTarget.getRecordcount(), sourcePartition.getAt(previousColKeys[col], 1));
+			}
+
+		}
+		return newTarget;
+	}
+
+	/**
+	 * Process a single select that is not partitioned (grouped or distinct)
+	 * 
+	 * @param pc PageContext
+	 * @param select Select instance
+	 * @param source Query we're select from
+	 * @param target Query object we're adding rows into. (passed back by reference)
+	 * @param maxrows Max rows from cfquery.
+	 * @param sql
+	 * @param hasOrders Is this overall query ordered?
+	 * @param isUnion Is this part of a union?
+	 * @param trgColumns Lookup array of column
+	 * @param trgValues Lookup array of expressions
+	 * @param headers Select lists
+	 * @throws PageException
+	 */
+	private void executeSingleNonPartitioned(PageContext pc, Select select, Query source, QueryImpl target, int maxrows, SQL sql, boolean hasOrders, boolean isUnion,
+			QueryColumn[] trgColumns, Object[] trgValues, Collection.Key[] headers) throws PageException {
+		Operation where = select.getWhere();
+
+		// If we are ordering or distincting the result, we can't enforce the maxrows until after
+		// we've built the entire query
+		boolean hasMaxrow = maxrows > -1 && !hasOrders;
+		// Is there at least on aggregate expression in the select list
+		boolean hasAggregateSelect = select.hasAggregateSelect();
+
+		// Loop over all rows in the source query
+		for (int row = 1; row <= source.getRecordcount(); row++) {
+			// Does this do anything??
 			sql.setPosition(0);
+			// If we can, optimize the max rows exit strategy
 			if (hasMaxrow && maxrows <= target.getRecordcount()) break;
-			boolean useRow = where == null || Caster.toBooleanValue(executeExp(pc, sql, qr, where, row));
-			if (useRow) {
+
+			// The where clause is a single Operation expression that returns try or false. Does
+			// this row match the where clause, if any?
+			if (where == null || Caster.toBooleanValue(executeExp(pc, sql, source, where, row))) {
 				target.addRow(1);
+				// If we have a match, add this row into the target query
 				for (int cell = 0; cell < headers.length; cell++) {
-					// Object value = selects.get(headers[cell]);
-					trgColumns[cell].set(target.getRecordcount(), getValue(pc, sql, qr, row, headers[cell], trgValues[cell]));
-					/*
-					 * target.setAt( headers[cell], target.getRecordcount(),
-					 * getValue(pc,sql,qr,row,headers[cell],trgValues[cell]) );
-					 */
+					trgColumns[cell].set(target.getRecordcount(), getValue(pc, sql, source, row, headers[cell], trgValues[cell]));
+				}
+
+				// If this was a non-grouped select with only aggregates like select "count(1) from
+				// table" than bail after a single row
+				if (hasAggregateSelect) {
+					break;
 				}
 			}
 		}
 
-		// Group By
-		if (select.getGroupbys().length > 0) throw new DatabaseException("group by are not supported at the moment", null, sql, null);
-		if (select.getHaving() != null) throw new DatabaseException("having is not supported at the moment", null, sql, null);
+	}
+
+	/**
+	 * Process a single select that is partitioned (grouped)
+	 * 
+	 * @param pc PageContext
+	 * @param select Select instance
+	 * @param source Query we're selecting from
+	 * @param target Query object we're adding rows into. (passed back by reference)
+	 * @param maxrows
+	 * @param sql
+	 * @param hasOrders Is this overall query ordered?
+	 * @param isUnion Is this part of a union?
+	 * @param trgColumns Lookup array of column
+	 * @param trgValues Lookup array of expressions
+	 * @param headers select columns
+	 * @throws PageException
+	 */
+	private void executeSinglePartitioned(PageContext pc, Select select, Query source, QueryImpl target, int maxrows, SQL sql, boolean hasOrders, boolean isUnion,
+			QueryColumn[] trgColumns, Object[] trgValues, Collection.Key[] headers) throws PageException {
+
+		Operation where = select.getWhere();
+		// Initialize object to track our partioned data
+		QueryPartitions queryPartitions = new QueryPartitions(sql, select.getSelects(), select.getGroupbys(), target, select.getAdditionalColumns(), this);
+
+		// For all records in the source query
+		for (int row = 1; row <= source.getRecordcount(); row++) {
+			sql.setPosition(0);
+			// If where operation is matched (or doesn't exist) ....
+			if (where == null || Caster.toBooleanValue(executeExp(pc, sql, source, where, row))) {
+				// ... add this row to our partitioned data
+				queryPartitions.addRow(pc, source, row, false);
+			}
+		}
+
+		// Now that all rows are partioned, eliminate partions we don't need via the having clause
+		if (select.getHaving() != null) {
+			// Loop over each partition
+			for (String partionKey: queryPartitions.getPartitions().keySet().toArray(new String[queryPartitions.getPartitions().size()])) {
+				// Eval the having clause on it
+				if (!Caster.toBooleanValue(executeExp(pc, sql, queryPartitions.getPartitions().get(partionKey), select.getHaving(), 1))) {
+					// Voted off the island :/
+					queryPartitions.getPartitions().remove(partionKey);
+				}
+				// ColumnExpressions cache the actual query column they use internally
+				// need to reset any cache data in the having Expression
+				// since each iteration is on a diff Query instance
+				select.getHaving().reset();
+			}
+		}
+
+		// Add first row of each group of partitioned data into final result
+		QueryImpl sourcePartition;
+		for (String partionKey: queryPartitions.getPartitions().keySet().toArray(new String[queryPartitions.getPartitions().size()])) {
+			sourcePartition = queryPartitions.getPartitions().get(partionKey);
+			target.addRow(1);
+			for (int cell = 0; cell < headers.length; cell++) {
+
+				// finally processing column expressions and aggregates
+				if (trgValues[cell] instanceof Expression) {
+					Expression exp = (Expression) trgValues[cell];
+					// Sharing columnExpressions across different query objects
+					// Can't have them caching those columns
+					exp.reset();
+				}
+				// If this is a column
+				if (trgValues[cell] instanceof ColumnExpression) {
+					ColumnExpression ce = (ColumnExpression) trgValues[cell];
+					if (ce.getColumn().equals(paramKey)) {
+						target.setAt(headers[cell], target.getRecordcount(), getValue(pc, sql, sourcePartition, 1, null, trgValues[cell]));
+					}
+					else {
+						// Then make sure to use the alias now to reference it since it changed
+						// names after going into the partition
+						target.setAt(headers[cell], target.getRecordcount(), getValue(pc, sql, sourcePartition, 1, ce.getColumnAlias(), null));
+					}
+				}
+				// For Operations, just execute them normally
+				else {
+					target.setAt(headers[cell], target.getRecordcount(), getValue(pc, sql, sourcePartition, 1, null, trgValues[cell]));
+				}
+			}
+
+		}
 
 	}
 
+	/**
+	 * Helper for adding a column to a query
+	 * 
+	 * @param query
+	 * @param column
+	 * @param type
+	 * @throws PageException
+	 */
 	private void queryAddColumn(QueryImpl query, Collection.Key column, int type) throws PageException {
 		if (!query.containsKey(column)) {
 			query.addColumn(column, new ArrayImpl(), type);
 		}
 	}
-
-	/*
-	 * private Array array(String value, int recordcount) { Array array = new ArrayImpl();
-	 * if(recordcount==0) return array; for(int i=0;i<recordcount;i++) { array.appendEL(value); } return
-	 * array; }
-	 */
-
-	/*
-	 * private QueryImpl execute2(PageContext pc,SQL sql, Query qr, Select select,Column[] orders,int
-	 * maxrows) throws PageException {
-	 * 
-	 * int recCount=qr.getRecordcount(); Expression[] expSelects = select.getSelects(); int
-	 * selCount=expSelects.length;
-	 * 
-	 * Map selects=new HashTable(); boolean isSMS=false; Key[] keys; // headers for(int
-	 * i=0;i<selCount;i++) { Expression expSelect = expSelects[i];
-	 * 
-	 * if(expSelect.getAlias().equals("*")) {
-	 * 
-	 * keys = qr.keys(); for(int y=0;y<keys.length;y++){
-	 * selects.put(keys[y].getLowerString(),keys[y].getLowerString()); } } else { String
-	 * alias=expSelect.getAlias(); alias=alias.toLowerCase();
-	 * 
-	 * selects.put(alias,expSelect); } } String[] headers = (String[])selects.keySet().toArray(new
-	 * String[selects.size()]);
-	 * 
-	 * QueryImpl rtn=new QueryImpl(headers,0,"query"); rtn.setSql(sql);
-	 * 
-	 * // loop records Operation where = select.getWhere();
-	 * 
-	 * boolean hasMaxrow=maxrows>-1 && (orders==null || orders.length==0); for(int
-	 * row=1;row<=recCount;row++) { sql.setPosition(0); if(hasMaxrow &&
-	 * maxrows<=rtn.getRecordcount())break; boolean useRow=where==null ||
-	 * Caster.toBooleanValue(executeExp(pc,sql,qr, where, row)); if(useRow) {
-	 * 
-	 * rtn.addRow(1); for(int cell=0;cell<headers.length;cell++){ Object value =
-	 * selects.get(headers[cell]);
-	 * 
-	 * rtn.setAt( headers[cell], rtn.getRecordcount(), getValue(pc,sql,qr,row,headers[cell],value) ); }
-	 * } }
-	 * 
-	 * // Group By if(select.getGroupbys().length>0) throw new
-	 * DatabaseException("group by are not supported at the moment",null,sql);
-	 * if(select.getHaving()!=null) throw new
-	 * DatabaseException("having is not supported at the moment",null,sql);
-	 * 
-	 * // Order By if(orders.length>0) {
-	 * 
-	 * for(int i=orders.length-1;i>=0;i--) { Column order = orders[i];
-	 * rtn.sort(order.getColumn().toLowerCase(),order.isDirectionBackward()?Query.ORDER_DESC:Query.
-	 * ORDER_ASC); } if(maxrows>-1) { rtn.cutRowsTo(maxrows); } } // Distinct if(select.isDistinct()) {
-	 * String[] _keys=rtn.getColumns(); QueryColumn[] columns=new QueryColumn[_keys.length]; for(int
-	 * i=0;i<columns.length;i++) { columns[i]=rtn.getColumn(_keys[i]); }
-	 * 
-	 * int i; outer:for(int row=rtn.getRecordcount();row>1;row--) { for(i=0;i<columns.length;i++) {
-	 * if(!Operator.equals(columns[i].get(row),columns[i].get(row-1),true)) continue outer; }
-	 * rtn.removeRow(row); } } return rtn; }
-	 */
 
 	/**
 	 * return value
@@ -283,7 +518,7 @@ public final class QoQ {
 	 * @return value
 	 * @throws PageException
 	 */
-	private Object getValue(PageContext pc, SQL sql, Query querySource, int row, Collection.Key key, Object value) throws PageException {
+	public Object getValue(PageContext pc, SQL sql, Query querySource, int row, Collection.Key key, Object value) throws PageException {
 		if (value instanceof Expression) return executeExp(pc, sql, querySource, ((Expression) value), row);
 		return querySource.getAt(key, row, null);
 	}
@@ -302,72 +537,70 @@ public final class QoQ {
 	 * Executes a ZEXp
 	 * 
 	 * @param sql
-	 * @param qr Query Result
+	 * @param source Query Result
 	 * @param exp expression to execute
 	 * @param row current row of resultset
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeExp(PageContext pc, SQL sql, Query qr, Expression exp, int row) throws PageException {
-		// print.e("name:"+exp.getClass().getName());
-		if (exp instanceof Value) return ((Value) exp).getValue();// executeConstant(sql,qr, (Value)exp, row);
-		if (exp instanceof Column) return executeColumn(sql, qr, (Column) exp, row);
-		if (exp instanceof Operation) return executeOperation(pc, sql, qr, (Operation) exp, row);
-		if (exp instanceof BracketExpression) return executeBracked(pc, sql, qr, (BracketExpression) exp, row);
+	private Object executeExp(PageContext pc, SQL sql, Query source, Expression exp, int row) throws PageException {
+		if (exp instanceof Value) return ((Value) exp).getValue();// executeConstant(sql,qr,
+		if (exp instanceof Column) return executeColumn(pc, sql, source, (Column) exp, row);
+		if (exp instanceof Operation) return executeOperation(pc, sql, source, (Operation) exp, row);
+		if (exp instanceof BracketExpression) return executeBracked(pc, sql, source, (BracketExpression) exp, row);
 		throw new DatabaseException("unsupported sql statement [" + exp + "]", null, sql, null);
 	}
 
-	private Object executeExp(PageContext pc, SQL sql, Query qr, Expression exp, int row, Object columnDefault) throws PageException {
-		// print.o(exp.getClass().getName());
-		if (exp instanceof Value) return ((Value) exp).getValue();// executeConstant(sql,qr, (Value)exp, row);
-		if (exp instanceof Column) return executeColumn(sql, qr, (Column) exp, row, columnDefault);
-		if (exp instanceof Operation) return executeOperation(pc, sql, qr, (Operation) exp, row);
-		if (exp instanceof BracketExpression) return executeBracked(pc, sql, qr, (BracketExpression) exp, row);
+	private Object executeExp(PageContext pc, SQL sql, Query source, Expression exp, int row, Object columnDefault) throws PageException {
+		if (exp instanceof Value) return ((Value) exp).getValue();// executeConstant(sql,qr,
+		if (exp instanceof Column) return executeColumn(pc, sql, source, (Column) exp, row, columnDefault);
+		if (exp instanceof Operation) return executeOperation(pc, sql, source, (Operation) exp, row);
+		if (exp instanceof BracketExpression) return executeBracked(pc, sql, source, (BracketExpression) exp, row);
 		throw new DatabaseException("unsupported sql statement [" + exp + "]", null, sql, null);
 	}
 
-	private Object executeOperation(PageContext pc, SQL sql, Query qr, Operation operation, int row) throws PageException {
+	private Object executeOperation(PageContext pc, SQL sql, Query source, Operation operation, int row) throws PageException {
 
 		if (operation instanceof Operation2) {
 			Operation2 op2 = (Operation2) operation;
 
 			switch (op2.getOperator()) {
 			case Operation.OPERATION2_AND:
-				return executeAnd(pc, sql, qr, op2, row);
+				return executeAnd(pc, sql, source, op2, row);
 			case Operation.OPERATION2_OR:
-				return executeOr(pc, sql, qr, op2, row);
+				return executeOr(pc, sql, source, op2, row);
 			case Operation.OPERATION2_XOR:
-				return executeXor(pc, sql, qr, op2, row);
+				return executeXor(pc, sql, source, op2, row);
 			case Operation.OPERATION2_EQ:
-				return executeEQ(pc, sql, qr, op2, row);
+				return executeEQ(pc, sql, source, op2, row);
 			case Operation.OPERATION2_NEQ:
-				return executeNEQ(pc, sql, qr, op2, row);
+				return executeNEQ(pc, sql, source, op2, row);
 			case Operation.OPERATION2_LTGT:
-				return executeNEQ(pc, sql, qr, op2, row);
+				return executeNEQ(pc, sql, source, op2, row);
 			case Operation.OPERATION2_LT:
-				return executeLT(pc, sql, qr, op2, row);
+				return executeLT(pc, sql, source, op2, row);
 			case Operation.OPERATION2_LTE:
-				return executeLTE(pc, sql, qr, op2, row);
+				return executeLTE(pc, sql, source, op2, row);
 			case Operation.OPERATION2_GT:
-				return executeGT(pc, sql, qr, op2, row);
+				return executeGT(pc, sql, source, op2, row);
 			case Operation.OPERATION2_GTE:
-				return executeGTE(pc, sql, qr, op2, row);
+				return executeGTE(pc, sql, source, op2, row);
 			case Operation.OPERATION2_MINUS:
-				return executeMinus(pc, sql, qr, op2, row);
+				return executeMinus(pc, sql, source, op2, row);
 			case Operation.OPERATION2_PLUS:
-				return executePlus(pc, sql, qr, op2, row);
+				return executePlus(pc, sql, source, op2, row);
 			case Operation.OPERATION2_DIVIDE:
-				return executeDivide(pc, sql, qr, op2, row);
+				return executeDivide(pc, sql, source, op2, row);
 			case Operation.OPERATION2_MULTIPLY:
-				return executeMultiply(pc, sql, qr, op2, row);
+				return executeMultiply(pc, sql, source, op2, row);
 			case Operation.OPERATION2_EXP:
-				return executeExponent(pc, sql, qr, op2, row);
+				return executeExponent(pc, sql, source, op2, row);
 			case Operation.OPERATION2_LIKE:
-				return Caster.toBoolean(executeLike(pc, sql, qr, op2, row));
+				return Caster.toBoolean(executeLike(pc, sql, source, op2, row));
 			case Operation.OPERATION2_NOT_LIKE:
-				return Caster.toBoolean(!executeLike(pc, sql, qr, op2, row));
+				return Caster.toBoolean(!executeLike(pc, sql, source, op2, row));
 			case Operation.OPERATION2_MOD:
-				return executeMod(pc, sql, qr, op2, row);
+				return executeMod(pc, sql, source, op2, row);
 			}
 
 		}
@@ -377,15 +610,15 @@ public final class QoQ {
 			int o = op1.getOperator();
 
 			if (o == Operation.OPERATION1_IS_NULL) {
-				Object value = executeExp(pc, sql, qr, op1.getExp(), row, null);
+				Object value = executeExp(pc, sql, source, op1.getExp(), row, null);
 				return Caster.toBoolean(value == null);
 			}
 			if (o == Operation.OPERATION1_IS_NOT_NULL) {
-				Object value = executeExp(pc, sql, qr, op1.getExp(), row, null);
+				Object value = executeExp(pc, sql, source, op1.getExp(), row, null);
 				return Caster.toBoolean(value != null);
 			}
 
-			Object value = executeExp(pc, sql, qr, op1.getExp(), row);
+			Object value = executeExp(pc, sql, source, op1.getExp(), row);
 
 			if (o == Operation.OPERATION1_MINUS) return Caster.toDouble(-Caster.toDoubleValue(value));
 			if (o == Operation.OPERATION1_PLUS) return Caster.toDouble(value);
@@ -396,25 +629,39 @@ public final class QoQ {
 		if (operation instanceof Operation3) {
 			Operation3 op3 = (Operation3) operation;
 			int o = op3.getOperator();
-			if (o == Operation.OPERATION3_BETWEEN) return executeBetween(pc, sql, qr, op3, row);
-			if (o == Operation.OPERATION3_LIKE) return executeLike(pc, sql, qr, op3, row);
+			if (o == Operation.OPERATION3_BETWEEN) return executeBetween(pc, sql, source, op3, row);
+			if (o == Operation.OPERATION3_LIKE) return executeLike(pc, sql, source, op3, row);
 		}
 
 		if (!(operation instanceof OperationN)) throw new DatabaseException("invalid syntax for SQL Statement", null, sql, null);
 
 		OperationN opn = (OperationN) operation;
 
-		String op = StringUtil.toLowerCase(opn.getOperator());
+		String op = opn.getOperator();
 		Expression[] operators = opn.getOperants();
 
-		/*
-		 * if(count==0 && op.equals("?")) { int pos=sql.getPosition(); if(sql.getItems().length<=pos) throw
-		 * new DatabaseException("invalid syntax for SQL Statement",null,sql); sql.setPosition(pos+1);
-		 * return sql.getItems()[pos].getValueForCF(); }
-		 */
 		// 11111111111111111111111111111111111111111111111111111
 		if (operators.length == 1) {
-			Object value = executeExp(pc, sql, qr, operators[0], row);
+
+			Object value = null;
+			Collection.Key key = null;
+
+			// Aggregate operations use the entire array of values for the column instead
+			// of a single value at a given row
+			if (operation instanceof OperationAggregate) {
+				if ((operators[0] instanceof ColumnExpression)) {
+					ColumnExpression ce = (ColumnExpression) operators[0];
+					key = ce.getColumn();
+				}
+				else if (!op.equals("count")) {
+					throw new DatabaseException("Aggregates can only reference columns.  Function [" + op + "] has [" + operators[0].getClass().getName() + "] forfirst operand.",
+							null, sql, null);
+				}
+			}
+
+			else {
+				value = executeExp(pc, sql, source, operators[0], row);
+			}
 
 			// Functions
 			switch (op.charAt(0)) {
@@ -423,11 +670,13 @@ public final class QoQ {
 				if (op.equals("acos")) return new Double(Math.acos(Caster.toDoubleValue(value)));
 				if (op.equals("asin")) return new Double(Math.asin(Caster.toDoubleValue(value)));
 				if (op.equals("atan")) return new Double(Math.atan(Caster.toDoubleValue(value)));
+				if (op.equals("avg")) return ArrayUtil.avg(Caster.toArray(((QueryColumnImpl) source.getColumn(key)).toArray()));
 				break;
 			case 'c':
 				if (op.equals("ceiling")) return new Double(Math.ceil(Caster.toDoubleValue(value)));
 				if (op.equals("cos")) return new Double(Math.cos(Caster.toDoubleValue(value)));
 				if (op.equals("cast")) return Caster.castTo(pc, CFTypes.toShort(operators[0].getAlias(), true, CFTypes.TYPE_UNKNOW), operators[0].getAlias(), value);
+				if (op.equals("count")) return Caster.toIntValue(source.getRecordcount());
 				break;
 			case 'e':
 				if (op.equals("exp")) return new Double(Math.exp(Caster.toDoubleValue(value)));
@@ -444,6 +693,30 @@ public final class QoQ {
 				if (op.equals("ltrim")) return StringUtil.ltrim(Caster.toString(value), null);
 				if (op.equals("length")) return new Double(Caster.toString(value).length());
 				break;
+			case 'm':
+				if (op.equals("max") || op.equals("min")) {
+					// Get column data as array
+					Array colData = Caster.toArray(((QueryColumnImpl) source.getColumn(key)).toArray());
+					// Get column type
+					String colType = source.getColumn(key).getTypeAsString();
+					String sortDir = "desc";
+					String sortType = "text";
+					if (op.equals("min")) {
+						sortDir = "asc";
+					}
+					// Numeric-based sort
+					if (colType.equals("NUMERIC") || colType.equals("INTEGER") || colType.equals("DOUBLE") || colType.equals("DECIMAL") || colType.equals("BIGINT")
+							|| colType.equals("TINYINT") || colType.equals("SMALLINT") || colType.equals("REAL")) {
+						sortType = "numeric";
+					}
+					// text-based sort
+					Comparator comp = ArrayUtil.toComparator(pc, sortType, sortDir, false);
+					// Sort the array with proper type and direction
+					colData.sortIt(comp);
+					// The first item in the array is our "max" or "min"
+					return colData.getE(1);
+				}
+				break;
 			case 'r':
 				if (op.equals("rtrim")) return StringUtil.rtrim(Caster.toString(value), null);
 				break;
@@ -452,6 +725,7 @@ public final class QoQ {
 				if (op.equals("sin")) return new Double(Math.sin(Caster.toDoubleValue(value)));
 				if (op.equals("soundex")) return StringUtil.soundex(Caster.toString(value));
 				if (op.equals("sin")) return new Double(Math.sqrt(Caster.toDoubleValue(value)));
+				if (op.equals("sum")) return ArrayUtil.sum(Caster.toArray(((QueryColumnImpl) source.getColumn(key)).toArray()));
 				break;
 			case 't':
 				if (op.equals("tan")) return new Double(Math.tan(Caster.toDoubleValue(value)));
@@ -466,8 +740,8 @@ public final class QoQ {
 
 			// if(op.equals("=") || op.equals("in")) return executeEQ(pc,sql,qr,expression,row);
 
-			Object left = executeExp(pc, sql, qr, operators[0], row);
-			Object right = executeExp(pc, sql, qr, operators[1], row);
+			Object left = executeExp(pc, sql, source, operators[0], row);
+			Object right = executeExp(pc, sql, source, operators[1], row);
 
 			// Functions
 			switch (op.charAt(0)) {
@@ -486,43 +760,24 @@ public final class QoQ {
 				break;
 			}
 
-			// throw new DatabaseException("unsopprted sql statement ["+op+"]",null,sql);
 		}
 		// 3333333333333333333333333333333333333333333333333333333333333333333
 
-		if (op.equals("in")) return executeIn(pc, sql, qr, opn, row, false);
-		if (op.equals("not_in")) return executeIn(pc, sql, qr, opn, row, true);
+		if (op.equals("in")) return executeIn(pc, sql, source, opn, row, false);
+		if (op.equals("not_in")) return executeIn(pc, sql, source, opn, row, true);
 
-		/*
-		 * 
-		 * addCustomFunction("cot",1); addCustomFunction("degrees",1); addCustomFunction("log",1);
-		 * addCustomFunction("log10",1);
-		 * 
-		 * addCustomFunction("pi",0); addCustomFunction("power",2); addCustomFunction("radians",1);
-		 * addCustomFunction("rand",0); addCustomFunction("round",2); addCustomFunction("roundmagic",1);
-		 * addCustomFunction("truncate",2); addCustomFunction("ascii",1); addCustomFunction("bit_length",1);
-		 * addCustomFunction("char",1); addCustomFunction("char_length",1);
-		 * addCustomFunction("difference",2); addCustomFunction("hextoraw",1);
-		 * addCustomFunction("insert",4); addCustomFunction("left",2); addCustomFunction("locate",3);
-		 * addCustomFunction("octet_length",1); addCustomFunction("rawtohex",1);
-		 * addCustomFunction("repeat",2); addCustomFunction("replace",3); addCustomFunction("right",2);
-		 * addCustomFunction("space",1); addCustomFunction("substr",3); addCustomFunction("substring",3);
-		 * addCustomFunction("curdate",0); addCustomFunction("curtime",0); addCustomFunction("datediff",3);
-		 * addCustomFunction("dayname",1); addCustomFunction("dayofmonth",1);
-		 * addCustomFunction("dayofweek",1); addCustomFunction("dayofyear",1); addCustomFunction("hour",1);
-		 * addCustomFunction("minute",1); addCustomFunction("month",1); addCustomFunction("monthname",1);
-		 * addCustomFunction("now",0); addCustomFunction("quarter",1); addCustomFunction("second",1);
-		 * addCustomFunction("week",1); addCustomFunction("year",1); addCustomFunction("current_date",1);
-		 * addCustomFunction("current_time",1); addCustomFunction("current_timestamp",1);
-		 * addCustomFunction("database",0); addCustomFunction("user",0);
-		 * addCustomFunction("current_user",0); addCustomFunction("identity",0);
-		 * addCustomFunction("ifnull",2); addCustomFunction("casewhen",3); addCustomFunction("convert",2);
-		 * //addCustomFunction("cast",1); addCustomFunction("coalesce",1000); addCustomFunction("nullif",2);
-		 * addCustomFunction("extract",1); addCustomFunction("position",1);
-		 */
+		if (op.equals("coalesce")) {
+			for (Expression thisOp: operators) {
+				// Support full null?
+				Object thisValue = executeExp(pc, sql, source, thisOp, row);
+				if (!Caster.toString(thisValue).equals("")) {
+					return thisValue;
+				}
+			}
+			return "";
+		}
 
-		// print(expression);
-		throw new DatabaseException("unsopprted sql statement (" + op + ") ", null, sql, null);
+		throw new DatabaseException("unsupported sql statement (" + op + ") ", null, sql, null);
 
 	}
 
@@ -530,8 +785,9 @@ public final class QoQ {
 	 * *
 	 * 
 	 * @param expression / private void print(ZExpression expression) {
-	 * print.ln("Operator:"+expression.getOperator().toLowerCase()); int len=expression.nbOperands();
-	 * for(int i=0;i<len;i++) { print.ln("	["+i+"]=	"+expression.getOperand(i)); } }/*
+	 * print.ln("Operator:"+expression.getOperator().toLowerCase()); int
+	 * len=expression.nbOperands(); for(int i=0;i<len;i++) { print.ln("	["+i+"]=	"
+	 * +expression.getOperand(i)); } }/*
 	 * 
 	 * 
 	 * 
@@ -539,7 +795,7 @@ public final class QoQ {
 	 * 
 	 * execute an and operation
 	 * 
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * 
 	 * @param expression
 	 * 
@@ -549,16 +805,16 @@ public final class QoQ {
 	 * 
 	 * @throws PageException
 	 */
-	private Object executeAnd(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
+	private Object executeAnd(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
 		// print.out("("+expression.getLeft().toString(true)+" AND
 		// "+expression.getRight().toString(true)+")");
-		boolean rtn = Caster.toBooleanValue(executeExp(pc, sql, qr, expression.getLeft(), row));
+		boolean rtn = Caster.toBooleanValue(executeExp(pc, sql, source, expression.getLeft(), row));
 		if (!rtn) return Boolean.FALSE;
-		return Caster.toBoolean(executeExp(pc, sql, qr, expression.getRight(), row));
+		return Caster.toBoolean(executeExp(pc, sql, source, expression.getRight(), row));
 	}
 
-	private Object executeBracked(PageContext pc, SQL sql, Query qr, BracketExpression expression, int row) throws PageException {
-		return executeExp(pc, sql, qr, expression.getExp(), row);
+	private Object executeBracked(PageContext pc, SQL sql, Query source, BracketExpression expression, int row) throws PageException {
+		return executeExp(pc, sql, source, expression.getExp(), row);
 	}
 
 	/**
@@ -566,18 +822,18 @@ public final class QoQ {
 	 * execute an and operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeOr(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
+	private Object executeOr(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
 		// print.out("("+expression.getLeft().toString(true)+" OR
 		// "+expression.getRight().toString(true)+")");
-		boolean rtn = Caster.toBooleanValue(executeExp(pc, sql, qr, expression.getLeft(), row));
+		boolean rtn = Caster.toBooleanValue(executeExp(pc, sql, source, expression.getLeft(), row));
 		if (rtn) return Boolean.TRUE;
-		Boolean rtn2 = Caster.toBoolean(executeExp(pc, sql, qr, expression.getRight(), row));
+		Boolean rtn2 = Caster.toBoolean(executeExp(pc, sql, source, expression.getRight(), row));
 
 		// print.out(rtn+ " or "+rtn2);
 
@@ -585,9 +841,9 @@ public final class QoQ {
 
 	}
 
-	private Object executeXor(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return Caster.toBooleanValue(executeExp(pc, sql, qr, expression.getLeft(), row)) ^ Caster.toBooleanValue(executeExp(pc, sql, qr, expression.getRight(), row)) ? Boolean.TRUE
-				: Boolean.FALSE;
+	private Object executeXor(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return Caster.toBooleanValue(executeExp(pc, sql, source, expression.getLeft(), row)) ^ Caster.toBooleanValue(executeExp(pc, sql, source, expression.getRight(), row))
+				? Boolean.TRUE : Boolean.FALSE;
 	}
 
 	/**
@@ -595,14 +851,14 @@ public final class QoQ {
 	 * execute an equal operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeEQ(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return (executeCompare(pc, sql, qr, expression, row) == 0) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeEQ(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return Operator.equals(executeExp(pc, sql, source, expression.getLeft(), row), executeExp(pc, sql, source, expression.getRight(), row), true);
 	}
 
 	/**
@@ -610,14 +866,14 @@ public final class QoQ {
 	 * execute a not equal operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeNEQ(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return (executeCompare(pc, sql, qr, expression, row) != 0) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeNEQ(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return (boolean) executeEQ(pc, sql, source, expression, row) == false;
 	}
 
 	/**
@@ -625,14 +881,14 @@ public final class QoQ {
 	 * execute a less than operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeLT(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return (executeCompare(pc, sql, qr, expression, row) < 0) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeLT(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return (executeCompare(pc, sql, source, expression, row) < 0) ? Boolean.TRUE : Boolean.FALSE;
 	}
 
 	/**
@@ -640,14 +896,14 @@ public final class QoQ {
 	 * execute a less than or equal operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeLTE(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return (executeCompare(pc, sql, qr, expression, row) <= 0) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeLTE(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return (executeCompare(pc, sql, source, expression, row) <= 0) ? Boolean.TRUE : Boolean.FALSE;
 	}
 
 	/**
@@ -655,14 +911,14 @@ public final class QoQ {
 	 * execute a greater than operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeGT(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return (executeCompare(pc, sql, qr, expression, row) > 0) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeGT(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return (executeCompare(pc, sql, source, expression, row) > 0) ? Boolean.TRUE : Boolean.FALSE;
 	}
 
 	/**
@@ -670,14 +926,14 @@ public final class QoQ {
 	 * execute a greater than or equal operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeGTE(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return (executeCompare(pc, sql, qr, expression, row) >= 0) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeGTE(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return (executeCompare(pc, sql, source, expression, row) >= 0) ? Boolean.TRUE : Boolean.FALSE;
 	}
 
 	/**
@@ -685,21 +941,21 @@ public final class QoQ {
 	 * execute an equal operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param op
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private int executeCompare(PageContext pc, SQL sql, Query qr, Operation2 op, int row) throws PageException {
+	private int executeCompare(PageContext pc, SQL sql, Query source, Operation2 op, int row) throws PageException {
 		// print.e(op.getLeft().getClass().getName());
-		return Operator.compare(executeExp(pc, sql, qr, op.getLeft(), row), executeExp(pc, sql, qr, op.getRight(), row));
+		return Operator.compare(executeExp(pc, sql, source, op.getLeft(), row), executeExp(pc, sql, source, op.getRight(), row));
 	}
 
-	private Object executeMod(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
+	private Object executeMod(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
 
-		return Caster
-				.toDouble(Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getLeft(), row)) % Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getRight(), row)));
+		return Caster.toDouble(
+				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) % Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
 	}
 
 	/**
@@ -707,18 +963,18 @@ public final class QoQ {
 	 * execute a greater than or equal operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Boolean executeIn(PageContext pc, SQL sql, Query qr, OperationN expression, int row, boolean isNot) throws PageException {
+	private Boolean executeIn(PageContext pc, SQL sql, Query source, OperationN expression, int row, boolean isNot) throws PageException {
 		Expression[] operators = expression.getOperants();
-		Object left = executeExp(pc, sql, qr, operators[0], row);
+		Object left = executeExp(pc, sql, source, operators[0], row);
 
 		for (int i = 1; i < operators.length; i++) {
-			if (Operator.compare(left, executeExp(pc, sql, qr, operators[i], row)) == 0) return isNot ? Boolean.FALSE : Boolean.TRUE;
+			if (Operator.compare(left, executeExp(pc, sql, source, operators[i], row)) == 0) return isNot ? Boolean.FALSE : Boolean.TRUE;
 		}
 		return isNot ? Boolean.TRUE : Boolean.FALSE;
 	}
@@ -728,14 +984,15 @@ public final class QoQ {
 	 * execute a minus operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeMinus(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return new Double(Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getLeft(), row)) - Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getRight(), row)));
+	private Object executeMinus(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return new Double(
+				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) - Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
 	}
 
 	/**
@@ -743,14 +1000,15 @@ public final class QoQ {
 	 * execute a divide operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeDivide(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return new Double(Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getLeft(), row)) / Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getRight(), row)));
+	private Object executeDivide(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return new Double(
+				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) / Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
 	}
 
 	/**
@@ -758,14 +1016,15 @@ public final class QoQ {
 	 * execute a multiply operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeMultiply(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return new Double(Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getLeft(), row)) * Caster.toDoubleValue(executeExp(pc, sql, qr, expression.getRight(), row)));
+	private Object executeMultiply(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return new Double(
+				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) * Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
 	}
 
 	/**
@@ -773,14 +1032,15 @@ public final class QoQ {
 	 * execute a multiply operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeExponent(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return Integer.valueOf(Caster.toIntValue(executeExp(pc, sql, qr, expression.getLeft(), row)) ^ Caster.toIntValue(executeExp(pc, sql, qr, expression.getRight(), row)));
+	private Object executeExponent(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return Integer
+				.valueOf(Caster.toIntValue(executeExp(pc, sql, source, expression.getLeft(), row)) ^ Caster.toIntValue(executeExp(pc, sql, source, expression.getRight(), row)));
 	}
 
 	/**
@@ -788,15 +1048,15 @@ public final class QoQ {
 	 * execute a plus operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executePlus(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		Object left = executeExp(pc, sql, qr, expression.getLeft(), row);
-		Object right = executeExp(pc, sql, qr, expression.getRight(), row);
+	private Object executePlus(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		Object left = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right = executeExp(pc, sql, source, expression.getRight(), row);
 
 		try {
 			return new Double(Caster.toDoubleValue(left) + Caster.toDoubleValue(right));
@@ -811,57 +1071,63 @@ public final class QoQ {
 	 * execute a between operation
 	 * 
 	 * @param sql
-	 * @param qr QueryResult to execute on it
+	 * @param source QueryResult to execute on it
 	 * @param expression
 	 * @param row row of resultset to execute
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeBetween(PageContext pc, SQL sql, Query qr, Operation3 expression, int row) throws PageException {
-		Object left = executeExp(pc, sql, qr, expression.getExp(), row);
-		Object right1 = executeExp(pc, sql, qr, expression.getLeft(), row);
-		Object right2 = executeExp(pc, sql, qr, expression.getRight(), row);
+	private Object executeBetween(PageContext pc, SQL sql, Query source, Operation3 expression, int row) throws PageException {
+		Object left = executeExp(pc, sql, source, expression.getExp(), row);
+		Object right1 = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right2 = executeExp(pc, sql, source, expression.getRight(), row);
 		// print.out(left+" between "+right1+" and "+right2
 		// +" = "+((Operator.compare(left,right1)>=0)+" && "+(Operator.compare(left,right2)<=0)));
 
 		return ((Operator.compare(left, right1) >= 0) && (Operator.compare(left, right2) <= 0)) ? Boolean.TRUE : Boolean.FALSE;
 	}
 
-	private Object executeLike(PageContext pc, SQL sql, Query qr, Operation3 expression, int row) throws PageException {
-		return LikeCompare.like(sql, Caster.toString(executeExp(pc, sql, qr, expression.getExp(), row)), Caster.toString(executeExp(pc, sql, qr, expression.getLeft(), row)),
-				Caster.toString(executeExp(pc, sql, qr, expression.getRight(), row))) ? Boolean.TRUE : Boolean.FALSE;
+	private Object executeLike(PageContext pc, SQL sql, Query source, Operation3 expression, int row) throws PageException {
+		return LikeCompare.like(sql, Caster.toString(executeExp(pc, sql, source, expression.getExp(), row)),
+				Caster.toString(executeExp(pc, sql, source, expression.getLeft(), row)), Caster.toString(executeExp(pc, sql, source, expression.getRight(), row))) ? Boolean.TRUE
+						: Boolean.FALSE;
 	}
 
-	private boolean executeLike(PageContext pc, SQL sql, Query qr, Operation2 expression, int row) throws PageException {
-		return LikeCompare.like(sql, Caster.toString(executeExp(pc, sql, qr, expression.getLeft(), row)), Caster.toString(executeExp(pc, sql, qr, expression.getRight(), row)));
+	private boolean executeLike(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		return LikeCompare.like(sql, Caster.toString(executeExp(pc, sql, source, expression.getLeft(), row)),
+				Caster.toString(executeExp(pc, sql, source, expression.getRight(), row)));
 	}
 
 	/**
 	 * Executes a constant value
 	 * 
 	 * @param sql
-	 * @param qr
+	 * @param source
 	 * @param column
 	 * @param row
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeColumn(SQL sql, Query qr, Column column, int row) throws PageException {
-		if (column.getColumn().equals("?")) {
+	private Object executeColumn(PageContext pc, SQL sql, Query source, Column column, int row) throws PageException {
+		if (column.isParam()) {
 			int pos = column.getColumnIndex();
 			if (sql.getItems().length <= pos) throw new DatabaseException("invalid syntax for SQL Statement", null, sql, null);
+			// If null=true is used with query param
+			if (sql.getItems()[pos].isNulls()) return null;
 			return sql.getItems()[pos].getValueForCF();
 		}
-		return column.getValue(qr, row);
-		// return qr.getAt(column.getColumn(),row);
+		return column.getValue(pc, source, row);
+		// return source.getAt(column.getColumn(),row);
 	}
 
-	private Object executeColumn(SQL sql, Query qr, Column column, int row, Object defaultValue) throws PageException {
-		if (column.getColumn().equals("?")) {
+	private Object executeColumn(PageContext pc, SQL sql, Query source, Column column, int row, Object defaultValue) throws PageException {
+		if (column.isParam()) {
 			int pos = column.getColumnIndex();
 			if (sql.getItems().length <= pos) throw new DatabaseException("invalid syntax for SQL Statement", null, sql, null);
+			// If null=true is used with query param
+			if (sql.getItems()[pos].isNulls()) return null;
 			return sql.getItems()[pos].getValueForCF();
 		}
-		return column.getValue(qr, row, defaultValue);
+		return column.getValue(pc, source, row, defaultValue);
 	}
 }

--- a/core/src/main/java/lucee/runtime/db/QoQ.java
+++ b/core/src/main/java/lucee/runtime/db/QoQ.java
@@ -183,7 +183,7 @@ public final class QoQ {
 				target.sort(c.getColumn(), col.isDirectionBackward() ? Query.ORDER_DESC : Query.ORDER_ASC);
 			}
 			else {
-				throw new DatabaseException("ORDER BY items must appear in the select list if the statement contains a UNION operator", null, sql, null);
+				throw new DatabaseException("ORDER BY items must be a column name/alias from the first select list if the statement contains a UNION operator", null, sql, null);
 			}
 		}
 	}

--- a/core/src/main/java/lucee/runtime/db/SQLCaster.java
+++ b/core/src/main/java/lucee/runtime/db/SQLCaster.java
@@ -128,7 +128,8 @@ public final class SQLCaster {
 				if (value instanceof lucee.runtime.type.Array) return Caster.toList(value);
 				if (value instanceof lucee.runtime.type.Struct) return Caster.toMap(value);
 
-				return value;// toSQLObject(value); TODO alle lucee spezifischen typen sollten in sql typen uebersetzt werden
+				return value;// toSQLObject(value); TODO alle lucee spezifischen typen sollten in
+								// sql typen uebersetzt werden
 			}
 		}
 		catch (PageException pe) {
@@ -181,8 +182,9 @@ public final class SQLCaster {
 			try {
 				stat.setClob(parameterIndex, SQLUtil.toClob(stat.getConnection(), value));
 				/*
-				 * if(value instanceof String) { try{ stat.setString(parameterIndex,Caster.toString(value)); }
-				 * catch(Throwable t){ExceptionUtil.rethrowIfNecessary(t);
+				 * if(value instanceof String) { try{
+				 * stat.setString(parameterIndex,Caster.toString(value)); } catch(Throwable
+				 * t){ExceptionUtil.rethrowIfNecessary(t);
 				 * stat.setClob(parameterIndex,SQLUtil.toClob(stat.getConnection(),value)); }
 				 * 
 				 * } else stat.setClob(parameterIndex,SQLUtil.toClob(stat.getConnection(),value));
@@ -297,7 +299,8 @@ public final class SQLCaster {
 		case Types.TIME:
 			try {
 
-				// stat.setObject(parameterIndex, new Time((Caster.toDate(value,null).getTime())), type);
+				// stat.setObject(parameterIndex, new Time((Caster.toDate(value,null).getTime())),
+				// type);
 				stat.setTime(parameterIndex, new Time(Caster.toDate(value, tz).getTime()), JREDateTimeUtil.getThreadCalendar(tz));
 			}
 			catch (PageException pe) {
@@ -307,7 +310,8 @@ public final class SQLCaster {
 			return;
 		case Types.TIMESTAMP:
 			try {
-				// stat.setObject(parameterIndex, new Timestamp((Caster.toDate(value,null).getTime())), type);
+				// stat.setObject(parameterIndex, new
+				// Timestamp((Caster.toDate(value,null).getTime())), type);
 				// stat.setObject(parameterIndex, value, type);
 				stat.setTimestamp(parameterIndex, new Timestamp(Caster.toDate(value, tz).getTime()), JREDateTimeUtil.getThreadCalendar(tz));
 			}
@@ -326,7 +330,8 @@ public final class SQLCaster {
 		 */
 		default:
 			stat.setObject(parameterIndex, value, type);
-			// throw new DatabaseException(toStringType(item.getType())+" is not a supported Type",null,null);
+			// throw new DatabaseException(toStringType(item.getType())+" is not a supported
+			// Type",null,null);
 
 		}
 	}
@@ -391,8 +396,8 @@ public final class SQLCaster {
 
 	/*
 	 * private static String toString(Clob clob) throws SQLException, IOException { Reader in =
-	 * clob.getCharacterStream(); StringBuilder buf = new StringBuilder(); for(int c=in.read();c != -1;c
-	 * = in.read()) { buf.append((char)c); } return buf.toString(); }
+	 * clob.getCharacterStream(); StringBuilder buf = new StringBuilder(); for(int c=in.read();c !=
+	 * -1;c = in.read()) { buf.append((char)c); } return buf.toString(); }
 	 */
 
 	/**
@@ -657,28 +662,35 @@ public final class SQLCaster {
 	 * public static int cfSQLTypeToIntType(String strType) throws DatabaseException {
 	 * strType=strType.toUpperCase().trim();
 	 * 
-	 * if(strType.equals("CF_SQL_ARRAY")) return Types.ARRAY; else if(strType.equals("CF_SQL_BIGINT"))
-	 * return Types.BIGINT; else if(strType.equals("CF_SQL_BINARY")) return Types.BINARY; else
-	 * if(strType.equals("CF_SQL_BIT")) return Types.BIT; else if(strType.equals("CF_SQL_BLOB")) return
-	 * Types.BLOB; else if(strType.equals("CF_SQL_BOOLEAN")) return Types.BOOLEAN; else
+	 * if(strType.equals("CF_SQL_ARRAY")) return Types.ARRAY; else
+	 * if(strType.equals("CF_SQL_BIGINT")) return Types.BIGINT; else
+	 * if(strType.equals("CF_SQL_BINARY")) return Types.BINARY; else
+	 * if(strType.equals("CF_SQL_BIT")) return Types.BIT; else if(strType.equals("CF_SQL_BLOB"))
+	 * return Types.BLOB; else if(strType.equals("CF_SQL_BOOLEAN")) return Types.BOOLEAN; else
 	 * if(strType.equals("CF_SQL_CHAR")) return Types.CHAR; else if(strType.equals("CF_SQL_CLOB"))
 	 * return Types.CLOB; else if(strType.equals("CF_SQL_DATALINK")) return Types.DATALINK; else
-	 * if(strType.equals("CF_SQL_DATE")) return Types.DATE; else if(strType.equals("CF_SQL_DISTINCT"))
-	 * return Types.DISTINCT; else if(strType.equals("CF_SQL_DECIMAL")) return Types.DECIMAL; else
-	 * if(strType.equals("CF_SQL_DOUBLE")) return Types.DOUBLE; else if(strType.equals("CF_SQL_FLOAT"))
-	 * return Types.FLOAT; else if(strType.equals("CF_SQL_IDSTAMP")) return CFTypes.IDSTAMP; else
-	 * if(strType.equals("CF_SQL_INTEGER")) return Types.INTEGER; else if(strType.equals("CF_SQL_INT"))
-	 * return Types.INTEGER; else if(strType.equals("CF_SQL_LONGVARBINARY"))return Types.LONGVARBINARY;
-	 * else if(strType.equals("CF_SQL_LONGVARCHAR"))return Types.LONGVARCHAR; else
-	 * if(strType.equals("CF_SQL_MONEY")) return Types.DOUBLE; else if(strType.equals("CF_SQL_MONEY4"))
-	 * return Types.DOUBLE; else if(strType.equals("CF_SQL_NUMERIC")) return Types.NUMERIC; else
+	 * if(strType.equals("CF_SQL_DATE")) return Types.DATE; else
+	 * if(strType.equals("CF_SQL_DISTINCT")) return Types.DISTINCT; else
+	 * if(strType.equals("CF_SQL_DECIMAL")) return Types.DECIMAL; else
+	 * if(strType.equals("CF_SQL_DOUBLE")) return Types.DOUBLE; else
+	 * if(strType.equals("CF_SQL_FLOAT")) return Types.FLOAT; else
+	 * if(strType.equals("CF_SQL_IDSTAMP")) return CFTypes.IDSTAMP; else
+	 * if(strType.equals("CF_SQL_INTEGER")) return Types.INTEGER; else
+	 * if(strType.equals("CF_SQL_INT")) return Types.INTEGER; else
+	 * if(strType.equals("CF_SQL_LONGVARBINARY"))return Types.LONGVARBINARY; else
+	 * if(strType.equals("CF_SQL_LONGVARCHAR"))return Types.LONGVARCHAR; else
+	 * if(strType.equals("CF_SQL_MONEY")) return Types.DOUBLE; else
+	 * if(strType.equals("CF_SQL_MONEY4")) return Types.DOUBLE; else
+	 * if(strType.equals("CF_SQL_NUMERIC")) return Types.NUMERIC; else
 	 * if(strType.equals("CF_SQL_NULL")) return Types.NULL; else if(strType.equals("CF_SQL_REAL"))
 	 * return Types.REAL; else if(strType.equals("CF_SQL_REF")) return Types.REF; else
 	 * if(strType.equals("CF_SQL_REFCURSOR")) return CFTypes.CURSOR; else
-	 * if(strType.equals("CF_SQL_OTHER")) return Types.OTHER; else if(strType.equals("CF_SQL_SMALLINT"))
-	 * return Types.SMALLINT; else if(strType.equals("CF_SQL_STRUCT")) return Types.STRUCT; else
-	 * if(strType.equals("CF_SQL_TIME")) return Types.TIME; else if(strType.equals("CF_SQL_TIMESTAMP"))
-	 * return Types.TIMESTAMP; else if(strType.equals("CF_SQL_TINYINT")) return Types.TINYINT; else
+	 * if(strType.equals("CF_SQL_OTHER")) return Types.OTHER; else
+	 * if(strType.equals("CF_SQL_SMALLINT")) return Types.SMALLINT; else
+	 * if(strType.equals("CF_SQL_STRUCT")) return Types.STRUCT; else
+	 * if(strType.equals("CF_SQL_TIME")) return Types.TIME; else
+	 * if(strType.equals("CF_SQL_TIMESTAMP")) return Types.TIMESTAMP; else
+	 * if(strType.equals("CF_SQL_TINYINT")) return Types.TINYINT; else
 	 * if(strType.equals("CF_SQL_VARBINARY")) return Types.VARBINARY; else
 	 * if(strType.equals("CF_SQL_VARCHAR")) return Types.VARCHAR; else
 	 * if(strType.equals("CF_SQL_NVARCHAR")) return Types.NVARCHAR; else

--- a/core/src/main/java/lucee/runtime/sql/QueryPartitions.java
+++ b/core/src/main/java/lucee/runtime/sql/QueryPartitions.java
@@ -1,0 +1,303 @@
+/**
+ *
+ * Copyright (c) 2014, the Railo Company Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ **/
+package lucee.runtime.sql;
+
+import java.io.IOException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import lucee.commons.digest.MD5;
+import lucee.runtime.PageContext;
+import lucee.runtime.db.QoQ;
+import lucee.runtime.db.SQL;
+import lucee.runtime.exp.DatabaseException;
+import lucee.runtime.exp.PageException;
+import lucee.runtime.op.Caster;
+import lucee.runtime.sql.exp.ColumnExpression;
+import lucee.runtime.sql.exp.Expression;
+import lucee.runtime.sql.exp.Literal;
+import lucee.runtime.sql.exp.value.Value;
+import lucee.runtime.type.ArrayImpl;
+import lucee.runtime.type.Collection;
+import lucee.runtime.type.Collection.Key;
+import lucee.runtime.type.Query;
+import lucee.runtime.type.QueryImpl;
+
+public class QueryPartitions {
+	// Select expressions for target query
+	private Expression[] columns;
+	// Array of keys for fast lookup
+	private Collection.Key[] columnKeys;
+	// Needed for functions and aggregates but not explicitly part of the final select
+	private Set<Collection.Key> additionalColumns;
+	// Group by expressions
+	private Expression[] groupbys;
+	// Target query for column references
+	private QueryImpl target;
+	// Mapof partitioned query data. Key is unique string representing grouped data, value is a
+	// Query object representing the matching rows in that group/partition
+	private HashMap<String, QueryImpl> partitions = new HashMap<String, QueryImpl>();
+	// Reference to QoQ instance
+	private QoQ qoQ;
+	// SQL instance
+	private SQL sql;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param sql
+	 * @param columns
+	 * @param groupbys
+	 * @param target
+	 * @param additionalColumns
+	 * @param qoQ
+	 * @throws PageException
+	 */
+	public QueryPartitions(SQL sql, Expression[] columns, Expression[] groupbys, QueryImpl target, Set<String> additionalColumns, QoQ qoQ) throws PageException {
+		this.sql = sql;
+		this.qoQ = qoQ;
+		this.columns = columns;
+		this.groupbys = groupbys;
+		// This happens when using distinct with no group by
+		// Just assume we're grouping on the entire select list
+		if (this.groupbys.length == 0) {
+			this.groupbys = columns;
+		}
+		this.target = target;
+
+		// Convert these strings to Keys now so we don't do it over and over later
+		this.additionalColumns = new HashSet<Collection.Key>();
+		for (String col: additionalColumns) {
+			this.additionalColumns.add(Caster.toKey(col));
+		}
+		// Convert these Expression aliases to Keys now so we don't do it over and over later
+		this.columnKeys = new Collection.Key[columns.length];
+		for (int cell = 0; cell < columns.length; cell++) {
+			this.columnKeys[cell] = (Caster.toKey(columns[cell].getAlias()));
+		}
+	}
+
+	/**
+	 * Call this to add a single row to the proper partition finaizedColumnVals is true when all
+	 * data in the source Query is fully realized and there are no expressions left to evaluate
+	 * 
+	 * @param pc PageContext
+	 * @param source Source query to get data from
+	 * @param row Row to get data from
+	 * @param finalizedColumnVals If we're adding finalized data, just copy it across. Easy. This
+	 *            applies when distincting a result set after it's already been processed
+	 * @throws PageException
+	 */
+	public void addRow(PageContext pc, Query source, int row, boolean finalizedColumnVals) throws PageException {
+		// Generate unique key based on row data
+		String partitionKey = buildPartitionKey(pc, source, row, finalizedColumnVals);
+		// Create partition if necessary
+		if (!partitions.containsKey(partitionKey)) {
+			partitions.put(partitionKey, createPartition(target, source, finalizedColumnVals));
+		}
+		QueryImpl targetPartition = partitions.get(partitionKey);
+
+		targetPartition.addRow(1);
+
+		// If we're adding finalized data, just copy it across. Easy. This applies when distincting
+		// a result set after it's already been processed
+		if (finalizedColumnVals) {
+			Collection.Key[] sourceColKeys = source.getColumnNames();
+			Collection.Key[] targetColKeys = targetPartition.getColumnNames();
+			for (int col = 0; col < targetColKeys.length; col++) {
+				targetPartition.setAt(targetColKeys[col], targetPartition.getRecordcount(), source.getAt(sourceColKeys[col], row));
+			}
+
+		}
+		// For normal group by operations, we ONLY put real data in the partition. Operations will
+		// be added later, but there's no use filling up the partition with place holders
+		else {
+			for (int cell = 0; cell < columns.length; cell++) {
+				// Literal values get by alias
+				if (columns[cell] instanceof Value) {
+					Value v = (Value) columns[cell];
+
+					targetPartition.setAt(columnKeys[cell], targetPartition.getRecordcount(), source.getAt(Caster.toKey(v.getAlias()), row, null), true);
+				}
+				// A column expressions is set by column Key
+				else if (columns[cell] instanceof ColumnExpression) {
+					ColumnExpression ce = (ColumnExpression) columns[cell];
+
+					targetPartition.setAt(columnKeys[cell], targetPartition.getRecordcount(), source.getAt(ce.getColumn(), row, null), true);
+				}
+
+			}
+			// Populate additional columns needed for operations but are not found in the select
+			// list above
+			for (Collection.Key col: additionalColumns) {
+				if (source.containsKey(col)) {
+					targetPartition.setAt(col, targetPartition.getRecordcount(), source.getAt(col, row, null));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Generate a unique string that represents the column data being grouped on
+	 * 
+	 * @param pc PageContext
+	 * @param source QueryImpl to get data from. Note, operations have not yet been processed
+	 * @param row Row to get data from
+	 * @param finalizedColumnVals If we're adding finalized data, just copy it across. Easy. This
+	 *            applies when distincting a result set after it's already been processed
+	 * @return unique string
+	 * @throws PageException
+	 */
+	public String buildPartitionKey(PageContext pc, Query source, int row, boolean finalizedColumnVals) throws PageException {
+		String partitionKey = "";
+		for (int cell = 0; cell < groupbys.length; cell++) {
+			String value;
+			// This is when reading columns out of a previous union query that doesn't have any
+			// expressions in it, just literal values It's important that we are just getting this
+			// value by index since the group by expressions may be a reference to the select
+			// expressions from another query object
+			if (finalizedColumnVals) {
+				value = Caster.toString(source.getAt(source.getColumnNames()[cell], row));
+			}
+
+			else {
+				value = Caster.toString(qoQ.getValue(pc, sql, source, row, null, groupbys[cell]));
+			}
+			// Internally Java uses a StringBuilder for this concatenation
+			partitionKey += createUniqueValue(value, groupbys[cell].toString(false));
+		}
+		return partitionKey;
+	}
+
+	/**
+	 * Helper function to turn column data into string
+	 * 
+	 * @param value
+	 * @param col
+	 * @return
+	 * @throws PageException
+	 */
+	private String createUniqueValue(String value, String col) throws PageException {
+
+		// There doesn't seem to be a key length on a HashMap, but it seems like a good
+		// idea to hash long values. Not hashing everything, because that is slower.
+		if (value.length() > 255) {
+			try {
+				return MD5.getDigestAsString(value);
+			}
+			catch (IOException e) {
+				throw new DatabaseException("Unable to hash query value for column [" + col + "] for partitioning.", e.getMessage(), null, null);
+			}
+		}
+		else {
+			// Inject some characters to prevent accidental overlap of data been nearby columns
+			return "______________" + value;
+		}
+	}
+
+	/**
+	 * Get number of partitions
+	 * 
+	 * @return
+	 */
+	public int getPartitionCount() {
+		return partitions.size();
+	}
+
+	/**
+	 * Get partition Map
+	 * 
+	 * @return
+	 */
+	public HashMap<String, QueryImpl> getPartitions() {
+		return partitions;
+	}
+
+	/**
+	 * Get array of grouped QueryImpl object
+	 * 
+	 * @return
+	 */
+	public QueryImpl[] getPartitionArray() {
+		return (QueryImpl[]) partitions.values().toArray();
+	}
+
+	/**
+	 * Create new QueryImpl for a partition. Needs to have all ColumnExpressions in the final select
+	 * as well as any additional columns required for operation expressions
+	 * 
+	 * @param target Query for target data (for column refernces)
+	 * @param source source query we're getting data from
+	 * @param finalizedColumnValsfinalizedColumnVals If we're adding finalized data, just copy it
+	 *            across. Easy. This applies when distincting a result set after it's already been
+	 *            processed
+	 * @return Empty QueryImpl with all the needed columns
+	 * @throws PageException
+	 */
+	private QueryImpl createPartition(Query target, Query source, boolean finalizedColumnVals) throws PageException {
+		QueryImpl newTarget = new QueryImpl(new Collection.Key[0], 0, "query", sql);
+
+		// If we're just distincting fully-realized data, this is just a simple lookup
+		if (finalizedColumnVals) {
+			for (int i = 0; i < columns.length; i++) {
+				ColumnExpression ce = (ColumnExpression) columns[i];
+				newTarget.addColumn(ce.getColumn(), new ArrayImpl(), target.getColumn(target.getColumnNames()[i]).getType());
+			}
+		}
+		// Standard group by
+		else {
+
+			Expression[] expSelects = columns;
+			int selCount = expSelects.length;
+
+			// Loop over all select expressions and add column to new query for every column
+			// expression and literal
+			for (int i = 0; i < selCount; i++) {
+				Expression expSelect = expSelects[i];
+				Key alias = Caster.toKey(expSelect.getAlias());
+
+				if (expSelect instanceof ColumnExpression) {
+					ColumnExpression ce = (ColumnExpression) expSelect;
+
+					int type = Types.OTHER;
+					if (!"?".equals(ce.getColumnName())) type = source.getColumn(Caster.toKey(ce.getColumnName())).getType();
+
+					newTarget.addColumn(alias, new ArrayImpl(), type);
+				}
+				else if (expSelect instanceof Literal) {
+					newTarget.addColumn(alias, new ArrayImpl(), Types.OTHER);
+				}
+			}
+
+			// As well as any additional columns that need to be used for expressions and aggregates
+			// but don't appear in the final select.
+			for (Collection.Key col: additionalColumns) {
+				// This check is here because it seems the SelectsParser also lists table names as
+				// ColumnExpressions
+				if (source.containsKey(col)) {
+					newTarget.addColumn(col, new ArrayImpl(), source.getColumn(col).getType());
+				}
+			}
+		}
+		return newTarget;
+	}
+
+}

--- a/core/src/main/java/lucee/runtime/sql/Select.java
+++ b/core/src/main/java/lucee/runtime/sql/Select.java
@@ -19,15 +19,23 @@
 package lucee.runtime.sql;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import lucee.runtime.sql.exp.Column;
+import lucee.runtime.sql.exp.ColumnExpression;
 import lucee.runtime.sql.exp.Expression;
 import lucee.runtime.sql.exp.op.Operation;
+import lucee.runtime.sql.exp.op.OperationAggregate;
 import lucee.runtime.sql.exp.value.ValueNumber;
+import lucee.runtime.type.Collection.Key;
+import lucee.runtime.type.Query;
 
 public class Select {
 	private List selects = new ArrayList();
+	private Set<String> additionalColumns = new HashSet();
 	private List froms = new ArrayList();
 	private Operation where;
 	private List groupbys = new ArrayList();
@@ -41,6 +49,27 @@ public class Select {
 		select.setIndex(selects.size());
 	}
 
+	public void expandAsterisks(Query source) {
+		Expression[] selectCols = getSelects();
+		this.selects.clear();
+		Iterator<Key> it;
+		Key k;
+		for (Expression col: selectCols) {
+			if (col.getAlias().equals("*")) {
+				it = source.keyIterator();
+				while (it.hasNext()) {
+					k = it.next();
+					addSelectExpression(new ColumnExpression(k.getString(), 0));
+				}
+			}
+			else {
+				addSelectExpression(col);
+			}
+		}
+		// We may not need all of these now.
+		calcAdditionalColumns(getAdditionalColumns());
+	}
+
 	public void addFromExpression(Column exp) {
 		froms.add(exp);
 		exp.setIndex(froms.size());
@@ -50,12 +79,29 @@ public class Select {
 		this.where = where;
 	}
 
-	public void addGroupByExpression(Column col) {
+	public void addGroupByExpression(Expression col) {
 		this.groupbys.add(col);
 	}
 
 	public void setTop(ValueNumber top) {
 		this.top = top;
+	}
+
+	public void calcAdditionalColumns(Set<String> allColumns) {
+		// Remove any columns we are explicitly selecting
+		for (Expression expSelect: getSelects()) {
+			if (expSelect instanceof ColumnExpression) {
+				ColumnExpression ce = (ColumnExpression) expSelect;
+				allColumns.remove(ce.getColumnName());
+			}
+		}
+		// What's left are columns used by functions and aggregates,
+		// but not directly part of the final result
+		this.additionalColumns = allColumns;
+	}
+
+	public Set<String> getAdditionalColumns() {
+		return this.additionalColumns;
 	}
 
 	/**
@@ -68,9 +114,9 @@ public class Select {
 	/**
 	 * @return the groupbys
 	 */
-	public Column[] getGroupbys() {
+	public Expression[] getGroupbys() {
 		if (groupbys == null) return new Column[0];
-		return (Column[]) groupbys.toArray(new Column[groupbys.size()]);
+		return (Expression[]) groupbys.toArray(new Expression[groupbys.size()]);
 	}
 
 	/**
@@ -85,6 +131,19 @@ public class Select {
 	 */
 	public Expression[] getSelects() {
 		return (Expression[]) selects.toArray(new Expression[selects.size()]);
+	}
+
+	/**
+	 * @return whether at least one select is an aggregate
+	 */
+	public boolean hasAggregateSelect() {
+		for (Expression col: getSelects()) {
+			if (col instanceof OperationAggregate) {
+				return true;
+			}
+		}
+		return false;
+
 	}
 
 	/**

--- a/core/src/main/java/lucee/runtime/sql/Select.java
+++ b/core/src/main/java/lucee/runtime/sql/Select.java
@@ -141,6 +141,9 @@ public class Select {
 			if (col instanceof OperationAggregate) {
 				return true;
 			}
+			if (col instanceof Operation && ((Operation) col).hasAggregate()) {
+				return true;
+			}
 		}
 		return false;
 

--- a/core/src/main/java/lucee/runtime/sql/SelectParser.java
+++ b/core/src/main/java/lucee/runtime/sql/SelectParser.java
@@ -105,13 +105,19 @@ public class SelectParser {
 			raw.removeSpace();
 
 			// group by
-			if (raw.forwardIfCurrentAndNoWordNumberAfter("group by")) {
-				groupByExpressions(raw, select);
+			if (raw.forwardIfCurrentAndNoWordNumberAfter("group")) {
 				raw.removeSpace();
+				if (raw.forwardIfCurrentAndNoWordNumberAfter("by")) {
+					groupByExpressions(raw, select);
+					raw.removeSpace();
 
-				// having
-				if (raw.forwardIfCurrentAndNoWordNumberAfter("having")) havingExpressions(raw, select);
-				raw.removeSpace();
+					// having
+					if (raw.forwardIfCurrentAndNoWordNumberAfter("having")) havingExpressions(raw, select);
+					raw.removeSpace();
+				}
+				else {
+					throw new SQLParserException("Incomplete group by clause (stop at:" + raw.getCurrent() + ")");
+				}
 			}
 			select.calcAdditionalColumns(allColumns);
 			allColumns = new HashSet<String>();
@@ -138,7 +144,15 @@ public class SelectParser {
 		while (runAgain);
 
 		// order by
-		if (raw.forwardIfCurrentAndNoWordNumberAfter("order by")) orderByExpressions(raw, selects);
+		if (raw.forwardIfCurrentAndNoWordNumberAfter("order")) {
+			raw.removeSpace();
+			if (raw.forwardIfCurrentAndNoWordNumberAfter("by")) {
+				orderByExpressions(raw, selects);
+			}
+			else {
+				throw new SQLParserException("Incomplete order by clause (stop at:" + raw.getCurrent() + ")");
+			}
+		}
 		raw.removeSpace();
 
 		if (raw.forwardIfCurrent(';')) raw.removeSpace();

--- a/core/src/main/java/lucee/runtime/sql/SelectParser.java
+++ b/core/src/main/java/lucee/runtime/sql/SelectParser.java
@@ -722,11 +722,18 @@ public class SelectParser {
 		else if (!(raw.isCurrentLetter() || raw.isCurrent('*') || raw.isCurrent('?') || raw.isCurrent('_'))) return null;
 
 		int start = raw.getPos();
+		boolean first = true;
 		do {
 			raw.next();
-			if (!(raw.isCurrentLetter() || raw.isCurrentBetween('0', '9') || raw.isCurrent('*') || raw.isCurrent('?') || raw.isCurrent('_'))) {
+			if (first && !(raw.isCurrentLetter() || raw.isCurrentBetween('0', '9') || raw.isCurrent('*') || raw.isCurrent('?') || raw.isCurrent('_'))) {
 				break;
 			}
+			// Don't look for stuff like * after first letter or text like col1*col2 will get read
+			// as one single column name
+			else if (!(raw.isCurrentLetter() || raw.isCurrentBetween('0', '9') || raw.isCurrent('_'))) {
+				break;
+			}
+			first = false;
 		}
 		while (raw.isValidIndex());
 		String str = raw.substring(start, raw.getPos() - start);

--- a/core/src/main/java/lucee/runtime/sql/SelectParser.java
+++ b/core/src/main/java/lucee/runtime/sql/SelectParser.java
@@ -368,12 +368,12 @@ public class SelectParser {
 			// IS [NOT] NULL
 			else if (raw.isCurrent("is ")) {
 				int start = raw.getPos();
-				if (raw.forwardIfCurrentAndNoWordNumberAfter("is null")) {
+				if (raw.forwardIfCurrentAndNoWordNumberAfter("is", "null")) {
 					raw.removeSpace();
 					return new Operation1(expr, Operation.OPERATION1_IS_NULL);
 
 				}
-				else if (raw.forwardIfCurrentAndNoWordNumberAfter("is not null")) {
+				else if (raw.forwardIfCurrentAndNoWordNumberAfter("is", "not", "null")) {
 					raw.removeSpace();
 					return new Operation1(expr, Operation.OPERATION1_IS_NOT_NULL);
 
@@ -385,7 +385,7 @@ public class SelectParser {
 			}
 
 			// not in
-			else if (raw.forwardIfCurrent("not in", '(')) {
+			else if (raw.forwardIfCurrent("not", "in", '(')) {
 				expr = new OperationN("not_in", readArguments(raw, expr));
 				hasChanged = true;
 			}
@@ -395,7 +395,7 @@ public class SelectParser {
 				hasChanged = true;
 			}
 			// not like
-			if (raw.forwardIfCurrentAndNoWordNumberAfter("not like")) {
+			if (raw.forwardIfCurrentAndNoWordNumberAfter("not", "like")) {
 				expr = decisionOpCreate(raw, Operation.OPERATION2_NOT_LIKE, expr);
 				hasChanged = true;
 			}
@@ -577,11 +577,21 @@ public class SelectParser {
 		raw.removeSpace();
 		if (raw.forwardIfCurrent('(')) {
 			String thisName = column.getFullName().toLowerCase();
-			if (thisName.equals("avg") || thisName.equals("count") || thisName.equals("max") || thisName.equals("min") || thisName.equals("sum")) {
-				return new OperationAggregate(column.getFullName().toLowerCase(), readArguments(raw));
+			if (thisName.equals("avg") || thisName.equals("max") || thisName.equals("min") || thisName.equals("sum")) {
+				return new OperationAggregate(thisName, readArguments(raw));
+			}
+			else if (thisName.equals("count")) {
+				raw.removeSpace();
+				if (raw.forwardIfCurrent("all")) {
+					return new OperationAggregate(thisName, readArguments(raw, new ValueString("all")));
+				}
+				if (raw.forwardIfCurrent("distinct")) {
+					return new OperationAggregate(thisName, readArguments(raw, new ValueString("distinct")));
+				}
+				return new OperationAggregate(thisName, readArguments(raw));
 			}
 			else {
-				return new OperationN(column.getFullName().toLowerCase(), readArguments(raw));
+				return new OperationN(thisName, readArguments(raw));
 			}
 		}
 		return column;

--- a/core/src/main/java/lucee/runtime/sql/Selects.java
+++ b/core/src/main/java/lucee/runtime/sql/Selects.java
@@ -30,19 +30,45 @@ import lucee.runtime.sql.exp.value.ValueNumber;
 
 public class Selects {
 
-	private List<Column> orderbys = new ArrayList<Column>();
+	private List<Expression> orderbys = new ArrayList<Expression>();
 	private List<Select> selects = new ArrayList<Select>();
 
-	public void addOrderByExpression(Column exp) {
+	public void addOrderByExpression(Expression exp) {
 		this.orderbys.add(exp);
+	}
+
+	public void calcOrderByExpressions() {
+		if (getSelects().length == 1) {
+			// Check if this order by is already present in the select
+			for (Expression exp: getOrderbys()) {
+				// For each expression in the select column list
+				for (Expression col: getSelects()[0].getSelects()) {
+					// If this same expression is present, regardless of alias...
+					if (col.toString(true).equals(exp.toString(true)) || col.getAlias().equals(exp.getAlias())) {
+						// Then set our order by's index to point to the index
+						// of the column that has that data
+						exp.setIndex(col.getIndex());
+						break;
+					}
+				}
+				// Didn't find it? It means we're ordering on a column we're not selecting like
+				// SELECT col1 FROM table ORDER BY col2
+				if (exp.getIndex() == 0) {
+					// We need to add a phantom column into our result so
+					// we can track the value and order on it
+					exp.setAlias("__order_by_expression__" + getSelects()[0].getSelects().length);
+					getSelects()[0].addSelectExpression(exp);
+				}
+			}
+		}
 	}
 
 	/**
 	 * @return the orderbys
 	 */
-	public Column[] getOrderbys() {
-		if (orderbys == null) return new Column[0];
-		return orderbys.toArray(new Column[orderbys.size()]);
+	public Expression[] getOrderbys() {
+		if (orderbys == null) return new Expression[0];
+		return orderbys.toArray(new Expression[orderbys.size()]);
 	}
 
 	public void addSelect(Select select) {
@@ -108,7 +134,7 @@ public class Selects {
 			}
 
 			// group by
-			Column[] gbs = s.getGroupbys();
+			Expression[] gbs = s.getGroupbys();
 			if (gbs.length > 0) {
 				sb.append("group by\n\t");
 				first = true;
@@ -133,7 +159,7 @@ public class Selects {
 		// order by
 		if (__selects.orderbys != null && __selects.orderbys.size() > 0) {
 			sb.append("order by\n\t");
-			Iterator<Column> it = __selects.orderbys.iterator();
+			Iterator<Expression> it = __selects.orderbys.iterator();
 			Expression exp;
 			boolean first = true;
 			while (it.hasNext()) {

--- a/core/src/main/java/lucee/runtime/sql/exp/Column.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/Column.java
@@ -18,6 +18,7 @@
  **/
 package lucee.runtime.sql.exp;
 
+import lucee.runtime.PageContext;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.type.Collection;
 import lucee.runtime.type.Query;
@@ -27,16 +28,20 @@ public interface Column extends Expression {
 
 	public Collection.Key getColumn();
 
+	public Collection.Key getColumnAlias();
+
 	public String getTable();
 
 	public boolean hasBracked();
 
 	public void hasBracked(boolean b);
 
+	public boolean isParam();
+
 	public int getColumnIndex();
 
-	public Object getValue(Query qry, int row) throws PageException;
+	public Object getValue(PageContext pc, Query qry, int row) throws PageException;
 
-	public Object getValue(Query qry, int row, Object defaultValue);
+	public Object getValue(PageContext pc, Query qry, int row, Object defaultValue);
 
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/ExpressionSupport.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/ExpressionSupport.java
@@ -67,4 +67,8 @@ public abstract class ExpressionSupport implements Expression {
 	public boolean isDirectionBackward() {
 		return directionBackward;
 	}
+
+	@Override
+	public void reset() {}
+
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation.java
@@ -51,4 +51,7 @@ public interface Operation extends Expression {
 
 	public static final int OPERATION3_BETWEEN = 50;
 	public static final int OPERATION3_LIKE = 51;
+
+	public boolean hasAggregate();
+
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation1.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation1.java
@@ -63,4 +63,15 @@ public class Operation1 extends ExpressionSupport implements Operation {
 		}
 	}
 
+	@Override
+	public boolean hasAggregate() {
+		if (exp instanceof OperationAggregate) {
+			return true;
+		}
+		if (exp instanceof Operation && ((Operation) exp).hasAggregate()) {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation1.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation1.java
@@ -56,4 +56,11 @@ public class Operation1 extends ExpressionSupport implements Operation {
 		return toString(true) + " as " + getAlias();
 	}
 
+	@Override
+	public void reset() {
+		if (exp != null) {
+			exp.reset();
+		}
+	}
+
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation2.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation2.java
@@ -125,4 +125,21 @@ public class Operation2 extends ExpressionSupport implements Operation {
 		}
 	}
 
+	@Override
+	public boolean hasAggregate() {
+		if (left instanceof OperationAggregate) {
+			return true;
+		}
+		if (left instanceof Operation && ((Operation) left).hasAggregate()) {
+			return true;
+		}
+		if (right instanceof OperationAggregate) {
+			return true;
+		}
+		if (right instanceof Operation && ((Operation) right).hasAggregate()) {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation2.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation2.java
@@ -115,4 +115,14 @@ public class Operation2 extends ExpressionSupport implements Operation {
 		return right;
 	}
 
+	@Override
+	public void reset() {
+		if (left != null) {
+			left.reset();
+		}
+		if (right != null) {
+			right.reset();
+		}
+	}
+
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation3.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation3.java
@@ -78,4 +78,17 @@ public class Operation3 extends ExpressionSupport implements Operation {
 	public Expression getRight() {
 		return right;
 	}
+
+	@Override
+	public void reset() {
+		if (left != null) {
+			left.reset();
+		}
+		if (right != null) {
+			right.reset();
+		}
+		if (exp != null) {
+			exp.reset();
+		}
+	}
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation3.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation3.java
@@ -91,4 +91,27 @@ public class Operation3 extends ExpressionSupport implements Operation {
 			exp.reset();
 		}
 	}
+
+	@Override
+	public boolean hasAggregate() {
+		if (left instanceof OperationAggregate) {
+			return true;
+		}
+		if (left instanceof Operation && ((Operation) left).hasAggregate()) {
+			return true;
+		}
+		if (right instanceof OperationAggregate) {
+			return true;
+		}
+		if (right instanceof Operation && ((Operation) right).hasAggregate()) {
+			return true;
+		}
+		if (exp instanceof OperationAggregate) {
+			return true;
+		}
+		if (exp instanceof Operation && ((Operation) exp).hasAggregate()) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/OperationAggregate.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/OperationAggregate.java
@@ -16,26 +16,14 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  * 
  **/
-package lucee.runtime.sql.exp;
+package lucee.runtime.sql.exp.op;
 
-public interface Expression {
-	public void setIndex(int index);
+import java.util.List;
 
-	public int getIndex();
+public class OperationAggregate extends OperationN {
 
-	public String getAlias();
+	public OperationAggregate(String operator, List operants) {
+		super(operator, operants);
+	}
 
-	public void setAlias(String alias);
-
-	public boolean hasAlias();
-
-	public boolean hasIndex();
-
-	public String toString(boolean noAlias);
-
-	public void setDirectionBackward(boolean b);
-
-	public void reset();
-
-	public boolean isDirectionBackward();
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/OperationN.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/OperationN.java
@@ -77,4 +77,19 @@ public class OperationN extends ExpressionSupport implements Operation {
 			exp.reset();
 		}
 	}
+
+	@Override
+	public boolean hasAggregate() {
+		Iterator it = operants.iterator();
+		while (it.hasNext()) {
+			Expression exp = (Expression) it.next();
+			if (exp instanceof OperationAggregate) {
+				return true;
+			}
+			if (exp instanceof Operation && ((Operation) exp).hasAggregate()) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/core/src/main/java/lucee/runtime/sql/exp/op/OperationN.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/OperationN.java
@@ -68,4 +68,13 @@ public class OperationN extends ExpressionSupport implements Operation {
 	public String getOperator() {
 		return operator;
 	}
+
+	@Override
+	public void reset() {
+		Iterator it = operants.iterator();
+		while (it.hasNext()) {
+			Expression exp = (Expression) it.next();
+			exp.reset();
+		}
+	}
 }

--- a/core/src/main/java/lucee/runtime/type/KeyImpl.java
+++ b/core/src/main/java/lucee/runtime/type/KeyImpl.java
@@ -192,7 +192,8 @@ public class KeyImpl implements Collection.Key, Castable, Comparable, Externaliz
 			return key.equalsIgnoreCase((String) other);
 		}
 		if (other instanceof Key) {
-			return ucKey.equalsIgnoreCase(((Key) other).getUpperString());
+			// Both strings are guaranteed to be upper case
+			return ucKey.equals(((Key) other).getUpperString());
 		}
 		return false;
 	}

--- a/core/src/main/java/lucee/runtime/type/QueryColumnImpl.java
+++ b/core/src/main/java/lucee/runtime/type/QueryColumnImpl.java
@@ -321,6 +321,13 @@ public class QueryColumnImpl implements QueryColumnPro, Objects {
 
 	@Override
 	public Object set(int row, Object value) throws DatabaseException {
+		return set(row, value, false);
+	}
+
+	// Pass trustType=true to optimize operations such as QoQ where lots of values are being moved
+	// around between query objects but we know the types are already fine and don't need to
+	// redefine them every time
+	public Object set(int row, Object value, boolean trustType) throws DatabaseException {
 		query.disableIndex();
 		// query.disconnectCache();
 		if (row < 1) throw new DatabaseException("invalid row number [" + row + "]", "valid row numbers a greater or equal to one", null, null);
@@ -329,7 +336,7 @@ public class QueryColumnImpl implements QueryColumnPro, Objects {
 			throw new DatabaseException("invalid row number [" + row + "]", "valid row numbers goes from 1 to " + size, null, null);
 		}
 		synchronized (sync) {
-			value = reDefineType(value);
+			if (!trustType) value = reDefineType(value);
 			data[row - 1] = value;
 			return value;
 		}
@@ -611,7 +618,8 @@ public class QueryColumnImpl implements QueryColumnPro, Objects {
 			trg.key = this.key;
 			if (trg.query != null) trg.query.disableIndex();
 
-			// we first get data local, because length of the object cannot be changed, the safes us from
+			// we first get data local, because length of the object cannot be changed, the safes us
+			// from
 			// modifications from outside
 			Object[] data = this.data;
 			trg.data = new Object[data.length];
@@ -722,7 +730,8 @@ public class QueryColumnImpl implements QueryColumnPro, Objects {
 		throwNotAllowedToAlter();
 		return false;
 		/*
-		 * Iterator<? extends Object> it = c.iterator(); while(it.hasNext()){ add(it.next()); } return true;
+		 * Iterator<? extends Object> it = c.iterator(); while(it.hasNext()){ add(it.next()); }
+		 * return true;
 		 */
 	}
 
@@ -730,8 +739,8 @@ public class QueryColumnImpl implements QueryColumnPro, Objects {
 		throwNotAllowedToAlter();
 		return false;
 		/*
-		 * Iterator<? extends Object> it = c.iterator(); while(it.hasNext()){ setEL(++index,it.next()); }
-		 * return true;
+		 * Iterator<? extends Object> it = c.iterator(); while(it.hasNext()){
+		 * setEL(++index,it.next()); } return true;
 		 */
 	}
 
@@ -775,8 +784,8 @@ public class QueryColumnImpl implements QueryColumnPro, Objects {
 		throwNotAllowedToAlter();
 		return false;
 		/*
-		 * boolean hasChanged=false; Iterator<? extends Object> it = c.iterator(); while(it.hasNext()){
-		 * if(remove(it.next())) { hasChanged=true; } } return hasChanged;
+		 * boolean hasChanged=false; Iterator<? extends Object> it = c.iterator();
+		 * while(it.hasNext()){ if(remove(it.next())) { hasChanged=true; } } return hasChanged;
 		 */
 	}
 

--- a/core/src/main/java/lucee/runtime/type/QueryImpl.java
+++ b/core/src/main/java/lucee/runtime/type/QueryImpl.java
@@ -138,7 +138,8 @@ public class QueryImpl implements Query, Objects, QueryResult {
 	private TemplateLine templateLine;
 
 	private Collection.Key indexName;
-	private Map<Collection.Key, Integer> indexes;// = new ConcurrentHashMap<Collection.Key,Integer>();
+	private Map<Collection.Key, Integer> indexes;// = new
+													// ConcurrentHashMap<Collection.Key,Integer>();
 
 	@Override
 	public String getTemplate() {
@@ -712,7 +713,8 @@ public class QueryImpl implements Query, Objects, QueryResult {
 
 			// Only allow column names that are valid variable name
 			// if(!Decision.isSimpleVariableName(columnNames[i]))
-			// throw new DatabaseException("invalid column name ["+columnNames[i]+"] for query", "column names
+			// throw new DatabaseException("invalid column name ["+columnNames[i]+"] for query",
+			// "column names
 			// must start with a letter and can be followed by
 			// letters numbers and underscores [_]. RegExp:[a-zA-Z][a-zA-Z0-9_]*",null,null,null);
 
@@ -731,8 +733,8 @@ public class QueryImpl implements Query, Objects, QueryResult {
 	}
 
 	/*
-	 * public QueryImpl(Collection.Key[] columnNames, QueryColumn[] columns, String name,long exeTime,
-	 * boolean isCached,SQL sql) throws DatabaseException { this.columnNames=columnNames;
+	 * public QueryImpl(Collection.Key[] columnNames, QueryColumn[] columns, String name,long
+	 * exeTime, boolean isCached,SQL sql) throws DatabaseException { this.columnNames=columnNames;
 	 * this.columns=columns; this.exeTime=exeTime; this.isCached=isCached; this.name=name;
 	 * this.columncount=columnNames.length; this.recordcount=columns.length==0?0:columns[0].size();
 	 * this.sql=sql;
@@ -1018,9 +1020,16 @@ public class QueryImpl implements Query, Objects, QueryResult {
 
 	@Override
 	public Object setAt(Collection.Key key, int row, Object value) throws PageException {
+		return setAt(key, row, value, false);
+	}
+
+	// Pass trustType=true to optimize operations such as QoQ where lots of values are being moved
+	// around between query objects but we know the types are already fine and don't need to
+	// redefine them every time
+	public Object setAt(Collection.Key key, int row, Object value, boolean trustType) throws PageException {
 		int index = getIndexFromKey(key);
 		if (index != -1) {
-			return columns[index].set(row, value);
+			return columns[index].set(row, value, trustType);
 		}
 		throw new DatabaseException("column [" + key + "] does not exist", "columns are [" + getColumnlist(getKeyCase(ThreadLocalPageContext.get())) + "]", sql, null);
 	}
@@ -1219,7 +1228,8 @@ public class QueryImpl implements Query, Objects, QueryResult {
 
 		if (getIndexFromKey(columnName) != -1) throw new DatabaseException("column name [" + columnName.getString() + "] already exist", null, sql, null);
 		if (content.size() != getRecordcount()) {
-			// throw new DatabaseException("array for the new column has not the same size like the query
+			// throw new DatabaseException("array for the new column has not the same size like the
+			// query
 			// (arrayLen!=query.recordcount)");
 			if (content.size() > getRecordcount()) addRow(content.size() - getRecordcount());
 			else content.setEL(getRecordcount(), "");
@@ -1245,8 +1255,8 @@ public class QueryImpl implements Query, Objects, QueryResult {
 	}
 
 	/*
-	 * * if this query is still connected with cache (same query also in cache) it will disconnetd from
-	 * cache (clone object and add clone to cache)
+	 * * if this query is still connected with cache (same query also in cache) it will disconnetd
+	 * from cache (clone object and add clone to cache)
 	 */
 	// protected void disconnectCache() {}
 

--- a/core/src/main/java/lucee/runtime/type/QueryImpl.java
+++ b/core/src/main/java/lucee/runtime/type/QueryImpl.java
@@ -1318,7 +1318,9 @@ public class QueryImpl implements Query, Objects, QueryResult {
 	@Override
 	public synchronized void rename(Collection.Key columnName, Collection.Key newColumnName) throws ExpressionException {
 		int index = getIndexFromKey(columnName);
-		if (index == -1) throw new ExpressionException("invalid column name definitions");
+		if (index == -1) {
+			throw new ExpressionException("Cannot rename column [" + columnName.getString() + "] to [" + newColumnName.getString() + "], original column doesn't exist");
+		}
 		columnNames[index] = newColumnName;
 		columns[index].setKey(newColumnName);
 	}

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,2 @@
 !*.class
+functions/datasource/cacheClear/

--- a/test/tickets/LDEV3042.cfc
+++ b/test/tickets/LDEV3042.cfc
@@ -1,0 +1,321 @@
+component extends="org.lucee.cfml.test.LuceeTestCase"	{
+
+	function beforeAll() {
+			employees = queryNew( 'name,age,email,department,isContract,yearsEmployed,sickDaysLeft,hireDate,isActive', 'varchar,varchar,varchar,varchar,boolean,integer,integer,date,boolean', [
+			[ 'John Doe',28,'John@company.com','Acounting',false,2,4,createDate(2010,1,21),true ],
+			[ 'Jane Doe',22,'Jane@company.com','Acounting',false,0,8,createDate(2011,2,21),true ],
+			[ 'Bane Doe',28,'Bane@company.com','Acounting',true,3,2,createDate(2012,3,21),true ],
+			[ 'Tom Smith',25,'Tom@company.com','Acounting',false,6,4,createDate(2013,4,21),false ],
+			[ 'Harry Johnson',38,'Harry@company.com','IT',false,8,6,createDate(2014,5,21),true ],
+			[ 'Jason Wood',37,'Jason@company.com','IT',false,19,4,createDate(2015,6,21),true ],
+			[ 'Doris Calhoun',67,'Doris@company.com','IT',true,3,6,createDate(2016,7,21),true ],
+			[ 'Mary Root',17,'Mary@company.com','IT',false,8,2,createDate(2017,8,21),true ],
+			[ 'Aurthur Duff',23,'Aurthur@company.com','IT',false,4,0,createDate(2018,9,21),true ],
+			[ 'Luis Hake',29,'Luis@company.com','IT',true,9,5,createDate(2019,10,21),true ],
+			[ 'Gavin Bezos',46,'Gavin@company.com','HR',false,2,5,createDate(2020,11,21),false ],
+			[ 'Nancy Garmon',57,'Nancy@company.com','HR',false,14,9,createDate(2005,12,21),true ],
+			[ 'Tom Zuckerburg',27,'Tom@company.com','HR',true,16,10,createDate(2006,1,21),true ],
+			[ 'Richard Gates',62,'Richard@company.com','Executive',false,11,1,createDate(2007,2,21),true ],
+			[ 'Amy Merryweather',58,'Amy@company.com','Executive',false,12,2,createDate(2008,3,21),true ]
+			] );
+
+	}
+
+	function run( testResults , testBox ) {
+
+		describe( 'QofQ' , function(){
+
+			it( 'Can select *' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT * FROM employees",
+					options = { dbtype: 'query' }
+				);
+				expect( actual ).toBeQuery();
+				expect( actual.recordcount ).toBe( employees.recordcount );
+			});
+
+			it( 'Can select with functions' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT upper(name), lower(email), coalesce( null, age ) FROM employees",
+					options = { dbtype: 'query' }
+				);
+				expect( actual.recordcount ).toBe( employees.recordcount );
+			});
+
+			it( 'Can select with functions that are aliased' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT upper(name) as name, lower(email) email, coalesce( null, age ) as foo FROM employees",
+					options = { dbtype: 'query' }
+				);
+				expect( actual.recordcount ).toBe( employees.recordcount );
+			});
+				
+			it( 'Can select with order bys' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT * from employees ORDER BY department, isActive desc, name, email",
+					options = { dbtype: 'query' }
+				);
+				expect( actual.recordcount ).toBe( 15 );
+			});
+				
+			it( 'Can order by alias' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT department as dept from employees ORDER BY dept",
+					options = { dbtype: 'query' }
+				);
+				expect( actual.recordcount ).toBe( 15 );
+			});
+				
+			it( 'Can order by literal' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT department as dept from employees ORDER BY 'test', 'foo', 7, false",
+					options = { dbtype: 'query' }
+				);
+				expect( actual.recordcount ).toBe( 15 );
+			});
+				
+			it( 'Can order by columns not in select' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT department from employees ORDER BY department, isActive desc, name, email",
+					options = { dbtype: 'query' }
+				);
+				expect( actual.recordcount ).toBe( 15 );
+			});
+
+			describe( 'Distinct' , function(){
+		
+				it( 'Can select distinct' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT distinct department FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 4 );
+				});
+		
+				it( 'Can select distinct with order by' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT distinct department FROM employees order by department",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 4 );
+				});
+	
+				it( 'Can select distinct with top' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT top 2 distinct department as foo FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 2 );
+				});
+	
+				it( 'Can select distinct with maxrows' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT distinct department FROM employees",
+						options = { dbtype: 'query', maxrows: 2 }
+					);
+					expect( actual.recordcount ).toBe( 2 );
+				});
+	
+				it( 'Can select distinct with maxrows' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT distinct department FROM employees",
+						options = { dbtype: 'query', maxrows: 2 }
+					);
+					expect( actual.recordcount ).toBe( 2 );
+				});
+	
+				it( 'Can select distinct with *' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT distinct * FROM employees",
+						options = { dbtype: 'query'}
+					);
+					expect( actual.recordcount ).toBe( employees.recordcount );
+				});
+				
+			});
+
+			describe( 'Query Union' , function(){
+				
+					it( 'Can union' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT * FROM employees
+							union
+							SELECT * FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 15 );
+				});
+				
+				it( 'Can union all' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT * FROM employees
+							union all
+							SELECT * FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 30 );
+				});
+				
+				it( 'Can union distinct' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT * FROM employees
+							union distinct
+							SELECT * FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 15 );
+				});
+				
+				it( 'Can union with top' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT top 2 * FROM employees
+							union all
+							SELECT top 3 * FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 5 );
+				});
+				
+				it( 'Can union with maxrows' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT * FROM employees
+							union all
+							SELECT * FROM employees",
+						options = { dbtype: 'query', maxrows: 2  }
+					);
+					expect( actual.recordcount ).toBe( 2 );
+				});
+				
+				it( 'Can union with order' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT * FROM employees
+							union
+							SELECT * FROM employees
+							order by department, name desc",
+						options = { dbtype: 'query'  }
+					);
+					expect( actual.recordcount ).toBe( 15 );
+				});
+				
+				it( 'Can union with group by' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department as thing, count(1) as count, max(age) as age FROM employees
+							GROUP BY department
+							union all
+							SELECT age, count(*), min(sickDaysLeft) FROM employees
+							GROUP BY age
+							ORDER BY thing",
+						options = { dbtype: 'query'  }
+					);
+					expect( actual.recordcount ).toBe( 18 );
+				});
+				
+				it( 'Can union with literals' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT TOP 1 'brad' as firstname, 'wood' as lastname FROM employees
+							union all SELECT TOP 1 'Scott', 'Steinbeck' FROM employees
+							union all SELECT TOP 1 'Gavin', 'Pickin' FROM employees
+							union all SELECT TOP 1 'Luis', 'Majano' FROM employees
+							",
+						options = { dbtype: 'query'  }
+					);
+					expect( actual.recordcount ).toBe( 4 );
+				});
+				
+			});
+
+			describe( 'Query grouping' , function(){
+				
+				it( 'Can use aggregates with no group by' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT avg(age) as avgAge, count(num) as totalEmps, max(hireDate) as mostRecentHire, min(sickDaysLeft) as fewestSickDays FROM employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 1 );
+					expect( actual.avgAge ).toBe( 37.6 );
+					expect( actual.totalEmps ).toBe( 15 );
+					expect( actual.mostRecentHire ).toBe( "{ts '2020-11-21 00:00:00'}" );
+					expect( actual.fewestSickDays ).toBe( 0 );
+				});
+				
+				it( 'Can use group by' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department as dept FROM employees GROUP BY department",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 4 );
+				});
+				
+				it( 'Can use group by with distinct' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT distinct department as dept FROM employees GROUP BY department",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 4 );
+				});
+				
+				it( 'Can use group by with aggregates' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department as dept, max(hireDate) as mostRecentHire, min(age) as youngestAge, max( email ) FROM employees GROUP BY department",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 4 );
+				});
+				
+				it( 'Can use group by with more than one group by' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department, isContract, isActive FROM employees GROUP BY department, isContract, isActive ORDER BY department, isContract, isActive",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 9 );
+				});
+				
+				it( 'Can use group by with having clause' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department, max(age) as maxAge from employees GROUP BY department HAVING max(age) > 30 ORDER BY department",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 3 );
+				});
+				
+				it( 'Can use group by with having clause and distinct' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department, max(age) as maxAge from employees GROUP BY department HAVING max(age) > 30 ORDER BY department",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 3 );
+				});
+				
+				it( 'Can use group by with operations' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT upper(department) as upperDept from employees GROUP BY upper(department) HAVING max(age) > 30 ORDER BY upper(department)",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 3 );
+				});
+				
+				it( 'Can use group by with columns not in select' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT 'test' as val from employees GROUP BY department, age, lower(email) ORDER BY upper(department)",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 15 );
+				});
+				
+				it( 'Can order by aggregate columns' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT department, max(age) as maxAge from employees GROUP BY department HAVING max(age) > 30 ORDER BY max(age)",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 3 );
+				});
+				
+			});
+
+			
+		});
+
+	}
+	
+	
+} 

--- a/test/tickets/LDEV3042.cfc
+++ b/test/tickets/LDEV3042.cfc
@@ -36,7 +36,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 			it( 'Can select with extra space in multi-word clause' , function() {				
 				actual = QueryExecute(
-					sql = "SELECT count(1) from employees where empID is  null or empID is  not  null and isActive not   like 'test' and isactive not    in ('test')",
+					sql = "SELECT count(1) from employees where empID is 	 null or empID is 	 not 	 null and isActive not  	 like 'test' and isactive not 	   in ('test')",
 					options = { dbtype: 'query' }
 				);
 				expect( actual ).toBeQuery();
@@ -52,9 +52,13 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 			});
 			
 				
-			it( 'test' , function() {				
+			it( 'Can select with math operations' , function() {				
 				actual = QueryExecute(
-					sql = "SELECT yearsEmployed/sickDaysLeft as calc from employees",
+					sql = "SELECT yearsEmployed/sickDaysLeft as calc1,
+								yearsEmployed*sickDaysLeft as calc2,
+								yearsEmployed-sickDaysLeft as calc3,
+								yearsEmployed+sickDaysLeft as calc4
+							from employees",
 					options = { dbtype: 'query' }
 				);
 				expect( actual.recordcount ).toBe( 15 );
@@ -74,6 +78,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 					options = { dbtype: 'query' }
 				);
 				expect( actual.recordcount ).toBe( 15 );
+				expect( actual.email[1] ).toBe( 'Bane@company.com' );
+				expect( actual.email[15] ).toBe( 'Mary@company.com' );
 			});
 				
 			it( 'Can order by alias' , function() {				
@@ -82,14 +88,18 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 					options = { dbtype: 'query' }
 				);
 				expect( actual.recordcount ).toBe( 15 );
+				expect( actual.dept[1] ).toBe( 'Acounting' );
+				expect( actual.dept[15] ).toBe( 'IT' );
 			});
 				
 			it( 'Can order by literal' , function() {				
 				actual = QueryExecute(
-					sql = "SELECT department as dept from employees ORDER BY 'test', 'foo', 7, false",
+					sql = "SELECT department as dept from employees ORDER BY name,'test', 'foo', 7, false",
 					options = { dbtype: 'query' }
 				);
 				expect( actual.recordcount ).toBe( 15 );
+				expect( actual.dept[1] ).toBe( 'Acounting' );
+				expect( actual.dept[15] ).toBe( 'Executive' );
 			});
 				
 			it( 'Can order by columns not in select' , function() {				
@@ -98,6 +108,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 					options = { dbtype: 'query' }
 				);
 				expect( actual.recordcount ).toBe( 15 );
+				expect( actual.department[1] ).toBe( 'Acounting' );
+				expect( actual.department[15] ).toBe( 'IT' );
 			});
 				
 			it( 'Can have extra whitespace in group by and order by clauses' , function() {
@@ -106,6 +118,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 					options = { dbtype: 'query' }
 				);
 				expect( actual.recordcount ).toBe( 4 );
+				expect( actual.department[1] ).toBe( 'Acounting' );
+				expect( actual.department[4] ).toBe( 'IT' );
 			});
 				
 			it( 'Can filter on date column' , function() {
@@ -121,10 +135,14 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		
 				it( 'Can select distinct' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT distinct department FROM employees",
+						sql = "SELECT distinct department FROM employees ORDER BY department",
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 4 );
+					expect( actual.department[1] ).toBe( 'Acounting' );
+					expect( actual.department[2] ).toBe( 'Executive' );
+					expect( actual.department[3] ).toBe( 'HR' );
+					expect( actual.department[4] ).toBe( 'IT' );
 				});
 		
 				it( 'Can select distinct with order by' , function() {				
@@ -145,18 +163,12 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	
 				it( 'Can select distinct with maxrows' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT distinct department FROM employees",
+						sql = "SELECT distinct department FROM employees order by department",
 						options = { dbtype: 'query', maxrows: 2 }
 					);
 					expect( actual.recordcount ).toBe( 2 );
-				});
-	
-				it( 'Can select distinct with maxrows' , function() {				
-					actual = QueryExecute(
-						sql = "SELECT distinct department FROM employees",
-						options = { dbtype: 'query', maxrows: 2 }
-					);
-					expect( actual.recordcount ).toBe( 2 );
+					expect( actual.department[1] ).toBe( 'Acounting' );
+					expect( actual.department[2] ).toBe( 'Executive' );
 				});
 	
 				it( 'Can select distinct with *' , function() {				
@@ -193,12 +205,18 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 				
 				it( 'Can union distinct' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT * FROM employees
+						sql = "SELECT upper( favoriteColor ) as favoriteColor FROM employees
 							union distinct
-							SELECT * FROM employees",
+							SELECT upper( favoriteColor ) FROM employees
+							order by favoriteColor",
 						options = { dbtype: 'query' }
 					);
-					expect( actual.recordcount ).toBe( 15 );
+					expect( actual.recordcount ).toBe( 5 );
+					expect( actual.favoriteColor[1] ).toBeWithCase( 'BLUE' );
+					expect( actual.favoriteColor[2] ).toBeWithCase( 'GREEN' );
+					expect( actual.favoriteColor[3] ).toBeWithCase( 'PURPLE' );
+					expect( actual.favoriteColor[4] ).toBeWithCase( 'RED' );
+					expect( actual.favoriteColor[5] ).toBeWithCase( 'YELLOW' );
 				});
 				
 				it( 'Can union with top' , function() {				
@@ -230,6 +248,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 						options = { dbtype: 'query'  }
 					);
 					expect( actual.recordcount ).toBe( 15 );
+					expect( actual.email[1] ).toBe( 'Tom@company.com' );
+					expect( actual.email[15] ).toBe( 'Aurthur@company.com' );
 				});
 				
 				it( 'Can union with group by' , function() {				
@@ -239,10 +259,16 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 							union all
 							SELECT age, count(*), min(sickDaysLeft) FROM employees
 							GROUP BY age
-							ORDER BY thing",
+							ORDER BY thing, age",
 						options = { dbtype: 'query'  }
 					);
 					expect( actual.recordcount ).toBe( 18 );
+					expect( actual.thing[1] ).toBe( 17 );
+					expect( actual.count[1] ).toBe( 1 );
+					expect( actual.age[1] ).toBe( 2 );
+					expect( actual.thing[18] ).toBe( 'IT' );
+					expect( actual.count[18] ).toBe( 6 );
+					expect( actual.age[18] ).toBe( 67 );
 				});
 				
 				it( 'Can union with literals' , function() {				
@@ -255,6 +281,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 						options = { dbtype: 'query'  }
 					);
 					expect( actual.recordcount ).toBe( 4 );
+					expect( actual.firstname[1] ).toBe( 'brad' );
+					expect( actual.firstname[4] ).toBe( 'Luis' );
 				});
 				
 			});
@@ -310,26 +338,38 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 				
 				it( 'Can use group by' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT department as dept FROM employees GROUP BY department",
+						sql = "SELECT department as dept FROM employees GROUP BY department ORDER BY department",
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 4 );
+					expect( actual.dept[1] ).toBe( 'Acounting' );
+					expect( actual.dept[2] ).toBe( 'Executive' );
+					expect( actual.dept[3] ).toBe( 'HR' );
+					expect( actual.dept[4] ).toBe( 'IT' );
 				});
 				
 				it( 'Can use group by with distinct' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT distinct department as dept FROM employees GROUP BY department",
+						sql = "SELECT distinct department as dept FROM employees GROUP BY department ORDER BY department",
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 4 );
+					expect( actual.dept[1] ).toBe( 'Acounting' );
+					expect( actual.dept[2] ).toBe( 'Executive' );
+					expect( actual.dept[3] ).toBe( 'HR' );
+					expect( actual.dept[4] ).toBe( 'IT' );
 				});
 				
 				it( 'Can use group by with aggregates' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT department as dept, max(hireDate) as mostRecentHire, min(age) as youngestAge, max( email ) FROM employees GROUP BY department",
+						sql = "SELECT department as dept, max(hireDate) as mostRecentHire, min(age) as youngestAge, max( email ) FROM employees GROUP BY department order by mostRecentHire desc",
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 4 );
+					expect( actual.dept[1] ).toBe( 'HR' );
+					expect( actual.mostRecentHire[1] ).toBe( '2020-11-21 00:00:00' );
+					expect( actual.dept[4] ).toBe( 'Executive' );
+					expect( actual.mostRecentHire[4] ).toBe( '2008-03-21 00:00:00' );
 				});
 				
 				it( 'Can use group by with more than one group by' , function() {				
@@ -338,6 +378,9 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 9 );
+					expect( actual.department[1] ).toBe( 'Acounting' );
+					expect( actual.department[5] ).toBe( 'HR' );
+					expect( actual.department[9] ).toBe( 'IT' );
 				});
 				
 				it( 'Can use group by with having clause' , function() {				
@@ -346,22 +389,37 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 3 );
+					expect( actual.department[1] ).toBe( 'Executive' );
+					expect( actual.department[2] ).toBe( 'HR' );
+					expect( actual.department[3] ).toBe( 'IT' );
+					expect( actual.maxAge[1] ).toBe( 62 );
+					expect( actual.maxAge[2] ).toBe( 57 );
+					expect( actual.maxAge[3] ).toBe( 67 );
 				});
 				
 				it( 'Can use group by with having clause and distinct' , function() {				
 					actual = QueryExecute(
 						sql = "SELECT department, max(age) as maxAge from employees GROUP BY department HAVING max(age) > 30 ORDER BY department",
 						options = { dbtype: 'query' }
-					);
+					)
 					expect( actual.recordcount ).toBe( 3 );
+					expect( actual.department[1] ).toBe( 'Executive' );
+					expect( actual.department[2] ).toBe( 'HR' );
+					expect( actual.department[3] ).toBe( 'IT' );
+					expect( actual.maxAge[1] ).toBe( 62 );
+					expect( actual.maxAge[2] ).toBe( 57 );
+					expect( actual.maxAge[3] ).toBe( 67 );
 				});
 				
 				it( 'Can use group by with operations' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT upper(department) as upperDept from employees GROUP BY upper(department) HAVING max(age) > 30 ORDER BY upper(department)",
+						sql = "SELECT lower(department) as lowerDept from employees GROUP BY upper(department) HAVING max(age) > 30 ORDER BY lower(department)",
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 3 );
+					expect( actual.lowerDept[1] ).toBeWithCase( 'executive' );
+					expect( actual.lowerDept[2] ).toBeWithCase( 'hr' );
+					expect( actual.lowerDept[3] ).toBeWithCase( 'it' );
 				});
 				
 				it( 'Can use group by with columns not in select' , function() {				
@@ -370,6 +428,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 15 );
+					expect( actual.val[1] ).toBe( 'test' );
+					expect( actual.val[15] ).toBe( 'test' );
 				});
 				
 				it( 'Can order by aggregate columns' , function() {				
@@ -378,6 +438,12 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 3 );
+					expect( actual.department[1] ).toBe( 'HR' );
+					expect( actual.department[2] ).toBe( 'Executive' );
+					expect( actual.department[3] ).toBe( 'IT' );
+					expect( actual.maxAge[1] ).toBe( 57 );
+					expect( actual.maxAge[2] ).toBe( 62 );
+					expect( actual.maxAge[3] ).toBe( 67 );
 				});
 				
 				it( 'Can reference more than one column in aggregate function' , function() {				

--- a/test/tickets/LDEV3042.cfc
+++ b/test/tickets/LDEV3042.cfc
@@ -1,22 +1,22 @@
 component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 	function beforeAll() {
-			employees = queryNew( 'name,age,email,department,isContract,yearsEmployed,sickDaysLeft,hireDate,isActive', 'varchar,integer,varchar,varchar,boolean,integer,integer,date,boolean', [
-			[ 'John Doe',28,'John@company.com','Acounting',false,2,4,createDate(2010,1,21),true ],
-			[ 'Jane Doe',22,'Jane@company.com','Acounting',false,0,8,createDate(2011,2,21),true ],
-			[ 'Bane Doe',28,'Bane@company.com','Acounting',true,3,2,createDate(2012,3,21),true ],
-			[ 'Tom Smith',25,'Tom@company.com','Acounting',false,6,4,createDate(2013,4,21),false ],
-			[ 'Harry Johnson',38,'Harry@company.com','IT',false,8,6,createDate(2014,5,21),true ],
-			[ 'Jason Wood',37,'Jason@company.com','IT',false,19,4,createDate(2015,6,21),true ],
-			[ 'Doris Calhoun',67,'Doris@company.com','IT',true,3,6,createDate(2016,7,21),true ],
-			[ 'Mary Root',17,'Mary@company.com','IT',false,8,2,createDate(2017,8,21),true ],
-			[ 'Aurthur Duff',23,'Aurthur@company.com','IT',false,4,0,createDate(2018,9,21),true ],
-			[ 'Luis Hake',29,'Luis@company.com','IT',true,9,5,createDate(2019,10,21),true ],
-			[ 'Gavin Bezos',46,'Gavin@company.com','HR',false,2,5,createDate(2020,11,21),false ],
-			[ 'Nancy Garmon',57,'Nancy@company.com','HR',false,14,9,createDate(2005,12,21),true ],
-			[ 'Tom Zuckerburg',27,'Tom@company.com','HR',true,16,10,createDate(2006,1,21),true ],
-			[ 'Richard Gates',62,'Richard@company.com','Executive',false,11,1,createDate(2007,2,21),true ],
-			[ 'Amy Merryweather',58,'Amy@company.com','Executive',false,12,2,createDate(2008,3,21),true ]
+			employees = queryNew( 'name,age,email,department,isContract,yearsEmployed,sickDaysLeft,hireDate,isActive,empID,favoriteColor', 'varchar,integer,varchar,varchar,boolean,integer,integer,date,boolean,varchar,varchar', [
+				[ 'John Doe',28,'John@company.com','Acounting',false,2,4,createDate(2010,1,21),true,'sdf','red' ],
+				[ 'Jane Doe',22,'Jane@company.com','Acounting',false,0,8,createDate(2011,2,21),true,'hdfg','blue' ],
+				[ 'Bane Doe',28,'Bane@company.com','Acounting',true,3,2,createDate(2012,3,21),true,'sdsfsff','green' ],
+				[ 'Tom Smith',25,'Tom@company.com','Acounting',false,6,4,createDate(2013,4,21),false,'HDFG','yellow' ],
+				[ 'Harry Johnson',38,'Harry@company.com','IT',false,8,6,createDate(2014,5,21),true,'4ge','purple' ],
+				[ 'Jason Wood',37,'Jason@company.com','IT',false,19,4,createDate(2015,6,21),true,'ShrtDF','Red' ],
+				[ 'Doris Calhoun',67,'Doris@company.com','IT',true,3,6,createDate(2016,7,21),true,'sgsdg','Blue' ],
+				[ 'Mary Root',17,'Mary@company.com','IT',false,8,2,createDate(2017,8,21),true,'SDsefF','Green' ],
+				[ 'Aurthur Duff',23,'Aurthur@company.com','IT',false,4,0,createDate(2018,9,21),true,nullValue(),'Yellow' ],
+				[ 'Luis Hake',29,'Luis@company.com','IT',true,9,5,createDate(2019,10,21),true,nullValue(),'Purple' ],
+				[ 'Gavin Bezos',46,'Gavin@company.com','HR',false,2,5,createDate(2020,11,21),false,nullValue(),'RED' ],
+				[ 'Nancy Garmon',57,'Nancy@company.com','HR',false,14,9,createDate(2005,12,21),true,nullValue(),'BLUE' ],
+				[ 'Tom Zuckerburg',27,'Tom@company.com','HR',true,16,10,createDate(2006,1,21),true,nullValue(),'GREEN' ],
+				[ 'Richard Gates',62,'Richard@company.com','Executive',false,11,1,createDate(2007,2,21),true,nullValue(),'YELLOW' ],
+				[ 'Amy Merryweather',58,'Amy@company.com','Executive',false,12,2,createDate(2008,3,21),true,nullValue(),'PURPLE' ]
 			] );
 
 	}
@@ -32,6 +32,15 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 				);
 				expect( actual ).toBeQuery();
 				expect( actual.recordcount ).toBe( employees.recordcount );
+			});
+
+			it( 'Can select with extra space in multi-word clause' , function() {				
+				actual = QueryExecute(
+					sql = "SELECT count(1) from employees where empID is  null or empID is  not  null and isActive not   like 'test' and isactive not    in ('test')",
+					options = { dbtype: 'query' }
+				);
+				expect( actual ).toBeQuery();
+				expect( actual.recordcount ).toBe( 1 );
 			});
 
 			it( 'Can select with functions' , function() {				
@@ -254,7 +263,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 				
 				it( 'Can use aggregates with no group by' , function() {				
 					actual = QueryExecute(
-						sql = "SELECT avg(age) as avgAge, count(num) as totalEmps, max(hireDate) as mostRecentHire, min(sickDaysLeft) as fewestSickDays FROM employees",
+						sql = "SELECT avg(age) as avgAge, count(1) as totalEmps, max(hireDate) as mostRecentHire, min(sickDaysLeft) as fewestSickDays FROM employees",
 						options = { dbtype: 'query' }
 					);
 					expect( actual.recordcount ).toBe( 1 );
@@ -262,6 +271,32 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 					expect( actual.totalEmps ).toBe( 15 );
 					expect( actual.mostRecentHire ).toBe( "{ts '2020-11-21 00:00:00'}" );
 					expect( actual.fewestSickDays ).toBe( 0 );
+				});
+				
+				it( 'Can use count all and count distinct' , function() {				
+					actual = QueryExecute(
+						sql = "SELECT count(1) as cNum, 
+									count(*) as cStar, 
+									count('asdf') as cLiteral, 
+									count(name) as cColumn ,  
+									count( all department ) as cDeptAll,
+									count( distinct department) as cDept, 
+									count( distinct empID ) as cEmpID, 
+									count( distinct favoriteColor ) as cfavoriteColor,
+									count( distinct upper( favoriteColor ) ) as cUpperfavoriteColor 
+								from employees",
+						options = { dbtype: 'query' }
+					);
+					expect( actual.recordcount ).toBe( 1 );
+					expect( actual.cNum ).toBe( 15 );
+					expect( actual.cStar ).toBe( 15 );
+					expect( actual.cLiteral ).toBe( 15 );
+					expect( actual.cColumn ).toBe( 15 );
+					expect( actual.cDeptAll ).toBe( 15 );
+					expect( actual.cDept ).toBe( 4 );
+					expect( actual.cEmpID ).toBe( 8 );
+					expect( actual.cfavoriteColor ).toBe( 15 );
+					expect( actual.cUpperfavoriteColor ).toBe( 5 );
 				});
 				
 				it( 'Can use aggregates with no group by and where' , function() {				
@@ -380,7 +415,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 					expect( actual.calc[3] ).toBe( 19 );
 					expect( actual.calc[4] ).toBe( 25 );
 				});
-				
+								
 			});
 
 			

--- a/test/tickets/_LDEV0272.cfc
+++ b/test/tickets/_LDEV0272.cfc
@@ -37,20 +37,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				errorMsg = "";
 				try {
 					query name="getDeptEmpCount" result="result" dbtype="query"{
-						echo("select COUNT(dept) AS dept from empDetails WHERE dept = 'Employee' GROUP BY dept");
-					}
-				} catch( any e ) {
-					errorMsg = e.Detail;
-				}
-				expect(errorMsg).toBe("");
-				expect(getDeptEmpCount).toBeTypeOf("Query");
-				expect(getMaxEmpAge.dept).toBe(2);
-			});
-
-			it("Checking QOQ with different alias for a column with some condition using it in where clause & group by clause", function( currentSpec ){
-				errorMsg = "";
-				try {
-					query name="getDeptEmpCount" result="result" dbtype="query"{
 						echo("select COUNT(dept) AS deptCount from empDetails WHERE dept = 'Employee' GROUP BY dept");
 					}
 				} catch( any e ) {


### PR DESCRIPTION
This pull is for ticket
https://luceeserver.atlassian.net/browse/LDEV-3042

It should also fix tickets
* https://luceeserver.atlassian.net/browse/LDEV-2541
* https://luceeserver.atlassian.net/browse/LDEV-1272

Improve the native Java implementation of QofQ to support
* group by clause
* having  clause
* aggregate functions
* Allow aggregates to reference nested operations including scalar functions
  * `ceiling( max( floor( yearsEmployed ) )+count(1) )`
* faster distinct support
* Fix buginess in unions were results aren't distinct by default (union distinct)
* Improve count() to support 
  * `count( all col )`
  * `count( 1 )`
  * `count( * )`
  * `count( 'literal' )`
  * `count( distinct col )`
  * `count( distinct scalarFunc( col ) )`
* Fix bugs in SQL parser that incorrectly requires only a single space between multi-word clauses
  * `is null`
  * `is not null`
  * `not in`
  * `not like`
  * `order by`
  * `group by`
* Remove single-threaded limitations
* Performance tune speed of queries

I have also added support for the following system props/env vars
* **lucee.qoq.hsqldb.disable**=true – Throw exception if native QoQ logic fails
* **lucee.qoq.hsqldb.debug**=true – Log message to WEB context's datasource log any time a QofQ "falls back" to HyperSQL. This could include just bad SQL syntax.

@michaeloffner @micstriit Please ask if you have any questions.  Every change here I have made for a reason-- many of them as part of my performance tuning to shave extra ms off of processing times in large loops.  Note there is a new TestBox spec that tests all the new functionality.  