### PR TITLE
fix: Don't use the Lucee DatasourceManager for ORM connections - LDEV-1564

### DIFF
--- a/core/src/main/java/lucee/runtime/PageContextImpl.java
+++ b/core/src/main/java/lucee/runtime/PageContextImpl.java
@@ -3457,8 +3457,6 @@ public final class PageContextImpl extends PageContext {
 			if (!create) return null;
 			ormSession = config.getORMEngine(this).createSession(this);
 		}
-		DatasourceManagerImpl manager = (DatasourceManagerImpl) getDataSourceManager();
-		manager.add(this, ormSession);
 
 		return ormSession;
 	}


### PR DESCRIPTION
Fixes LDEV-1564 by removing the use of the Lucee DatasourceManager for ORM connections. 

See this commit on the Hibernate extension - it's clear that the ORM extension contains its own session / connection manager.

https://github.com/lucee/extension-hibernate/commit/fe8c7f314f3ca98cd4d8d468399414eac24b8718

https://luceeserver.atlassian.net/browse/LDEV-1564