### PR TITLE
len() tests for arrays, structs & query objects

### DIFF
--- a/test/jira/Jira2998.cfc
+++ b/test/jira/Jira2998.cfc
@@ -59,6 +59,17 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	}
 	public void function testLen(){
 		assertEquals(3,"abc".len());
+		assertEquals(0, [].len());
+		assertEquals(0, {}.len());
+		assertEquals(0, {}.len());
+		assertEquals(3, ["abc", "xyz", 1].len());
+		assertEquals(3, {a=1, b=2, c=3}.len());
+		assertEquals(3, [a=1, b=2, c=3].len());
+		local.a = [];
+		arrayResize(local.a, 3)
+		$assert.isEqual(3, local.a.len());
+		local.q = queryNew("i", "integer", [{i=1}, {i=2}, {i=3}]);
+		$assert.isEqual(3, local.q.len());
 	}
 	public void function testRemoveChars(){
 		assertEquals("aefghijklm","abcdefghijklm".RemoveChars(2,3));


### PR DESCRIPTION
According to [documentation](https://docs.lucee.org/reference/functions/len.html), `len()` returns length for "string, array,struct,query ...".  Arrays & structs seem to work, but query objects appear to throw an error.
```
The function [len] does not exist in the Object, only the following functions are available: [addColumn,addRow,columnArray,columnCount,columnData,columnExists,columnList,currentRow,deleteColumn,deleteRow,duplicate,each,every,filter,getCell,getCellByIndex,getRow,keyExists,map,recordCount,reduce,rowByIndex,rowData,rowDataByIndex,setCell,slice,some,sort,valueArray,valueList]
```