### PR TITLE
add support for running additional tests (-DtestAdditional="dir")

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -63,9 +63,14 @@
     <property name="srcInst" location="${rootDir}/instrumentation/src/main/java"/> 
     <property name="ant" location="${rootDir}/ant"/>
     <property name="test" location="${rootDir}/test"/>
+    <!-- free text filter, comma delimitered to filter tests based on path -->
     <property name="testFilter" value=""/>
+    <!-- list of labels to filter tests by, comma delimitered -->
     <property name="testLabels" value=""/>
+    <!-- a local directory to install additional extensions -->
     <property name="testExtensions" value=""/>
+    <!-- a local directory to run additional tests  -->
+    <property name="testAdditional" value=""/>
     <property name="temp" location="${rootDir}/temp"/>
     <property name="loader" location="${temp}/loader"/>
     <property name="core" location="${temp}/core"/>
@@ -511,6 +516,7 @@
       <jvmarg value="-Dtest=${test}"/>
       <jvmarg value="-DtestFilter=${testFilter}"/>
       <jvmarg value="-DtestLabels=${testLabels}"/>
+      <jvmarg value="-DtestAdditional=${testAdditional}"/>      
       <jvmarg value="-Dtemp=${temp}"/>
       <jvmarg value="-Dbasedir=${baseDir}"/>
       <jvmarg value="-Dsrcall=${srcAll}"/>

--- a/test/_testRunner.cfc
+++ b/test/_testRunner.cfc
@@ -4,35 +4,38 @@ component {
 	}
 
 	// testbox doesn't always sort the order of tests, so we do it manually LDEV-3541
-	public array function getBundles(){
-		var bundles = directoryList( path="/test", recurse=true, listInfo="path", filter="*.cfc" )
-			.filter( filter=testFilter, parallel=true ); // directoryList doesn't allow parallel filters
-		
-		var rootPathLen = ExpandPath( "/test" ).len() - 4;
-		ArrayEach( bundles, function( el, idx, arr ){
-			var clean  = ListChangeDelims( mid( arguments.el, rootPathLen ), ".", "/\" ); // strip off dir prefix
-			arguments.arr[ arguments.idx ] = mid( clean, 1, len( clean ) - 4 ); // strip off .cfc
-		});
+	public array function getBundles( testMapping, testDirectory ){
+		var srcBundles = directoryList( path=arguments.testMapping, recurse=true, listInfo="path", filter="*.cfc" );
+		var testDirectoryLen = len( arguments.testDirectory );
+		var mapping = ListChangeDelims( arguments.testMapping, "", "/\" ); 
+		var bundles = [];
+		ArrayEach( array=srcBundles, closure=function( el, idx, arr ){
+			if ( testFilter( arguments.el, testDirectory, testMapping ) ) {
+				var clean  = ListChangeDelims( mid( arguments.el, testDirectoryLen + 1  ), ".", "/\" ); // strip off dir prefix
+				arrayAppend(bundles, mapping & "." & mid( clean, 1, len( clean ) - 4 ) ); // strip off .cfc
+			}
+		}, parallel=true );
 		ArraySort( bundles, "textnocase", "asc" );
 		return bundles;
 	}
 
-	public boolean function testFilter ( string path ) localmode=true {
+	public boolean function testFilter ( string path, string testDirectory, string testMapping ) localmode=true {
+		//systemOutput(arguments, true);
 		var isValidTestCase = function ( string path ){
 			// get parent
 			var testDir = getDirectoryFromPath( arguments.path );
-			testDir = listCompact(left( testDir, testDir.len() - 1 ), "\/" );
+			testDir = listCompact( left( testDir, testDir.len() - 1 ), "\/" );
 			if ( left( arguments.path, 1 ) eq "/")
 				testDir = "/" & testDir; // avoid issues with non windows paths
 			var name = listLast( arguments.path, "\/" );
-			var testPath = Mid(arguments.path, len(request.testFolder) + 1); // otherwise "image" would match extension-image on CI
+			var testPath = Mid( arguments.path, len( testDirectory ) + 1); // otherwise "image" would match extension-image on CI
 			switch ( true ){
 				case ( left (name, 1 ) == "_" ):
 					return "test has _ prefix (#name#)";
 				case ( checkTestFilter( testPath ) ):
 					return "excluded by testFilter";
-				case ( FindNoCase( request.testFolder, testDir ) neq 1 ):
-					return "not under test dir (#request.testFolder#, #testDir#)";
+				case ( FindNoCase( testDirectory, testDir ) neq 1 ):
+					return "not under test dir (#testDirectory#, #testDir#)";
 				case fileExists( testDir & "/Application.cfc" ):
 					return "test in directory with Application.cfc";
 				default:
@@ -67,8 +70,8 @@ component {
 
 		var getTestMeta = function (string path){
 			// finally only allow files which extend "org.lucee.cfml.test.LuceeTestCase"
-			var cfcPath = ListChangeDelims( "/test" & Mid( arguments.path, len( request.testFolder ) + 1 ), ".", "/\" );
-			cfcPath = mid( cfcPath, 1, len( cfcPath ) - 4 );
+			var cfcPath = ListChangeDelims( testMapping & Mid( arguments.path, len( testDirectory ) + 1 ), ".", "/\" );
+			cfcPath = mid( cfcPath, 1, len( cfcPath ) - 4 ); // strip off ".cfc"
 			try {
 				// triggers a compile, which make the initial filter slower, but it would be compiled later anyway
 				// GetComponentMetaData leaks output https://luceeserver.atlassian.net/browse/LDEV-3582
@@ -135,9 +138,20 @@ component {
 
 		try {
 			var filterTimer = getTickCount();
-			var tb = new testbox.system.TestBox( bundles=getBundles(), reporter="console" );
+			var bundles = getBundles( "/test", request.testFolder );
+			//SystemOutput( bundles, true);
+			var additionalBundles = [];
+			if ( len( request.testAdditional ) ){
+				additionalBundles = getBundles( "/testAdditional", request.testAdditional );
+				// SystemOutput( additionalBundles, true );
+				bundles = ArrayMerge( bundles, additionalBundles );
+			}
+			var tb = new testbox.system.TestBox( bundles=bundles, reporter="console" );
 
 			SystemOutput( "Found #tb.getBundles().len()# tests to run, filter took #getTickCount()-filterTimer#ms", true );
+			if ( len( additionalBundles ) ){
+				SystemOutput( "Found #additionalBundles.len()# additional tests to run", true );
+			}
 			if (false and Arraylen( request.testFilter )){
 				// dump matches by testFilter
 				for ( b in tb.getBundles() )

--- a/test/run-tests.cfm
+++ b/test/run-tests.cfm
@@ -30,7 +30,7 @@ try {
 		type="web"
 		password="#request.WEBADMINPASSWORD#"
 		virtual="/test"
-		physical="#test#"
+		physical="#request.testFolder#"
 		toplevel="true"
 		archive=""
 		primary="physical"
@@ -104,6 +104,35 @@ try {
 		SystemOutput( "Filtering tests with the following label(s) #request.testLabels.toJson()#", true );
 	else
 		systemOutput( NL & 'Running all tests, to run a subset of test(s), use the parameter -DtestLabels="s3,oracle"', true );
+
+	param name="testAdditional" default="";	
+	request.testAdditional = testAdditional;
+
+	if ( len( request.testAdditional ) eq 0 ){
+		request.testAdditional = server._getSystemPropOrEnvVars("testAdditional", "", false);
+		if ( structCount( request.testAdditional ) )
+			request.testAdditional = request.testAdditional.testAdditional;
+		else
+			request.testAdditional="";
+	}		
+	if ( len(request.testAdditional) ){
+		SystemOutput( "Adding additional tests from [#request.testAdditional#]", true );
+		if (!DirectoryExists( request.testAdditional )){
+			SystemOutput( "ERROR directory [#request.testAdditional#] doesn't exist!", true );
+			request.testAdditional = "";
+		} else {
+			admin
+				action="updateMapping"
+				type="web"
+				password="#request.WEBADMINPASSWORD#"
+				virtual="/testAdditional"
+				physical="#testAdditional#"
+				toplevel="true"
+				archive=""
+				primary="physical"
+				trusted="no";
+		}
+	}
 
 	// output deploy log
 	pc = getPageContext();


### PR DESCRIPTION
this build parameter allows you to include additional testbox cases from a directory

useful for running extended tests for an extension

`ant -DtestFilter="zip" -DtestAdditional="C:\work\lucee-extensions\extension-compress\tests"`

