### PR TITLE
remove unused cfadmin surveillance

### DIFF
--- a/core/src/main/cfml/context/admin/overview.cfm
+++ b/core/src/main/cfml/context/admin/overview.cfm
@@ -47,14 +47,8 @@ Defaults --->
 		<cfset error.cfcatch=cfcatch>
 	</cfcatch>
 </cftry>
-<cfadmin 
-	action="surveillance" 
-	type="#request.adminType#" 
-	password="#session["password"&request.adminType]#" 
-	returnVariable="surveillance">
-
 <!---
-Redirtect to entry --->
+Redirect to entry --->
 <cfif cgi.request_method EQ "POST" and error.message EQ "" and form.mainAction NEQ "none">
 	<cflocation url="#request.self#" addtoken="no">
 </cfif>


### PR DESCRIPTION
it's not even used and crashes the admin randomly due to
https://luceeserver.atlassian.net/browse/LDEV-2830
https://luceeserver.atlassian.net/browse/LDEV-2829