### PR TITLE
use an ordered struct for getTagData attributes LDEV-3040

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/other/GetTagData.java
+++ b/core/src/main/java/lucee/runtime/functions/other/GetTagData.java
@@ -138,7 +138,7 @@ public final class GetTagData implements Function {
 			sct.set("attributeType", metadata.get("attributeType", ""));
 			sct.set("parseBody", Caster.toBoolean(metadata.get("parseBody", Boolean.FALSE), Boolean.FALSE));
 
-			Struct _attrs = new StructImpl();
+			Struct _attrs = new StructImpl(Struct.TYPE_LINKED);
 			sct.set(KeyConstants._attributes, _attrs);
 
 			Struct srcAttrs = Caster.toStruct(metadata.get(KeyConstants._attributes, null), null, false);


### PR DESCRIPTION
Need to preserve the order of attributes from the XML definition

https://luceeserver.atlassian.net/browse/LDEV-3040