### PR TITLE
return debug logs as json via url param

### DIFF
--- a/core/src/main/cfml/context/admin/debugging.logs.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.cfm
@@ -147,13 +147,19 @@ Redirtect to entry --->
     
     <cfreturn (time/1000000)&" ms">
 </cffunction> 
-    
+<cfscript>
+	param name="url.action2" default="list";
+	param name="url.format" default="";
 
-
-<cfparam name="url.action2" default="list">
-
-<cfif url.action2 EQ "list">
-	<cfinclude template="debugging.logs.list.cfm">
-<cfelse>
-	<cfinclude template="debugging.logs.detail.cfm">
-</cfif>
+	if (url.action2 EQ "list"){
+		if (url.format eq "json"){
+			setting showdebugoutput="false";
+			content reset="yes" type="application/json";
+			echo(serializeJson(logs));
+			abort;		
+		}
+		include template="debugging.logs.list.cfm";
+	} else {
+		include template="debugging.logs.detail.cfm";
+	}
+</cfscript>

--- a/core/src/main/cfml/context/admin/debugging.logs.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.cfm
@@ -151,8 +151,8 @@ Redirtect to entry --->
 	param name="url.action2" default="list";
 	param name="url.format" default="";
 
-	if (url.action2 EQ "list"){
-		if (url.format eq "json"){
+	if (url.action2 EQ "list") {
+		if (url.format eq "json") {
 			setting showdebugoutput="false";
 			content reset="yes" type="application/json";
 			echo(serializeJson(logs));

--- a/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
@@ -53,7 +53,7 @@
 		}
 	}
 	
-	if (url.format eq "json"){
+	if (url.format eq "json") {
 		setting showdebugoutput="false";
 		content reset="yes" type="application/json";
 		echo(serializeJson(log));

--- a/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.detail.cfm
@@ -52,6 +52,13 @@
 			log=el;
 		}
 	}
+	
+	if (url.format eq "json"){
+		setting showdebugoutput="false";
+		content reset="yes" type="application/json";
+		echo(serializeJson(log));
+		abort;		
+	}
 </cfscript>
 <cfoutput>
 	<cfif !isSimpleValue(log) && structCount(drivers)>


### PR DESCRIPTION
add support for format=json for the debug log lists and log detail page

the idea behind this is, an IDE extension could access this as a JSON api

and use it to show the request code path, show execution times, flag implicit variable problems etc