### PR TITLE
update core-cfml.tld application attribute mail to mailservers and add modifier attribute to cffunction

### DIFF
--- a/core/src/main/java/resource/tld/core-cfml.tld
+++ b/core/src/main/java/resource/tld/core-cfml.tld
@@ -218,11 +218,20 @@
 		</attribute>
 		<attribute>
 			<type>array</type>
-			<name>mails</name>
-			<alias>mail</alias>
+			<name>mailservers</name>
+			<alias>mail,mails</alias>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description>mail servers.</description>
+			<description>Array of structs that defines the mailserver configuration. Each struct configures one mailserver. Struct keys used for smtp configuration are:
+            - host (string): host name of smtp server
+            - port (numeric): port number of smtp server
+            - username (string): smtp username
+            - password (string): smtp userpassword 
+            - ssl (boolean): enable secure connections via SSL.
+            - tls (boolean): enables Transport Layer Security.
+            - lifeTimespan (timespan): overall timeout for the connections established to the mail server.
+            - idleTimespan (timespan): idle timeout for the connections established to the mail server.
+            </description>
 		</attribute>
 		<attribute>
 			<type>struct</type>

--- a/core/src/main/java/resource/tld/core-cfml.tld
+++ b/core/src/main/java/resource/tld/core-cfml.tld
@@ -1190,6 +1190,16 @@ a timespan (created with function CreateTimeSpan): If original content date fall
 
 To use cached data, the function must be called with the exact same arguments.</description>
     </attribute>
+    <attribute>
+			<type>string</type>
+			<name>modifier</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<description>Use modifier to denote a function as abstract, static or final.
+            - abstract: implementation must be defined in extended component.
+            - final: implementation cannot be extended.
+            - static: does not access instance variables in the component.</description>
+		</attribute>
 	</tag>
 	<!-- Header -->
 	<tag>

--- a/core/src/main/java/resource/tld/core-cfml.tld
+++ b/core/src/main/java/resource/tld/core-cfml.tld
@@ -1190,7 +1190,7 @@ a timespan (created with function CreateTimeSpan): If original content date fall
 
 To use cached data, the function must be called with the exact same arguments.</description>
     </attribute>
-    <attribute>
+        <attribute>
 			<type>string</type>
 			<name>modifier</name>
 			<required>false</required>


### PR DESCRIPTION
This PR corrects the attribute "mail" for the tag "application" by renaming it to "mailservers" as exported by the administrator. I've moved the former value "mail" to the alias list.

This PR also adds the attribute "modifier" to cffunction tag