### PR TITLE
LDEV-3711

### DIFF
--- a/core/src/main/java/lucee/runtime/exp/DatabaseException.java
+++ b/core/src/main/java/lucee/runtime/exp/DatabaseException.java
@@ -49,7 +49,7 @@ public final class DatabaseException extends PageExceptionImpl {
 
 		set(sqle);
 		set(dc);
-		initCause( sqle.getCause() );
+		initCause( sqle );
 	}
 
 	public DatabaseException(String message, String detail, SQL sql, DatasourceConnection dc) {

--- a/core/src/main/java/lucee/runtime/exp/DatabaseException.java
+++ b/core/src/main/java/lucee/runtime/exp/DatabaseException.java
@@ -49,6 +49,7 @@ public final class DatabaseException extends PageExceptionImpl {
 
 		set(sqle);
 		set(dc);
+		initCause( sqle.getCause() );
 	}
 
 	public DatabaseException(String message, String detail, SQL sql, DatasourceConnection dc) {


### PR DESCRIPTION
Preserve the cause in DatabaseExceptions which can contain valuable nested exceptions from the JDBC driver.