### PR TITLE
LDEV-3112 Fix crash on versions of Java that to not match the expected format

### DIFF
--- a/core/src/main/cfml/context/admin/overview.cfm
+++ b/core/src/main/cfml/context/admin/overview.cfm
@@ -773,7 +773,12 @@ Error Output --->
 <cfscript>
 	function getJavaVersion() {
 		var verArr=listToArray(server.java.version,'.');
-		if(verArr[1]>2) return verArr[1];
-		return verArr[2];
+		if(verArr[1]>2) {
+			return verArr[1];
+		} elseif (verArr.len() GT 1) {
+			return verArr[2];
+		} else {
+		    return val(server.java.version);
+		}
 	}
 </cfscript>


### PR DESCRIPTION
Fix crash on versions of Java that to not match the expected format, for example "16-ea".