### PR TITLE
disable downloading bundles for test builds LDEV-3241

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -846,6 +846,7 @@
       <jvmarg value="-Dlucee.enable.dialect=true"/>
       <jvmarg value="-Dlucee.extensions.install=true"/>
       <jvmarg value="-Dlucee.full.null.support=false"/>
+      <jvmarg value="-Dlucee.enable.bundle.download=false"/>
       <!--
       <jvmarg value="-Dlucee.system.out=file:.../out.txt"/>
       <jvmarg value="-Dlucee.system.err=file:.../err.txt"/>


### PR DESCRIPTION
this way any build misconfiguration which results in external jars or extensions needing to be downloaded will be caught immediately

https://luceeserver.atlassian.net/browse/LDEV-3241