### PR TITLE
LDEV-3112 fix

### DIFF
--- a/core/src/main/cfml/context/admin/overview.cfm
+++ b/core/src/main/cfml/context/admin/overview.cfm
@@ -773,7 +773,10 @@ Error Output --->
 <cfscript>
 	function getJavaVersion() {
 		var verArr=listToArray(server.java.version,'.');
-		if(verArr[1]>2) return verArr[1];
-		return verArr[2];
+		if(verArr[1]>2) {
+			return verArr[1];
+		} else {
+			return verArr[2];
+		}
 	}
 </cfscript>


### PR DESCRIPTION
Only return verArr[2] if verArr[1] under 2.
Fix for JDKs with only major version.