### PR TITLE
cfldap timeout LDEV-1860

### DIFF
--- a/core/src/main/java/lucee/runtime/net/ldap/LDAPClient.java
+++ b/core/src/main/java/lucee/runtime/net/ldap/LDAPClient.java
@@ -93,7 +93,7 @@ public final class LDAPClient {
 	 * @param port
 	 * @param binaryColumns
 	 */
-	public LDAPClient(String server, int port, String[] binaryColumns) {
+	public LDAPClient(String server, int port, int timeout, String[] binaryColumns) {
 
 		env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
 		env.put("java.naming.provider.url", "ldap://" + server + ":" + port);
@@ -104,6 +104,9 @@ public final class LDAPClient {
 
 		// Referral
 		env.put("java.naming.referral", "ignore");
+
+		// timeout
+		env.put("com.sun.jndi.ldap.read.timeout", timeout);		
 	}
 
 	/**

--- a/core/src/main/java/lucee/runtime/tag/Ldap.java
+++ b/core/src/main/java/lucee/runtime/tag/Ldap.java
@@ -144,7 +144,7 @@ public final class Ldap extends TagImpl {
 	}
 
 	/**
-	 * Specifies the maximum amount of time, in seconds, to wait for LDAP processing. Defaults to 60
+	 * Specifies the maximum amount of time, in milliseconds, to wait for LDAP processing. Defaults to 60
 	 * seconds.
 	 * 
 	 * @param timeout The timeout to set.
@@ -361,7 +361,7 @@ public final class Ldap extends TagImpl {
 
 		// LDAPClient client=new
 		// LDAPClient(server,port,secureLevel,returnAsBinary,username,password,referral);
-		LDAPClient client = new LDAPClient(server, port, returnAsBinary);
+		LDAPClient client = new LDAPClient(server, port, timeout, returnAsBinary);
 		if (secureLevel != LDAPClient.SECURE_NONE) client.setSecureLevel(secureLevel);
 		if (username != null) client.setCredential(username, password);
 		if (referral > 0) client.setReferral(referral);

--- a/core/src/main/java/resource/tld/core-base.tld
+++ b/core/src/main/java/resource/tld/core-base.tld
@@ -4619,8 +4619,8 @@ Permits searching collections by title or displaying a separate title from the k
 			<name>timeout</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description>Specifies the maximum amount of time, in seconds, to wait for LDAP processing. Defaults to
-		60 seconds.</description>
+			<description>Specifies the maximum amount of time, in milliseconds, to wait for LDAP processing. Defaults to
+		60000 ms (60 seconds).</description>
 		</attribute>
 		<attribute>
 			<type>number</type>


### PR DESCRIPTION
- correct documentation to be in milliseconds (not seconds)
- always set timeout for all LDAP operations

https://luceeserver.atlassian.net/browse/LDEV-1860