### PR TITLE
LDEV-3723: Refactor/page source impl thread safety

### DIFF
--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -294,8 +294,6 @@ public final class PageSourceImpl implements PageSource {
 	}
 
 	private boolean hasPageChanged(ConfigWeb config,Page page, Resource srcFile, long srcLastModified) {
-		if (srcLastModified == 0L) return false;
-
 		if (srcLastModified != page.getSourceLastModified() || (page instanceof PagePro && ((PagePro) page).getSourceLength() != srcFile.length())) {
 			// same size, maybe the content has not changed?
 			boolean same = false;
@@ -357,6 +355,7 @@ public final class PageSourceImpl implements PageSource {
 
 		Resource srcFile = getPhysicalFile();
 		long srcLastModified = srcFile.lastModified();
+		if (srcLastModified == 0L) return null;
 		// Page exists
 		if (page != null) {
 			if (this.hasPageChanged(config, page, srcFile, srcLastModified)) {

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -308,9 +308,9 @@ public final class PageSourceImpl implements PageSource {
 				}
 
 			}
-			return same;
+			return !same;
 		}
-		return false;
+		return true;
 	}
 
 	private Page loadClass(ConfigWeb config, Resource classFile) throws ClassFormatError, Exception {
@@ -353,7 +353,7 @@ public final class PageSourceImpl implements PageSource {
 
 		ConfigWeb config = pc.getConfig();
 		PageContextImpl pci = (PageContextImpl) pc;
-		if (page != null && (mapping.getInspectTemplate() == Config.INSPECT_NEVER || pci.isTrusted(page)) && page.getLoadType() == LOAD_PHYSICAL) return page;
+		if ((mapping.getInspectTemplate() == Config.INSPECT_NEVER || pci.isTrusted(page)) && page != null && page.getLoadType() == LOAD_PHYSICAL) return page;
 
 		Resource srcFile = getPhysicalFile();
 		long srcLastModified = srcFile.lastModified();
@@ -420,7 +420,7 @@ public final class PageSourceImpl implements PageSource {
 	}
 
 	private Page compilePhysical(ConfigWeb config, Resource classRootDir, Page existing, boolean returnValue, boolean ignoreScopes) throws TemplateException {
-		Page page = compile(config, classRootDir, existing, false, ignoreScopes);
+		Page page = compile(config, classRootDir, existing, returnValue, ignoreScopes);
 		if (page != null) {
 			page.setPageSource(this);
 			page.setLoadType(LOAD_PHYSICAL);

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -353,7 +353,7 @@ public final class PageSourceImpl implements PageSource {
 
 		ConfigWeb config = pc.getConfig();
 		PageContextImpl pci = (PageContextImpl) pc;
-		if ((mapping.getInspectTemplate() == Config.INSPECT_NEVER || pci.isTrusted(page)) && page.getLoadType() == LOAD_PHYSICAL) return page;
+		if (page != null && (mapping.getInspectTemplate() == Config.INSPECT_NEVER || pci.isTrusted(page)) && page.getLoadType() == LOAD_PHYSICAL) return page;
 
 		Resource srcFile = getPhysicalFile();
 		long srcLastModified = srcFile.lastModified();

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -94,8 +94,8 @@ public final class PageSourceImpl implements PageSource {
 	}
 
 	private static class PageAndClassName {
-		private AtomicReference<Page> page;
-		private AtomicReference<String> className;
+		private AtomicReference<Page> page = new AtomicReference<Page>();
+		private AtomicReference<String> className = new AtomicReference<String>();;
 
 		public String getClassName() {
 			return this.className.get();

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -64,13 +64,10 @@ import lucee.transformer.util.PageSourceCode;
 public final class PageSourceImpl implements PageSource {
 
 	private static final long serialVersionUID = -7661676586215092539L;
-	// public static final byte LOAD_NONE=1;
 	public static final byte LOAD_ARCHIVE = 2;
 	public static final byte LOAD_PHYSICAL = 3;
 	private static final long MAX = 1024 * 1024 * 100;
 	public static File logAccessDirectory;
-
-	// private byte load=LOAD_NONE;
 
 	private final MappingImpl mapping;
 
@@ -147,9 +144,6 @@ public final class PageSourceImpl implements PageSource {
 	 * @param isOutSide
 	 */
 	PageSourceImpl(MappingImpl mapping, String realPath, boolean isOutSide) {
-		// recompileAlways=mapping.getConfig().getCompileType()==Config.RECOMPILE_ALWAYS;
-		// recompileAfterStartUp=mapping.getConfig().getCompileType()==Config.RECOMPILE_AFTER_STARTUP ||
-		// recompileAlways;
 		this.mapping = mapping;
 		this.isOutSide = isOutSide;
 		if (realPath.indexOf("//") != -1) {
@@ -287,7 +281,6 @@ public final class PageSourceImpl implements PageSource {
 			return page;
 		}
 		catch (Exception e) {
-			// MUST print.e(e); is there a better way?
 			return null;
 		}
 	}
@@ -313,7 +306,6 @@ public final class PageSourceImpl implements PageSource {
 
 		// Page exists
 		if (page != null) {
-			// if(page!=null && !recompileAlways) {
 			if (srcLastModified != page.getSourceLastModified() || (page instanceof PagePro && ((PagePro) page).getSourceLength() != srcFile.length())) {
 				// same size, maybe the content has not changed?
 				boolean same = false;

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -285,10 +285,7 @@ public final class PageSourceImpl implements PageSource {
 		}
 	}
 
-	private boolean hasPageChanged(Page page) {
-
-		Resource srcFile = getPhysicalFile();
-		long srcLastModified = srcFile.lastModified();
+	private boolean hasPageChanged(Page page, Resource srcFile, long srcLastModified) {
 		if (srcLastModified == 0L) return false;
 
 		if (srcLastModified != page.getSourceLastModified() || (page instanceof PagePro && ((PagePro) page).getSourceLength() != srcFile.length())) {
@@ -350,9 +347,11 @@ public final class PageSourceImpl implements PageSource {
 		PageContextImpl pci = (PageContextImpl) pc;
 		if ((mapping.getInspectTemplate() == Config.INSPECT_NEVER || pci.isTrusted(page)) && this.isLoad(LOAD_PHYSICAL)) return page;
 
+		Resource srcFile = getPhysicalFile();
+		long srcLastModified = srcFile.lastModified();
 		// Page exists
 		if (page != null) {
-			if (this.hasPageChanged(page)) {
+			if (this.hasPageChanged(page, srcFile, srcLastModified)) {
 				page = this.compilePhysical(config, mapping.getClassRootDirectory(), page, false, pc.ignoreScopes());
 			} else {
 				page.setLoadType(LOAD_PHYSICAL);

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -79,7 +79,7 @@ public final class PageSourceImpl implements PageSource {
 	private String className;
 	private String fileName;
 
-	private Resource physcalSource;
+	private Resource physicalSource;
 	private Resource archiveSource;
 	private String compName;
 	private PageAndClassName pcn = new PageAndClassName();
@@ -551,15 +551,15 @@ public final class PageSourceImpl implements PageSource {
 	 */
 	@Override
 	public Resource getPhyscalFile() {
-		if (physcalSource == null) {
+		if (physicalSource == null) {
 			if (!mapping.hasPhysical()) {
 				return null;
 			}
 			Resource tmp = mapping.getPhysical().getRealResource(relPath);
-			physcalSource = ResourceUtil.toExactResource(tmp);
+			physicalSource = ResourceUtil.toExactResource(tmp);
 			// fix if the case not match
-			if (!tmp.getAbsolutePath().equals(physcalSource.getAbsolutePath())) {
-				String relpath = extractRealpath(relPath, physcalSource.getAbsolutePath());
+			if (!tmp.getAbsolutePath().equals(physicalSource.getAbsolutePath())) {
+				String relpath = extractRealpath(relPath, physicalSource.getAbsolutePath());
 				// just a security!
 				if (relPath.equalsIgnoreCase(relpath)) {
 					this.relPath = relpath;
@@ -567,7 +567,7 @@ public final class PageSourceImpl implements PageSource {
 				}
 			}
 		}
-		return physcalSource;
+		return physicalSource;
 	}
 
 	public Resource getArchiveFile() {

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -315,7 +315,7 @@ public final class PageSourceImpl implements PageSource {
 		if (cn != null) {
 			try {
 				LogUtil.log(config, Log.LEVEL_DEBUG, "compile", "load class from ClassLoader  [" + getDisplayPath() + "]");
-				pcn.set(page = newInstance(mapping.getPhysicalClass(cn)));
+				page = newInstance(mapping.getPhysicalClass(cn));
 				done = true;
 			}
 			catch (ClassNotFoundException cnfe) {
@@ -325,7 +325,12 @@ public final class PageSourceImpl implements PageSource {
 		if (!done) {
 			LogUtil.log(config, Log.LEVEL_DEBUG, "compile", "load class from binary  [" + getDisplayPath() + "]");
 			byte[] bytes = IOUtil.toBytes(classFile);
-			if (ClassUtil.isBytecode(bytes)) pcn.set(page = newInstance(mapping.getPhysicalClass(this.getClassName(), bytes)));
+			if (ClassUtil.isBytecode(bytes)) page = newInstance(mapping.getPhysicalClass(this.getClassName(), bytes));
+		}
+		if (page != null) {
+			page.setPageSource(this);
+			page.setLoadType(LOAD_PHYSICAL);
+			pcn.set(page);
 		}
 		return page;
 	}

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import lucee.commons.io.IOUtil;
 import lucee.commons.io.log.Log;
@@ -36,7 +37,6 @@ import lucee.commons.lang.StringUtil;
 import lucee.commons.lang.compiler.JavaFunction;
 import lucee.commons.lang.types.RefBoolean;
 import lucee.commons.lang.types.RefBooleanImpl;
-import lucee.commons.lang.types.RefIntegerSync;
 import lucee.loader.engine.CFMLEngine;
 import lucee.runtime.compiler.CFMLCompilerImpl.Result;
 import lucee.runtime.config.Config;
@@ -84,7 +84,7 @@ public final class PageSourceImpl implements PageSource {
 	private String compName;
 	private PageAndClassName pcn = new PageAndClassName();
 	private long lastAccess;
-	private RefIntegerSync accessCount = new RefIntegerSync();
+	private AtomicInteger accessCount = new AtomicInteger();
 	private boolean flush = false;
 
 	private PageSourceImpl() {
@@ -913,13 +913,13 @@ public final class PageSourceImpl implements PageSource {
 
 	@Override
 	public final void setLastAccessTime() {
-		accessCount.plus(1);
+		accessCount.incrementAndGet(1);
 		this.lastAccess = System.currentTimeMillis();
 	}
 
 	@Override
 	public final int getAccessCount() {
-		return accessCount.toInt();
+		return accessCount.intValue();
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/PageSourceImpl.java
+++ b/core/src/main/java/lucee/runtime/PageSourceImpl.java
@@ -545,12 +545,19 @@ public final class PageSourceImpl implements PageSource {
 	}
 
 	/**
+	 * @deprecated typo
+	 * @return file Object
+	 */
+	public Resource getPhyscalFile() {
+		return this.getPhysicalFile();
+	}
+
+	/**
 	 * return file object, based on physical path and realpath
 	 * 
 	 * @return file Object
 	 */
-	@Override
-	public Resource getPhyscalFile() {
+	public Resource getPhysicalFile() {
 		if (physicalSource == null) {
 			if (!mapping.hasPhysical()) {
 				return null;


### PR DESCRIPTION
Ticket: https://luceeserver.atlassian.net/browse/LDEV-3723

Reason for the MR:

Currently Component loader relly heavily on PageSource.loadPageThrowTemplateException

This method is currently synchronized, and any helper used as a themed function repository will puth the lock under pressure, this refactoring aims at reducing the amount of time with the lock held, 

If the idea floats, i'll add a small rework to ensure a single threads enters the compilation routine, and the others benefit from the result to avoid another thrampling.

We discovered this issue by having hoptpoints pointing to this stacktrace:

```
http-nio-192.168.35.136-8080-exec-3" #70 daemon prio=1 os_prio=0 tid=0x00007f054da75000 nid=0x3a46 waiting for monitor entry [0x00007f04a1025000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at lucee.runtime.PageSourceImpl.loadPageThrowTemplateException(PageSourceImpl.java:233)
	- waiting to lock <0x000000052d207d38> (a lucee.runtime.PageSourceImpl)
	at lucee.runtime.PageSourceImpl.loadPage(PageSourceImpl.java:1013)
	at lucee.runtime.component.ComponentLoader._search(ComponentLoader.java:219)
	at lucee.runtime.component.ComponentLoader._search(ComponentLoader.java:117)
	at lucee.runtime.component.ComponentLoader.searchComponent(ComponentLoader.java:84)
	at lucee.runtime.functions.other._GetStaticScope.call(_GetStaticScope.java:32)
	at business.object_cfc$cf$1.udfCalla(/cfc/business/Object.cfc:510)
	at business.object_cfc$cf$1.udfCall(/cfc/business/Object.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:344)
```

the code involved here was simply 
```
Component A {
    public static method test() { return 1; }
}

Component B {
    public static method caller() { return A::test(); }
}
```

This on a high traffic created hotpoints around the A component, only allowing one thread at a time to move through this zone.

Let me know how to let that move forward