### PR TITLE
fix for LDEV-3199

### DIFF
--- a/core/src/main/java/lucee/commons/date/JREDateTimeUtil.java
+++ b/core/src/main/java/lucee/commons/date/JREDateTimeUtil.java
@@ -167,7 +167,7 @@ public class JREDateTimeUtil extends DateTimeUtil {
 		int week = c.get(Calendar.WEEK_OF_YEAR);
 
 		if (week == 1 && c.get(Calendar.MONTH) == Calendar.DECEMBER) {
-			if (isLeapYear(c.get(Calendar.YEAR)) && c.get(Calendar.DAY_OF_WEEK) == 1) {
+			if (isLeapYear(c.get(Calendar.YEAR)) && c.get(Calendar.DAY_OF_WEEK) == 1 && c.get(Calendar.DAY_OF_MONTH) == 31) {
 				return 54;
 			}
 			return 53;


### PR DESCRIPTION
Fix for week() at end of December on leap year.
Should only be 54 weeks on leap years starting on Sat Jan 1.  This should now give the same results as ACF.