### PR TITLE
add a test case to check local docs

### DIFF
--- a/test/general/localDocs.cfc
+++ b/test/general/localDocs.cfc
@@ -1,0 +1,32 @@
+<!--- 
+ *
+ * Copyright (c) 2015, Lucee Assosication Switzerland. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ --->
+component extends="org.lucee.cfml.test.LuceeTestCase"	{
+
+	public void function testLocalDocs() {
+		local.specificDocs = "tags.cfm?item=cfapplication,functions.cfm?item=getapplicationsettings,components.cfm?item=org.lucee.cfml.Administrator";
+		loop list="index.cfm,tags.cfm,functions.cfm,components.cfm,objects.cfm,#specificDocs#" item="local.p"{
+			// systemOutput(local.p);
+			local.docs = _internalRequest(
+				template: "/lucee/doc/#local.p#"
+			);
+			expect( docs.status ).toBe( 200, "Status code #local.p#" );
+		}
+	}
+	
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3346

     [java]    [script]         test.general.localDocs  (0 tests passed in 1,214 ms)
     [java]    [script] ERRORED
     [java]    [script]         Suites/Specs: 1/1
     [java]    [script]         Failures: 0
     [java]    [script]         Errors:   1
     [java]    [script]         Pass:     0
     [java]    [script]         Skipped:  0
     [java]    [script]
     [java]    [script] testLocalDocs
     [java]    [script]         Errored: java.lang.NullPointerException
     [java]    [script]         C:\work\lucee\test\general\localDocs.cfc:26
     [java]    [script]
     [java]    [script]         lucee.runtime.exp.NativeException: java.lang.NullPointerException
     [java]    [script]         at lucee.runtime.listener.MixedAppListener.getApplicationPage(MixedAppListener.java:54)
     [java]    [script]         at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:42)
     [java]    [script]         at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2447)
     [java]    [script]         at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2437)
     [java]    [script]         at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2408)
     [java]    [script]         at lucee.runtime.functions.system.InternalRequest.call(InternalRequest.java:111)
     [java]    [script]         at general.localdocs_cfc$cf.udfCall(/test/general/localDocs.cfc:26)
