### PR TITLE
stop updating admin graphs on navigation LDEV-3098

### DIFF
--- a/core/src/main/cfml/context/admin/overview.cfm
+++ b/core/src/main/cfml/context/admin/overview.cfm
@@ -90,6 +90,7 @@ Error Output --->
 <cfhtmlbody>
     <script src="../res/js/echarts-all.js.cfm" type="text/javascript"></script>
     <script type="text/javascript">
+    	var chartTimer;
     	labels={'heap':"Heap",'nonheap':"Non-Heap",'cpuSystem':"Whole System",'cpuProcess':"Lucee Process"};
 		function requestData(){
 			jQuery.ajax({
@@ -130,7 +131,8 @@ Error Output --->
 						}
 						window[chrt].setOption(cpuSystemChartOption); // passed the data into the chats
 					});
-					setTimeout(requestData, 1000);
+					if (chartTimer !== null)
+						chartTimer = setTimeout(requestData, 5000);
 				}
 			})
 		}

--- a/core/src/main/cfml/context/admin/web.cfm
+++ b/core/src/main/cfml/context/admin/web.cfm
@@ -503,6 +503,7 @@
 				$(function() {
 					initMenu();
 					__blockUI=function() {
+						chartTimer = null; // stop the overview page graphs from updating after navigation
 						setTimeout(createWaitBlockUI(<cfoutput>"#JSStringFormat(stText.general.wait)#"</cfoutput>),1000);
 					}
 					$('.submit,.menu_inactive,.menu_active').click(__blockUI);


### PR DESCRIPTION
This helps make the admin less animated for RDP sessions

change the update interval to 5s
https://luceeserver.atlassian.net/browse/LDEV-3098

builds on https://github.com/lucee/Lucee/pull/1077