### PR TITLE
add empty application.cfc's to sub folders which don't contain actual testbox tests

### DIFF
--- a/test/functions/Duplicate/comps/some/Application.cfc
+++ b/test/functions/Duplicate/comps/some/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/functions/Duplicate/comps/some/sub/Application.cfc
+++ b/test/functions/Duplicate/comps/some/sub/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/functions/GetComponentMetadata/Application.cfc
+++ b/test/functions/GetComponentMetadata/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/general/abstract/Application.cfc
+++ b/test/general/abstract/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/general/modifiers/Application.cfc
+++ b/test/general/modifiers/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/general/static/Application.cfc
+++ b/test/general/static/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV0279/failure/Application.cfc
+++ b/test/tickets/LDEV0279/failure/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV0279/success/Application.cfc
+++ b/test/tickets/LDEV0279/success/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV0285/Application.cfc
+++ b/test/tickets/LDEV0285/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV0835/Application.cfc
+++ b/test/tickets/LDEV0835/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1102/Application.cfc
+++ b/test/tickets/LDEV1102/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1123/lib/Application.cfc
+++ b/test/tickets/LDEV1123/lib/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1152/Application.cfc
+++ b/test/tickets/LDEV1152/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1614/Application.cfc
+++ b/test/tickets/LDEV1614/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1663/Application.cfc
+++ b/test/tickets/LDEV1663/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1812/Application.cfc
+++ b/test/tickets/LDEV1812/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1818/Application.cfc
+++ b/test/tickets/LDEV1818/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV1835/Application.cfc
+++ b/test/tickets/LDEV1835/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}

--- a/test/tickets/LDEV3060/Application.cfc
+++ b/test/tickets/LDEV3060/Application.cfc
@@ -1,0 +1,3 @@
+component {
+    // place holder to prevent the testFilter checking to see if these files are test cases
+}


### PR DESCRIPTION
When we parse cfc's under the test directory, any cfc in a folder with an application.cfc is skipped

Otherwise, we compile the cfc and check the metadata, which ends up throwing irrelevant errors