### PR TITLE
refactor test filters

### DIFF
--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -228,7 +228,7 @@ try {
 					};
 
 					allowed = isValidTestCase( arguments.path );
-					SystemOutput( arguments.path & " :: " & allowed, true );
+					//SystemOutput( arguments.path & " :: " & allowed, true );
 					if ( allowed != "" ){
 						//SystemOutput( arguments.path & " :: " & allowed, true );
 						return false;

--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -226,7 +226,7 @@ try {
 					};
 
 					allowed = isValidTestCase( arguments.path );
-					// SystemOutput( arguments.path & " :: " & allowed, true );
+					SystemOutput( arguments.path & " :: " & allowed, true );
 					if ( allowed != "" ){
 						//SystemOutput( arguments.path & " :: " & allowed, true );
 						return false;

--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -46,13 +46,12 @@ NL = "
 ";
 TAB = "	";
 
+// this isn't used ???
 fixCase = {};
-for (el in ["bundleId", "debugBuffer", "endTime", "error", "failMessage", "failOrigin", "globalException", "name", "parentId", "path", "specStats", 
+for (el in ["bundleId", "debugBuffer", "endTime", "error", "failMessage", "failOrigin", "globalException", "name", "parentId", "path", "specStats",
 	"startTime", "status", "suiteId", "suiteStats", "totalDuration", "totalError", "totalFail", "totalPass", "totalSkipped", "totalSpecs", "totalSuites"]) {
 	fixCase[ucase(el)] = el;
 }
-
-failedTestCases = [];
 
 try {
 
@@ -65,24 +64,6 @@ try {
 			systemOutput(TAB & replace(ucFirst(type), '_', ' ') & " " & qry.name & ": " & perc & "%", true);
 		}
 	}
-
-	// strips off the stack trace to exclude testbox and back to the first .cfc call in the stack
-	function printStackTrace( st ){
-		local.i = find( "/testbox/", arguments.st );
-		if ( i eq 0 ){ // dump it all out
-			systemOutput( TAB & arguments.st, true );
-			return;
-		}
-		local.tmp = mid( arguments.st, 1, i ); // strip out anything after testbox
-		local.tmp2 = reverse( local.tmp );
-		local.i = find( ":cfc.", local.tmp2 ); // find the first cfc line
-		if ( local.i gt 0 ){
-			local.i = len( local.tmp )-i;
-			local.j = find( ")", local.tmp, local.i ); // find the end of the line
-			local.tmp = mid( local.tmp, 1, local.j );
-		}
-		systemOutput( TAB & local.tmp, true );
-	};
 
 	// set a password for the admin
 	try {
@@ -103,25 +84,25 @@ try {
 	}
 	catch(e){}	// may exist from previous execution
 
-	systemOutput("set password #dateTimeFormat(now())#", true);
+	systemOutput( "set admin password #dateTimeFormat(now())#", true );
 
-	if (Arraylen(request.testFilter) gt 0)
-		systemOutput(NL & "Filtering only tests containing: " & request.testFilter.toJson() & NL, true);	
+	if ( Arraylen(request.testFilter) gt 0 )
+		systemOutput( NL & "Filtering only tests containing: " & request.testFilter.toJson() & NL, true );
 	else
-		systemOutput(NL & 'Running all tests, to run a subset of test(s), use the parameter -DtestFilter="image,orm,etc"'& NL, true);	
+		systemOutput( NL & 'Running all tests, to run a subset of test(s), use the parameter -DtestFilter="image,orm,etc"'& NL, true );
 
 	// output deploy log
-	pc=getPageContext();
-	config=pc.getConfig();
-	configDir=config.getConfigServerDir();
-	logsDir=configDir&server.separator.file&"logs";
-	deployLog=logsDir&server.separator.file&"deploy.log";
+	pc = getPageContext();
+	config = pc.getConfig();
+	configDir = config.getConfigServerDir();
+	logsDir = configDir & server.separator.file & "logs";
+	deployLog = logsDir & server.separator.file & "deploy.log";
 	//dump(deployLog);
-	content=fileRead(deployLog);
+	content = fileRead( deployLog );
 	systemOutput("-------------- Deploy.Log ------------",true);
-	systemOutput(content,true);
+	systemOutput( content, true );
 	systemOutput("--------------------------------------",true);
-	
+
 
 	// create "/test" mapping
 	admin
@@ -138,332 +119,98 @@ try {
 	systemOutput("set /test mapping #dateTimeFormat(now())#", true);
 
 	// you can also provide a json file with your environment variables, i.e. just set LUCEE_BUILD_ENV="c:\work\lucee\loader\env.json"
-	setupTestServices = new test._setupTestServices().setup();	
+	setupTestServices = new test._setupTestServices().setup();
 
 	// set the testbox mapping
 	application
 		action="update"
 		componentpaths = "#[{archive:testboxArchive}]#";
 
-	systemOutput("update componentpaths #dateTimeFormat(now())#" & NL, true);
+	systemOutput( "update componentpaths #dateTimeFormat( now() )#" & NL, true );
 
 	// load testbox
-	SystemOut=createObject("java", "lucee.commons.lang.SystemOut");
-	out=SystemOut.setOut(nullValue());
-	//err=SystemOut.setErr(nullValue());
+	SystemOut = createObject( "java", "lucee.commons.lang.SystemOut" );
+	out = SystemOut.setOut( nullValue() );
+	//err = SystemOut.setErr( nullValue() );
 
 	request._tick = getTickCount();
 	request.overhead = [];
 
-	admin 
+	admin
 		action="getMappings"
 		type="web"
 		password="#request.WEBADMINPASSWORD#"
 		returnVariable="mappings";
-		
+
 	systemOutput("-------------- Mappings --------------", true);
 	loop query="mappings" {
-		systemOutput("#mappings.virtual# #TAB# #mappings.strPhysical# " 
+		systemOutput("#mappings.virtual# #TAB# #mappings.strPhysical# "
 			& (len(mappings.strArchive) ? "[#mappings.strArchive#] " : "")
 			& (len(mappings.inspect) ? "(#mappings.inspect#)" : ""), true);
 	}
-	
-	systemOutput(NL & "-------------- Start Tests -----------", true);
 
+	systemOutput(NL & "-------------- Start Tests -----------", true);
 	silent {
 		try {
-
-			dir = {
-				 mapping : "/test"
-				,recurse : true
-				,filter  : function(path) localmode=true {
-					var isValidTestCase = function ( string path ){
-						// get parent
-						var testDir = getDirectoryFromPath( arguments.path );
-						testDir = listCompact(left( testDir, testDir.len() - 1 ), "\/" );
-						if ( left( arguments.path, 1 ) eq "/")
-							testDir = "/" & testDir; // avoid issues with non windows paths
-						var name = listLast( arguments.path, "\/" );
-
-						switch ( true ){
-							case ( left (name, 1 ) == "_" ):
-								return "test has _ prefix (#name#)";
-							case ( checkTestFilter( arguments.path ) ):
-								return "excluded by testFilter";
-							case ( FindNoCase( request.testFolder, testDir ) neq 1 ):
-								return "not under test dir (#request.testFolder#, #testDir#)";
-							case fileExists( testDir & "/Application.cfc" ):
-								return "test in directory with Application.cfc";
-							default:
-								break;
-						};
-						var extends = checkExtendsTestCase( arguments.path );
-						if ( extends neq "org.lucee.cfml.test.LuceeTestCase" )
-							return "test doesn't extend Lucee Test Case (#extends#)";
-						else 
-							return "";
-					};
-
-					var checkTestFilter = function ( string path ){
-						if ( Arraylen( request.testFilter ) eq 0 )
-							return false;
-						loop array="#request.testFilter#" item="local.f" {
-							if ( FindNoCase( f, arguments.path ) gt 0 )
-								return false;
-						}
-						return true;
-					};
-
-					var checkExtendsTestCase = function (string path){
-						// finally only allow files which extend "org.lucee.cfml.test.LuceeTestCase"
-						var cfcPath = ListChangeDelims( "/test" & Mid( arguments.path, len( request.testFolder ) + 1 ), ".", "/\" );
-						cfcPath = mid( cfcPath, 1, len( cfcPath ) - 4 );
-						try {
-							// triggers a compile, which make the initial filter slower, but it would be compiled later anyway
-							var meta = GetComponentMetaData( cfcPath ); 
-						} catch ( e ){
-							return cfcatch.message;
-						}
-						return meta.extends.fullname ?: "";
-					};
-
-					allowed = isValidTestCase( arguments.path );
-					//SystemOutput( arguments.path & " :: " & allowed, true );
-					if ( allowed != "" ){
-						//SystemOutput( arguments.path & " :: " & allowed, true );
-						return false;
-					} else {
-						return true;
-					}
-				}
-			};
-
-			filterTimer = getTickCount();
-			tb = new testbox.system.TestBox(directory=dir, reporter="console");
-
-			SystemOutput("Found #tb.getBundles().len()# tests to run, filter took #getTickCount()-filterTimer#ms", true);
-			if (false and Arraylen(request.testFilter)){
-				// dump matches by testFilter
-				for (b in tb.getBundles())
-					SystemOutput(b, true);
-			}
-
-			// execute
-			report = tb.run(callbacks=
-{
-	 onBundleStart = function(cfc, testResults){
-		var meta = getComponentMetadata(cfc);
-		SystemOut.setOut(out);
-		//SystemOut.setErr(err);
-		//"=============================================================" 
-		systemOutput(TAB & meta.name, false);
-		SystemOut.setOut(nullValue());
-		//SystemOut.setErr(nullValue());
-	} // onBundleStart = function
-	,onBundleEnd = function(cfc, testResults){
-		var bundle = arrayLast(testResults.getBundleStats());
-		var oh = (getTickCount()-request._tick)-bundle.totalDuration;
-		request._tick = getTickCount();
-		ArrayAppend(request.overhead, oh);
-		try {
-			SystemOut.setOut(out);
-			//SystemOut.setErr(err);
-			systemOutput(TAB & " (#bundle.totalPass# tests passed in #NumberFormat(bundle.totalDuration)# ms)", true);
-			//mem("non_heap");
-			//mem("heap");
-
-		// we have an error
-		if ((bundle.totalFail + bundle.totalError) > 0) {
-
-			systemOutput("ERRORED" & NL & "	Suites/Specs: #bundle.totalSuites#/#bundle.totalSpecs#
-	Failures: #bundle.totalFail#
-	Errors:   #bundle.totalError#
-	Pass:     #bundle.totalPass#
-	Skipped:  #bundle.totalSkipped#"
-			, true);
-
-			if (!isNull(bundle.suiteStats)) {
-				loop array=bundle.suiteStats item="local.suiteStat" {
-					if (!isNull(suiteStat.specStats)) {
-						loop array=suiteStat.specStats item="local.specStat" {
-
-							if (!isNull(specStat.failMessage) && len(trim(specStat.failMessage))) {
-
-								var failedTestCase = {
-									 type       : "Failed"
-									,bundle     : bundle.name
-									,testCase   : specStat.name
-									,errMessage : specStat.failMessage
-									,stackTrace : []
-								};
-								failedTestCases.append(failedTestCase);
-
-								systemOutput(NL & specStat.name);
-								systemOutput(NL & TAB & "Failed: " & specStat.failMessage, true);
-
-								if (!isNull(specStat.failOrigin) && !isEmpty(specStat.failOrigin)){
-
-									var rawStackTrace = specStat.failOrigin;
-									var testboxPath = getDirectoryFromPath(rawStackTrace[1].template);
-
-									//systemOutput(TAB & TAB & "at", true);
-
-									loop array=rawStackTrace item="local.st" index="local.i" {
-
-										if (!st.template.hasPrefix(testboxPath)){
-											if (local.i eq 1 or st.template does not contain "testbox"){
-												var frame = st.template & ":" & st.line;
-												failedTestCase.stackTrace.append(frame);
-												systemOutput(TAB & frame, true);
-											}
-										}
-									}
-								} 
-								systemOutput(NL);
-							} // if !isNull
-
-							if (!isNull(specStat.error) && !isEmpty(specStat.error)){
-
-								var failedTestCase = {
-									 type       : "Errored"
-									,bundle     : bundle.name
-									,testCase   : specStat.name
-									,errMessage : specStat.error.Message
-									,stackTrace : []
-								};
-								failedTestCases.append(failedTestCase);
-
-								systemOutput(NL & specStat.name);
-								systemOutput(NL & TAB & "Errored: " & specStat.error.Message, true);
-								if (len(specStat.error.Detail))
-									systemOutput(TAB & "Detail: " & specStat.error.Detail, true);
-
-								if (!isNull(specStat.error.TagContext) && !isEmpty(specStat.error.TagContext)){
-
-									var rawStackTrace = specStat.error.TagContext;
-
-									//systemOutput(TAB & TAB & "at", true);
-
-									loop array=rawStackTrace item="local.st" index="local.i" {
-										if (local.i eq 1 or st.template does not contain "testbox"){
-											var frame = st.template & ":" & st.line;
-											failedTestCase.stackTrace.append(frame);
-											systemOutput(TAB & frame, true);
-										}
-									}
-									systemOutput(NL);
-									/*
-									if (arrayLen(rawStackTrace) gt 0){
-										systemOutput(TAB & rawStackTrace[1].codePrintPlain, true);
-										systemOutput(NL);
-									}
-									*/
-								}
-								if (!isNull(specStat.error.StackTrace) && !isEmpty(specStat.error.StackTrace)){
-									printStackTrace(specStat.error.StackTrace);
-									systemOutput(NL);
-								}
-
-							//	systemOutput(NL & serialize(specStat.error), true);
-
-							} // if !isNull
-						}
-					}
-				}
-			}
-			//systemOutput(serializeJson(bundle.suiteStats));
+			testResults = new test._testRunner().runTests();
+		} catch(e) {
+			testResults = {};
+			systemOutput( cfcatch.message, true );
 		}
-
-	// exceptions
-	if (!isSimpleValue(bundle.globalException)) {
-		systemOutput("Global Bundle Exception
-		#bundle.globalException.type#
-		#bundle.globalException.message#
-		#bundle.globalException.detail#
-=============================================================
-Begin Stack Trace
-=============================================================
-#bundle.globalException.stacktrace#
-=============================================================
-  End Stack Trace
-=============================================================", true);
 	}
-
-//systemOutput("=============================================================",true);
-		} // try
-		finally {
-			SystemOut.setOut(nullValue());
-			//SystemOut.setErr(nullValue());
-		} // finally
-	} // onBundleEnd = function
-	/*,onSuiteStart 	= function( bundle, testResults, suite ){}
-	,onSuiteEnd		= function( bundle, testResults, suite ){}
-	,onSpecStart		= function( bundle, testResults, suite, spec ){}
-	,onSpecEnd 		= function( bundle, testResults, suite, spec ){}*/
-} // callbacks
-			); // report = tb.run
-
-	 		// get the result
-	 		result = tb.getResult();
- 		}
- 		finally {
- 			//SystemOut.setOut(out);
- 			//SystemOut.setErr(err);
- 		} // try
-	} // silent
-
+	echo( NL & NL & "---------- post test result #structKeyList(testResults)# ----------------" & NL ); // DEBUG, full run doesn't get here?
+	result = testResults.result;
+	failedTestcases = testResults.failedTestcases;
+	tb = testResults.tb;
 
 	echo(NL & NL & "=============================================================" & NL);
 	echo("TestBox Version: #tb.getVersion()#" & NL);
 	echo("Lucee Version: #server.lucee.version#" & NL);
 	echo("Java Version: #server.java.version#" & NL);
-	echo("Total Execution time: (#NumberFormat((getTickCount()-request._start)/1000)# s)" & NL);
-	echo("Test Execution time: (#NumberFormat(result.getTotalDuration()/1000)# s)" & NL);	
-	echo("Average Test Overhead: (#NumberFormat(ArrayAvg(request.overhead))# ms)" & NL);
-	echo("Total Test Overhead: (#NumberFormat(ArraySum(request.overhead))# ms)" & NL);
+	echo("Total Execution time: (#NumberFormat( ( getTickCount()-request._start) / 1000 )# s)" & NL);
+	echo("Test Execution time: (#NumberFormat( result.getTotalDuration() /1000 )# s)" & NL);
+	echo("Average Test Overhead: (#NumberFormat( ArrayAvg( request.overhead ) )# ms)" & NL);
+	echo("Total Test Overhead: (#NumberFormat( ArraySum( request.overhead ) )# ms)" & NL);
 
-	
-	
 	echo("=============================================================" & NL & NL);
 	echo("-> Bundles/Suites/Specs: #result.getTotalBundles()#/#result.getTotalSuites()#/#result.getTotalSpecs()#" & NL);
 	echo("-> Pass:     #result.getTotalPass()#" & NL);
 	echo("-> Skipped:  #result.getTotalSkipped()#" & NL);
 	echo("-> Failures: #result.getTotalFail()#" & NL);
 	echo("-> Errors:   #result.getTotalError()#" & NL);
-	
+
 	servicesReport = new test._setupTestServices().reportServiceSkipped();
 	for (s in servicesReport){
 		echo ( s & NL );
 	}
 
-		if (!isEmpty(failedTestCases)){
-			echo(NL);
-			for (el in failedTestCases){
-				echo(el.type & ": " & el.bundle & NL & TAB & el.testCase & NL);
-				echo(TAB & el.errMessage & NL);
-				if (!isEmpty(el.stackTrace)){
-					//echo(TAB & TAB & "at" & NL);
-					for (frame in el.stackTrace){
-						echo(TAB & TAB & frame & NL);
-					}
+	if ( !isEmpty( failedTestCases ) ){
+		echo( NL );
+		for ( el in failedTestCases ){
+			echo( el.type & ": " & el.bundle & NL & TAB & el.testCase & NL );
+			echo( TAB & el.errMessage & NL );
+			if ( !isEmpty( el.stackTrace ) ){
+				//echo(TAB & TAB & "at" & NL);
+				for ( frame in el.stackTrace ){
+					echo( TAB & TAB & frame & NL );
 				}
-				echo(NL);
 			}
-			echo(NL);
+			echo( NL );
 		}
+		echo( NL );
+	}
 
- 		if ((result.getTotalFail() + result.getTotalError()) > 0) {
- 			throw "TestBox could not successfully execute all testcases: #result.getTotalFail()# tests failed; #result.getTotalError()# tests errored.";
- 		}
+	if ( ( result.getTotalFail() + result.getTotalError() ) > 0 ) {
+		throw "TestBox could not successfully execute all testcases: #result.getTotalFail()# tests failed; #result.getTotalError()# tests errored.";
 	}
-	catch(e){
-		echo("-------------------------------------------------------" & NL);
-		echo("Testcase failed:" & NL);
-		echo( e.message & NL);
-		echo( ReReplace( Serialize(e), "[\r\n]\s*([\r\n]|\Z)", Chr(10), "ALL" ) & NL); // avoid too much whitespace from dump
-		echo("-------------------------------------------------------" & NL);
-		rethrow;
-	}
+} catch( e ){
+	echo( "-------------------------------------------------------" & NL );
+	echo( "Testcase failed:" & NL );
+	echo( e.message & NL );
+	echo( ReReplace( Serialize( e ), "[\r\n]\s*([\r\n]|\Z)", Chr( 10 ) , "ALL" ) & NL ); // avoid too much whitespace from dump
+	echo( "-------------------------------------------------------" & NL );
+	rethrow;
+}
 
 } // if (execute)
 ]]>

--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -181,6 +181,8 @@ try {
 						// get parent
 						var testDir = getDirectoryFromPath( arguments.path );
 						testDir = listCompact(left( testDir, testDir.len() - 1 ), "\/" );
+						if ( left( arguments.path, 1 ) eq "/")
+							testDir = "/" & testDir; // avoid issues with non windows paths
 						var name = listLast( arguments.path, "\/" );
 
 						switch ( true ){

--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -189,7 +189,7 @@ try {
 							case ( checkTestFilter( arguments.path ) ):
 								return "excluded by testFilter";
 							case ( FindNoCase( request.testFolder, testDir ) neq 1 ):
-								return "not under test dir";
+								return "not under test dir (#request.testFolder#, #testDir#)";
 							case fileExists( testDir & "/Application.cfc" ):
 								return "test in directory with Application.cfc";
 							default:

--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -34,7 +34,8 @@ if (execute) {
 
 request.basedir = basedir;
 request.srcall = srcall;
-request.testFilter = testFilter;
+request.testFilter = ListToArray( trim( testFilter ) );
+request.testFolder = test;
 
 request.WEBADMINPASSWORD = "webweb";
 request.SERVERADMINPASSWORD = "webweb";
@@ -104,10 +105,10 @@ try {
 
 	systemOutput("set password #dateTimeFormat(now())#", true);
 
-	if (len(request.testFilter) gt 0)
-		systemOutput(NL & "Filtering only tests containing: [" & request.testFilter & "]" & NL, true);	
+	if (Arraylen(request.testFilter) gt 0)
+		systemOutput(NL & "Filtering only tests containing: " & request.testFilter.toJson() & NL, true);	
 	else
-		systemOutput(NL & 'Running all tests, to run a subset of test(s), use the parameter -DtestFilter="image"'& NL, true);	
+		systemOutput(NL & 'Running all tests, to run a subset of test(s), use the parameter -DtestFilter="image,orm,etc"'& NL, true);	
 
 	// output deploy log
 	pc=getPageContext();
@@ -175,29 +176,75 @@ try {
 			dir = {
 				 mapping : "/test"
 				,recurse : true
-				,filter  : function(path){
-		//			echo(arguments.path&"
-		//");
-					var name=listLast(arguments.path,"\/");
-					if (len(request.testFilter) gt 0 and FindNoCase(request.testFilter, arguments.path) eq 0) return false;
+				,filter  : function(path) localmode=true {
+					var isValidTestCase = function ( string path ){
+						// get parent
+						var testDir = getDirectoryFromPath( arguments.path );
+						testDir = listCompact(left( testDir, testDir.len() - 1 ), "\/" );
+						var name = listLast( arguments.path, "\/" );
 
-					// get parent
-					var p = getDirectoryFromPath(arguments.path);
-					p = left(p, p.len() - 1);
-					p = listCompact(p, "\/");
+						switch ( true ){
+							case ( left (name, 1 ) == "_" ):
+								return "test has _ prefix (#name#)";
+							case ( checkTestFilter( arguments.path ) ):
+								return "excluded by testFilter";
+							case ( FindNoCase( request.testFolder, testDir ) neq 1 ):
+								return "not under test dir";
+							case fileExists( testDir & "/Application.cfc" ):
+								return "test in directory with Application.cfc";
+							default:
+								break;
+						};
+						var extends = checkExtendsTestCase( arguments.path );
+						if ( extends neq "org.lucee.cfml.test.LuceeTestCase" )
+							return "test doesn't extend Lucee Test Case (#extends#)";
+						else 
+							return "";
+					};
 
-					// get grand parent
-					var pp = getDirectoryFromPath(p);
-					pp = left(pp, pp.len() - 1);
-					pp = listCompact(pp, "\/");
+					var checkTestFilter = function ( string path ){
+						if ( Arraylen( request.testFilter ) eq 0 )
+							return false;
+						loop array="#request.testFilter#" item="local.f" {
+							if ( FindNoCase( f, arguments.path ) gt 0 )
+								return false;
+						}
+						return true;
+					};
 
-					// only testcases in sub directory of "test" are allowed
-					var _test = listCompact(test,"\/");
-					return (_test == pp || _test == p) && left(name, 1) != "_";
+					var checkExtendsTestCase = function (string path){
+						// finally only allow files which extend "org.lucee.cfml.test.LuceeTestCase"
+						var cfcPath = ListChangeDelims( "/test" & Mid( arguments.path, len( request.testFolder ) + 1 ), ".", "/\" );
+						cfcPath = mid( cfcPath, 1, len( cfcPath ) - 4 );
+						try {
+							// triggers a compile, which make the initial filter slower, but it would be compiled later anyway
+							var meta = GetComponentMetaData( cfcPath ); 
+						} catch ( e ){
+							return cfcatch.message;
+						}
+						return meta.extends.fullname ?: "";
+					};
+
+					allowed = isValidTestCase( arguments.path );
+					// SystemOutput( arguments.path & " :: " & allowed, true );
+					if ( allowed != "" ){
+						//SystemOutput( arguments.path & " :: " & allowed, true );
+						return false;
+					} else {
+						return true;
+					}
 				}
 			};
 
+			filterTimer = getTickCount();
 			tb = new testbox.system.TestBox(directory=dir, reporter="console");
+
+			SystemOutput("Found #tb.getBundles().len()# tests to run, filter took #getTickCount()-filterTimer#ms", true);
+			if (false and Arraylen(request.testFilter)){
+				// dump matches by testFilter
+				for (b in tb.getBundles())
+					SystemOutput(b, true);
+			}
 
 			// execute
 			report = tb.run(callbacks=

--- a/ant/run-testcases.xml
+++ b/ant/run-testcases.xml
@@ -151,64 +151,58 @@ try {
 
 	systemOutput(NL & "-------------- Start Tests -----------", true);
 	silent {
-		try {
-			testResults = new test._testRunner().runTests();
-		} catch(e) {
-			testResults = {};
-			systemOutput( cfcatch.message, true );
-		}
+		testResults = new test._testRunner().runTests();
 	}
-	echo( NL & NL & "---------- post test result #structKeyList(testResults)# ----------------" & NL ); // DEBUG, full run doesn't get here?
 	result = testResults.result;
 	failedTestcases = testResults.failedTestcases;
 	tb = testResults.tb;
 
-	echo(NL & NL & "=============================================================" & NL);
-	echo("TestBox Version: #tb.getVersion()#" & NL);
-	echo("Lucee Version: #server.lucee.version#" & NL);
-	echo("Java Version: #server.java.version#" & NL);
-	echo("Total Execution time: (#NumberFormat( ( getTickCount()-request._start) / 1000 )# s)" & NL);
-	echo("Test Execution time: (#NumberFormat( result.getTotalDuration() /1000 )# s)" & NL);
-	echo("Average Test Overhead: (#NumberFormat( ArrayAvg( request.overhead ) )# ms)" & NL);
-	echo("Total Test Overhead: (#NumberFormat( ArraySum( request.overhead ) )# ms)" & NL);
+	systemOutput( NL & NL & "=============================================================", true );
+	systemOutput( "TestBox Version: #tb.getVersion()#", true );
+	systemOutput( "Lucee Version: #server.lucee.version#", true );
+	systemOutput( "Java Version: #server.java.version#", true );
+	systemOutput( "Total Execution time: (#NumberFormat( ( getTickCount()-request._start) / 1000 )# s)", true );
+	systemOutput( "Test Execution time: (#NumberFormat( result.getTotalDuration() /1000 )# s)", true );
+	systemOutput( "Average Test Overhead: (#NumberFormat( ArrayAvg( request.overhead ) )# ms)", true );
+	systemOutput( "Total Test Overhead: (#NumberFormat( ArraySum( request.overhead ) )# ms)", true );
 
-	echo("=============================================================" & NL & NL);
-	echo("-> Bundles/Suites/Specs: #result.getTotalBundles()#/#result.getTotalSuites()#/#result.getTotalSpecs()#" & NL);
-	echo("-> Pass:     #result.getTotalPass()#" & NL);
-	echo("-> Skipped:  #result.getTotalSkipped()#" & NL);
-	echo("-> Failures: #result.getTotalFail()#" & NL);
-	echo("-> Errors:   #result.getTotalError()#" & NL);
+	systemOutput( "=============================================================" & NL, true );
+	systemOutput( "-> Bundles/Suites/Specs: #result.getTotalBundles()#/#result.getTotalSuites()#/#result.getTotalSpecs()#", true );
+	systemOutput( "-> Pass:     #result.getTotalPass()#", true );
+	systemOutput( "-> Skipped:  #result.getTotalSkipped()#", true );
+	systemOutput( "-> Failures: #result.getTotalFail()#", true );
+	systemOutput( "-> Errors:   #result.getTotalError()#", true );
 
 	servicesReport = new test._setupTestServices().reportServiceSkipped();
-	for (s in servicesReport){
-		echo ( s & NL );
+	for ( s in servicesReport ){
+		systemOutput ( s, true );
 	}
 
 	if ( !isEmpty( failedTestCases ) ){
-		echo( NL );
+		systemOutput( NL );
 		for ( el in failedTestCases ){
-			echo( el.type & ": " & el.bundle & NL & TAB & el.testCase & NL );
-			echo( TAB & el.errMessage & NL );
+			systemOutput( el.type & ": " & el.bundle & NL & TAB & el.testCase, true );
+			systemOutput( TAB & el.errMessage, true );
 			if ( !isEmpty( el.stackTrace ) ){
-				//echo(TAB & TAB & "at" & NL);
+				//systemOutput( TAB & TAB & "at", true);
 				for ( frame in el.stackTrace ){
-					echo( TAB & TAB & frame & NL );
+					systemOutput( TAB & TAB & frame, true );
 				}
 			}
-			echo( NL );
+			systemOutput( NL );
 		}
-		echo( NL );
+		systemOutput( NL );
 	}
 
 	if ( ( result.getTotalFail() + result.getTotalError() ) > 0 ) {
 		throw "TestBox could not successfully execute all testcases: #result.getTotalFail()# tests failed; #result.getTotalError()# tests errored.";
 	}
 } catch( e ){
-	echo( "-------------------------------------------------------" & NL );
-	echo( "Testcase failed:" & NL );
-	echo( e.message & NL );
-	echo( ReReplace( Serialize( e ), "[\r\n]\s*([\r\n]|\Z)", Chr( 10 ) , "ALL" ) & NL ); // avoid too much whitespace from dump
-	echo( "-------------------------------------------------------" & NL );
+	systemOutput( "-------------------------------------------------------", true );
+	systemOutput( "Testcase failed:", true );
+	systemOutput( e.message, true );
+	systemOutput( ReReplace( Serialize( e.stacktrace ), "[\r\n]\s*([\r\n]|\Z)", Chr( 10 ) , "ALL" ), true ); // avoid too much whitespace from dump
+	systemOutput( "-------------------------------------------------------", true );
 	rethrow;
 }
 

--- a/core/src/main/java/lucee/runtime/jsr223/ScriptEngineImpl.java
+++ b/core/src/main/java/lucee/runtime/jsr223/ScriptEngineImpl.java
@@ -64,7 +64,17 @@ public class ScriptEngineImpl implements ScriptEngine {
 			return res.getValue();
 		}
 		catch (PageException pe) {
+			pe.printStackTrace();
 			throw toScriptException(pe);
+		}
+		catch (RuntimeException re) {
+			re.printStackTrace();
+			throw re;
+		}
+		catch (Throwable t) {
+			if (t instanceof ThreadDeath) throw (ThreadDeath) t;
+			t.printStackTrace();
+			throw new RuntimeException(t);
 		}
 		finally {
 			releasePageContext(pc, oldPC);

--- a/test/_setupTestServices.cfc
+++ b/test/_setupTestServices.cfc
@@ -136,19 +136,21 @@ component {
 		systemOutput( "", true) ;		
 		systemOutput("-------------- Test Services ------------", true );
 
-		loop list="MySQL,MSsql,postgres,h2,oracle,mongoDb,smtp,pop,imap,s3,ftp,sftp" item="service" {
-			cfg = server.getTestService( service=service, verify=true );
-			server.test_services[ service ]= {
+		services = ListToArray("oracle,MySQL,MSsql,postgres,h2,mongoDb,smtp,pop,imap,s3,ftp,sftp");
+		// take a while, do them in parallel
+		services.each( function( service ) localmode=true {
+			cfg = server.getTestService( service=arguments.service, verify=true );
+			server.test_services[ arguments.service ]= {
 				valid: false,
 				missedTests: 0
 			};
 			if ( StructCount(cfg) eq 0 ){
-				systemOutput( "Service [ #service# ] not configured", true) ;
+				systemOutput( "Service [ #arguments.service# ] not configured", true) ;
 			} else {
 				// validate the cfg
 				verify = "configured, but not tested";
 				try {
-					switch ( service ){
+					switch ( arguments.service ){
 						case "s3":
 							s3 = verifyS3(cfg);
 							break;
@@ -159,10 +161,10 @@ component {
 						case "smtp":
 							break;
 						case "ftp":
-							verify = verifyFTP(cfg, service);
+							verify = verifyFTP(cfg, arguments.service);
 							break;
 						case "sftp":
-							verify = verifyFTP(cfg, service);
+							verify = verifyFTP(cfg, arguments.service);
 							break;
 						case "mongoDb":
 							verify = verifyMongo(cfg);
@@ -171,14 +173,14 @@ component {
 							verify = verifyDatasource(cfg);
 							break;
 					}
-					systemOutput( "Service [ #service# ] is [ #verify# ]", true) ;
-					server.test_services[service].valid = true;
+					systemOutput( "Service [ #arguments.service# ] is [ #verify# ]", true) ;
+					server.test_services[arguments.service].valid = true;
 				} catch (e) {
-					systemOutput( "ERROR Service [ #service# ] threw [ #cfcatch.message# ]", true);
+					systemOutput( "ERROR Service [ #arguments.service# ] threw [ #cfcatch.message# ]", true);
 				}
 			}
-		}
-		systemOutput( " ", true) ;
+		}, true, 4);
+		systemOutput( " ", true);
 	}
 
 	public array function reportServiceSkipped () localmode=true {

--- a/test/_testRunner.cfc
+++ b/test/_testRunner.cfc
@@ -1,0 +1,282 @@
+component {
+	public function init (){
+		return this;
+	}
+
+	public function getTestFilter () {
+		var dir = {
+			mapping : "/test"
+		   ,recurse : true
+		   ,filter  : function(path) localmode=true {
+			   var isValidTestCase = function ( string path ){
+				   // get parent
+				   var testDir = getDirectoryFromPath( arguments.path );
+				   testDir = listCompact(left( testDir, testDir.len() - 1 ), "\/" );
+				   if ( left( arguments.path, 1 ) eq "/")
+					   testDir = "/" & testDir; // avoid issues with non windows paths
+				   var name = listLast( arguments.path, "\/" );
+
+				   switch ( true ){
+					   case ( left (name, 1 ) == "_" ):
+						   return "test has _ prefix (#name#)";
+					   case ( checkTestFilter( arguments.path ) ):
+						   return "excluded by testFilter";
+					   case ( FindNoCase( request.testFolder, testDir ) neq 1 ):
+						   return "not under test dir (#request.testFolder#, #testDir#)";
+					   case fileExists( testDir & "/Application.cfc" ):
+						   return "test in directory with Application.cfc";
+					   default:
+						   break;
+				   };
+				   var extends = checkExtendsTestCase( arguments.path );
+				   if ( extends neq "org.lucee.cfml.test.LuceeTestCase" )
+					   return "test doesn't extend Lucee Test Case (#extends#)";
+				   else
+					   return "";
+			   };
+
+			   var checkTestFilter = function ( string path ){
+				   if ( Arraylen( request.testFilter ) eq 0 )
+					   return false;
+				   loop array="#request.testFilter#" item="local.f" {
+					   if ( FindNoCase( f, arguments.path ) gt 0 )
+						   return false;
+				   }
+				   return true;
+			   };
+
+			   var checkExtendsTestCase = function (string path){
+				   // finally only allow files which extend "org.lucee.cfml.test.LuceeTestCase"
+				   var cfcPath = ListChangeDelims( "/test" & Mid( arguments.path, len( request.testFolder ) + 1 ), ".", "/\" );
+				   cfcPath = mid( cfcPath, 1, len( cfcPath ) - 4 );
+				   try {
+					   // triggers a compile, which make the initial filter slower, but it would be compiled later anyway
+					   var meta = GetComponentMetaData( cfcPath );
+				   } catch ( e ){
+					   return cfcatch.message;
+				   }
+				   return meta.extends.fullname ?: "";
+			   };
+
+			   allowed = isValidTestCase( arguments.path );
+			   //SystemOutput( arguments.path & " :: " & allowed, true );
+			   if ( allowed != "" ){
+				   //SystemOutput( arguments.path & " :: " & allowed, true );
+				   return false;
+			   } else {
+				   return true;
+			   }
+		   }
+	   };
+	   return dir;
+	}
+
+	public struct function runTests() localmode=true {
+		SystemOut = createObject( "java", "lucee.commons.lang.SystemOut" );
+		out = SystemOut.setOut( nullValue() );
+		//err=SystemOut.setErr(nullValue());
+		TAB = chr( 9 );
+		NL = chr( 10 ) & chr( 13 );
+		failedTestCases = [];
+
+		// strips off the stack trace to exclude testbox and back to the first .cfc call in the stack
+		function printStackTrace( st ){
+			local.i = find( "/testbox/", arguments.st );
+			if ( i eq 0 ){ // dump it all out
+				systemOutput( TAB & arguments.st, true );
+				return;
+			}
+			local.tmp = mid( arguments.st, 1, i ); // strip out anything after testbox
+			local.tmp2 = reverse( local.tmp );
+			local.i = find( ":cfc.", local.tmp2 ); // find the first cfc line
+			if ( local.i gt 0 ){
+				local.i = len( local.tmp )-i;
+				local.j = find( ")", local.tmp, local.i ); // find the end of the line
+				local.tmp = mid( local.tmp, 1, local.j );
+			}
+			systemOutput( TAB & local.tmp, true );
+		};
+
+		try {
+
+			var filterTimer = getTickCount();
+			var tb = new testbox.system.TestBox( directory=getTestFilter(), reporter="console" );
+
+			SystemOutput( "Found #tb.getBundles().len()# tests to run, filter took #getTickCount()-filterTimer#ms", true );
+			if (false and Arraylen( request.testFilter )){
+				// dump matches by testFilter
+				for ( b in tb.getBundles() )
+					SystemOutput( b, true );
+			}
+			// formatting is odd, because we are outputting to the console and whitespace matters
+			// execute
+			tb.run(callbacks=
+{
+	 onBundleStart = function( cfc, testResults ){
+		var meta = getComponentMetadata( cfc );
+		SystemOut.setOut( out );
+		//SystemOut.setErr(err);
+		//"============================================================="
+		systemOutput( TAB & meta.name, false );
+		SystemOut.setOut( nullValue() );
+		//SystemOut.setErr(nullValue());
+	} // onBundleStart = function
+	,onBundleEnd = function( cfc, testResults ){
+		var bundle = arrayLast( testResults.getBundleStats() );
+		var oh = ( getTickCount() - request._tick )-bundle.totalDuration;
+		request._tick = getTickCount();
+		ArrayAppend( request.overhead, oh );
+		try {
+			SystemOut.setOut( out );
+			//SystemOut.setErr(err);
+			systemOutput( TAB & " (#bundle.totalPass# tests passed in #NumberFormat(bundle.totalDuration)# ms)", true );
+			//mem("non_heap");
+			//mem("heap");
+		// we have an error
+		if ( ( bundle.totalFail + bundle.totalError ) > 0 ) {
+
+			systemOutput( "ERRORED" & NL & "	Suites/Specs: #bundle.totalSuites#/#bundle.totalSpecs#
+	Failures: #bundle.totalFail#
+	Errors:   #bundle.totalError#
+	Pass:     #bundle.totalPass#
+	Skipped:  #bundle.totalSkipped#"
+			, true );
+
+			if ( !isNull( bundle.suiteStats ) ) {
+				loop array=bundle.suiteStats item="local.suiteStat" {
+					if ( !isNull( suiteStat.specStats ) ) {
+						loop array=suiteStat.specStats item="local.specStat" {
+
+							if ( !isNull( specStat.failMessage ) && len( trim( specStat.failMessage ) ) ) {
+
+								var failedTestCase = {
+									 type       : "Failed"
+									,bundle     : bundle.name
+									,testCase   : specStat.name
+									,errMessage : specStat.failMessage
+									,stackTrace : []
+								};
+								failedTestCases.append( failedTestCase );
+
+								systemOutput( NL & specStat.name );
+								systemOutput( NL & TAB & "Failed: " & specStat.failMessage, true );
+
+								if ( !isNull( specStat.failOrigin ) && !isEmpty( specStat.failOrigin ) ){
+
+									var rawStackTrace = specStat.failOrigin;
+									var testboxPath = getDirectoryFromPath( rawStackTrace[1].template );
+
+									//systemOutput(TAB & TAB & "at", true);
+
+									loop array=rawStackTrace item="local.st" index="local.i" {
+
+										if ( !st.template.hasPrefix( testboxPath ) ){
+											if ( local.i eq 1 or st.template does not contain "testbox" ){
+												var frame = st.template & ":" & st.line;
+												failedTestCase.stackTrace.append( frame );
+												systemOutput( TAB & frame, true );
+											}
+										}
+									}
+								}
+								systemOutput( NL );
+							} // if !isNull
+
+							if ( !isNull( specStat.error ) && !isEmpty( specStat.error ) ){
+
+								var failedTestCase = {
+									 type       : "Errored"
+									,bundle     : bundle.name
+									,testCase   : specStat.name
+									,errMessage : specStat.error.Message
+									,stackTrace : []
+								};
+								failedTestCases.append( failedTestCase );
+
+								systemOutput( NL & specStat.name );
+								systemOutput( NL & TAB & "Errored: " & specStat.error.Message, true );
+								if ( len( specStat.error.Detail ) )
+									systemOutput( TAB & "Detail: " & specStat.error.Detail, true );
+
+								if ( !isNull( specStat.error.TagContext ) && !isEmpty( specStat.error.TagContext ) ){
+
+									var rawStackTrace = specStat.error.TagContext;
+
+									//systemOutput(TAB & TAB & "at", true);
+
+									loop array=rawStackTrace item="local.st" index="local.i" {
+										if ( local.i eq 1 or st.template does not contain "testbox" ){
+											var frame = st.template & ":" & st.line;
+											failedTestCase.stackTrace.append( frame );
+											systemOutput( TAB & frame, true );
+										}
+									}
+									systemOutput( NL );
+									/*
+									if (arrayLen(rawStackTrace) gt 0){
+										systemOutput(TAB & rawStackTrace[1].codePrintPlain, true);
+										systemOutput(NL);
+									}
+									*/
+								}
+								if ( !isNull( specStat.error.StackTrace ) && !isEmpty( specStat.error.StackTrace ) ){
+									printStackTrace( specStat.error.StackTrace );
+									systemOutput( NL );
+								}
+
+							//	systemOutput(NL & serialize(specStat.error), true);
+
+							} // if !isNull
+						}
+					}
+				}
+			}
+			//systemOutput(serializeJson(bundle.suiteStats));
+		}
+	// exceptions
+	if ( !isSimpleValue( bundle.globalException ) ) {
+		systemOutput( "Global Bundle Exception
+		#bundle.globalException.type#
+		#bundle.globalException.message#
+		#bundle.globalException.detail#
+=============================================================
+Begin Stack Trace
+=============================================================
+#bundle.globalException.stacktrace#
+=============================================================
+  End Stack Trace
+=============================================================", true);
+	}
+
+//systemOutput("=============================================================",true);
+		} // try
+		finally {
+			SystemOut.setOut( nullValue() );
+			//SystemOut.setErr(nullValue());
+		} // finally
+	} // onBundleEnd = function
+	/*,onSuiteStart 	= function( bundle, testResults, suite ){}
+	,onSuiteEnd		= function( bundle, testResults, suite ){}
+	,onSpecStart		= function( bundle, testResults, suite, spec ){}
+	,onSpecEnd 		= function( bundle, testResults, suite, spec ){}*/
+} // callbacks
+			); // report = tb.run
+
+	 		// get the result
+
+	}
+	finally {
+		//SystemOut.setOut(out);
+		//SystemOut.setErr(err);
+	} // try
+	
+	testResults = {
+		result: tb.getResult(),
+		failedTestCases: failedTestCases,
+		tb: tb
+	};
+	systemOutput("--------------------before return #structKeyList(testResults)#--------------------",true);
+	return testResults;
+}
+
+}

--- a/test/_testRunner.cfc
+++ b/test/_testRunner.cfc
@@ -269,13 +269,12 @@ Begin Stack Trace
 		//SystemOut.setOut(out);
 		//SystemOut.setErr(err);
 	} // try
-	
+
 	testResults = {
 		result: tb.getResult(),
 		failedTestCases: failedTestCases,
 		tb: tb
-	};
-	systemOutput("--------------------before return #structKeyList(testResults)#--------------------",true);
+	};	
 	return testResults;
 }
 

--- a/test/tickets/LDEV0835/Base.cfc
+++ b/test/tickets/LDEV0835/Base.cfc
@@ -1,11 +1,10 @@
 component {
-		static {
-		
-	static.base="Base";
-	static.all="Base";
+	static {		
+		static.base="Base";
+		static.all="Base";
 	}
 
 	public static string function getData(){
-		return static.base&":"&static.all;
+		return static.base & " : " & static.all;
 	}
 }

--- a/test/tickets/LDEV2005.cfc
+++ b/test/tickets/LDEV2005.cfc
@@ -5,12 +5,12 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	}
 
 	public void function testGetBaseTemplatePath(){
-		assertEquals("TestBox.cfc",listLast(GetBaseTemplatePath(),"\/"));
+		assertEquals("_testRunner.cfc",listLast(GetBaseTemplatePath(),"\/"));
 	}
 
 	public void function testGetTemplatePath(){
 		var arr=GetTemplatePath();
-		assertEquals("TestBox.cfc",listLast(arr[1],"\/"));
+		assertEquals("TestBox.cfc",listLast(arr[2],"\/"));
 		assertEquals("LDEV2005.cfc",listLast(arr[arr.len()],"\/"));
 	}
 } 


### PR DESCRIPTION
change test filter checks to be clearer
- only allow tests which extend "org.lucee.cfml.test.LuceeTestCase"
- this allows moving tests around into deeper subdirectories

support a comma delimitered list of testFilters  i.e "mysql,oracle", i.e. multiple filters

check test datasources in parallel (oracle is slow), saves 4s per run