### PR TITLE
fix cfexecute directory arg resource type check LDEV-3117

### DIFF
--- a/core/src/main/java/lucee/commons/cli/Command.java
+++ b/core/src/main/java/lucee/commons/cli/Command.java
@@ -46,7 +46,7 @@ public class Command {
 		if (!StringUtil.isEmpty(workingDir, true)) {
 			Resource res = ResourceUtil.toResourceExisting(pc, workingDir);
 			if (!res.isDirectory()) throw new IOException("CFEXECUTE Directory [" + workingDir + "] is not a existing directory");
-			if (dir instanceof FileResource) dir = (FileResource) res;
+			if (res instanceof FileResource) dir = (FileResource) res;
 			else throw new IOException("CFEXECUTE directory [" + workingDir + "] must be a local directory, scheme [" + res.getResourceProvider().getScheme() + "] is not supported in this context.");
 		}
 		return Runtime.getRuntime().exec(commands, null, dir);

--- a/test/tags/Execute.cfc
+++ b/test/tags/Execute.cfc
@@ -21,6 +21,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		assertTrue(find('"session"',x)>0);
 	}
 	
+	public function testDirectoryArg() {
+		cfexecute(name="curl", arguments=["https://update.lucee.org/rest/update/provider/echoGet"] ,variable="variables.x", directory=getTempDirectory());
+		assertTrue(find('"session"',x)>0);
+	}
+	
 	public function testTimeout() {
 		try {
 			cfexecute(name="curl", timeout="0.01", arguments="https://update.lucee.org/rest/update/provider/echoGet" ,variable="variables.x");


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3117
https://luceeserver.atlassian.net/browse/LDEV-2912

fixes https://github.com/lucee/Lucee/commit/a0c7d993dca0a82c1705e9e05a0fa358d9dd1374#diff-a1b7be775e1e5730fc56ec7f2b94a96a23daa4a94264ec7493a427ca9c103dd2