### PR TITLE
add -DtestExtensions="ext dist dir" to build process

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -65,6 +65,7 @@
     <property name="test" location="${rootDir}/test"/>
     <property name="testFilter" value=""/>
     <property name="testLabels" value=""/>
+    <property name="testExtensions" value=""/>
     <property name="temp" location="${rootDir}/temp"/>
     <property name="loader" location="${temp}/loader"/>
     <property name="core" location="${temp}/core"/>
@@ -489,6 +490,11 @@
 </target>
 
 <target name="__build_testbox" if="testcases">
+    <!-- optionally install test lucee extensions from a directory -->
+    <deployTestExtensions
+      srcdir="${testExtensions}" 
+      deploydir="${temp}/archive/base/lucee-server/deploy/"/>
+
     <listDirectory directory="${test}/lib" delimiter=":" returnvalue="test_jars"/>
     <echots message="execute testcases ${testcases}"/>
     <!-- execute CFML testcases -->

--- a/ant/build-utils.xml
+++ b/ant/build-utils.xml
@@ -141,5 +141,38 @@
      ]]>
   </scriptdef>
 
+  <scriptdef name="deployTestExtensions" language="javascript" loaderRef="sharedbuild-loaderRef">
+     <attribute name="srcdir" />
+     <attribute name="deploydir" />
+     <![CDATA[
+          var srcDir = attributes.get("srcdir");
+          var deployDir = attributes.get("deploydir");
+          var echo = project.createTask( "echo" );
+          var copy = project.createTask( "copy" );
+
+          if ( srcDir && srcDir.length > 0 ){
+            var dir = new java.io.File( srcDir );
+            var deployDir = new java.io.File( deployDir );
+            var exts = dir.listFiles();
+            
+            if (exts != null )
+              if ( !deployDir.exists() )
+                deployDir.mkdirs();
+              echo.setMessage( "Adding test extensions (*.lex) from: [" + srcDir +"]");
+              echo.perform();
+              for(var i = 0 ; i < exts.length ; i++ ) {
+                var path = exts[i].getPath();
+                if ( !path.endsWith( ".lex" ) ) 
+                  continue;
+                copy.setFile( new java.io.File( path ) );
+                copy.setTofile( new java.io.File( deployDir + "/" + exts[i].getName() ) );
+                echo.setMessage( "Deploying test extension: [" + path + "] to [" + deployDir + "/" + exts[i].getName() + "]" );
+                echo.perform();
+                copy.perform();
+            }
+          }
+     ]]>
+  </scriptdef>
+
 
 </project>

--- a/test/tickets/LDEV2660.cfc
+++ b/test/tickets/LDEV2660.cfc
@@ -1,4 +1,4 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" skip="true"{
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="zip" skip="true"{
 	function beforeAll(){
 		variables.uri = createURI("LDEV2660");
 	}
@@ -8,14 +8,14 @@ component extends="org.lucee.cfml.test.LuceeTestCase" skip="true"{
 			it(title = "Checking overwrite attribute in cfzip action=unzip", body = function( currentSpec ) {
 				local.result = _InternalRequest(
 					template:"#variables.uri#/index.cfm"
-                );
+				);
 				expect(local.result.filecontent.trim()).toBe("true");
 			});
 		});
 	}
 
 	private string function createURI(string calledName){
-		var baseURI="/test/#listLast(getDirectoryFromPath(getCurrenttemplatepath()),"\/")#/";
+		var baseURI="/test/#listLast(getDirectoryFromPath(getCurrentTemplatePath()),"\/")#/";
 		return baseURI&""&calledName;
 	}
 }


### PR DESCRIPTION
allows testing local builds of extensions

```
ant -DtestLabels="zip" -DtestExtensions="C:\work\lucee-extensions\extension-compress\dist"
```
__build_testbox:
[deployTestExtensions] Warning: Nashorn engine is planned to be removed from a future JDK release
     [echo] Adding test extensions (*.lex) from: [C:\work\lucee-extensions\extension-compress\dist]
     [echo] Deploying test extension: [C:\work\lucee-extensions\extension-compress\dist\compress-extension-1.0.0.4-SNAPSHOT.lex] to [C:\work\lucee6\temp\archive\base\lucee-server\deploy/compress-extension-1.0.0.4-SNAPSHOT.lex]
     [copy] Copying 1 file to C:\work\lucee6\temp\archive\base\lucee-server\deploy
```
