### PR TITLE
don't append / to the front of a windows path

### DIFF
--- a/core/src/main/java/lucee/commons/io/res/util/ResourceUtil.java
+++ b/core/src/main/java/lucee/commons/io/res/util/ResourceUtil.java
@@ -373,6 +373,10 @@ public final class ResourceUtil {
 		return SystemUtil.isWindows() && (path.startsWith("//") || path.startsWith("\\\\"));
 	}
 
+	public static boolean isWindowsPath(String path) {
+		return SystemUtil.isWindows() && path.length() > 1 && path.charAt(1) == ':';
+	}
+
 	/**
 	 * translate the path of the file to an existing file path by changing case of letters Works only on
 	 * Linux, because
@@ -590,7 +594,7 @@ public final class ResourceUtil {
 		path = prettifyPath(path);
 
 		// begin
-		if (slashAdBegin) {
+		if (slashAdBegin && !isWindowsPath(path)) {
 			if (path.indexOf('/') != 0) path = '/' + path;
 		}
 		else {


### PR DESCRIPTION
check to see if on windows, if the second character of the path is a `:`  i.e. `c:\lucee\etc`  ,  don't prefix a slash

https://luceeserver.atlassian.net/browse/LDEV-3328