### PR TITLE
LDEV-3096 Log file name that errored

### DIFF
--- a/loader/src/main/java/lucee/loader/osgi/BundleLoader.java
+++ b/loader/src/main/java/lucee/loader/osgi/BundleLoader.java
@@ -170,7 +170,7 @@ public class BundleLoader {
 				rtn.put(loadBundleInfo(jars[i]), jars[i]);
 			}
 			catch (final IOException ioe) {
-				ioe.printStackTrace();
+				new Exception("Error loading bundle info for [" + jars[i].toString() + "]", ioe).printStackTrace();
 			}
 		}
 		return rtn;


### PR DESCRIPTION
If an IOException is encountered while reading bundle info for any of Lucee's jar files, you get an exception like this in the console:
```
java.util.zip.ZipException: error in opening zip file
        at java.util.zip.ZipFile.open(Native Method)
        at java.util.zip.ZipFile.<init>(Unknown Source)
        at java.util.zip.ZipFile.<init>(Unknown Source)
        at java.util.jar.JarFile.<init>(Unknown Source)
        at java.util.jar.JarFile.<init>(Unknown Source)
        at lucee.loader.osgi.BundleLoader.loadBundleInfo(BundleLoader.java:192)
        at lucee.loader.osgi.BundleLoader.loadAvailableBundles(BundleLoader.java:182)
        at lucee.loader.osgi.BundleLoader.loadBundles(BundleLoader.java:118)
        at lucee.loader.engine.CFMLEngineFactory.initEngine(CFMLEngineFactory.java:363)
        at lucee.loader.engine.CFMLEngineFactory.initEngineIfNecessary(CFMLEngineFactory.java:262)
        at lucee.loader.engine.CFMLEngineFactory.getInstance(CFMLEngineFactory.java:168)
        at lucee.runtime.script.BaseScriptEngineFactory.<init>(BaseScriptEngineFactory.java:59)
        ...
```
But the error doesn't tell you what file was being read, making it nearly impossible to debug.  This pull request that will output the exact file that caused the error to help troubleshoot.

For ticket: https://luceeserver.atlassian.net/browse/LDEV-3096