### PR TITLE
performance: Change Math.rand() to ThreadLocalRandom

### DIFF
--- a/core/src/main/java/lucee/commons/collection/Hashing.java
+++ b/core/src/main/java/lucee/commons/collection/Hashing.java
@@ -25,6 +25,7 @@
 package lucee.commons.collection;
 
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import lucee.commons.io.SystemUtil;
 
@@ -215,7 +216,7 @@ public class Hashing {
 		 *
 		 * We try to improve upon the default seeding.
 		 */
-		static final Random SEED_MAKER = new Random(Double.doubleToRawLongBits(Math.random()) ^ System.identityHashCode(Hashing.class) ^ System.currentTimeMillis()
+		static final Random SEED_MAKER = new Random(Double.doubleToRawLongBits(ThreadLocalRandom.current().nextDouble()) ^ System.identityHashCode(Hashing.class) ^ System.currentTimeMillis()
 				^ System.nanoTime() ^ Runtime.getRuntime().freeMemory());
 
 		/**

--- a/core/src/main/java/lucee/commons/img/AbstractCaptcha.java
+++ b/core/src/main/java/lucee/commons/img/AbstractCaptcha.java
@@ -18,6 +18,8 @@
  **/
 package lucee.commons.img;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -198,8 +200,6 @@ public abstract class AbstractCaptcha {
 
 	private int r(int startColor) {
 		return rnd(startColor - 100, startColor);
-		// int r= ((int)(Math.random()*(255-startColor)))+startColor;
-		// return r;
 	}
 
 	private Point getRandomPointOnBorder(Dimension dimension) {
@@ -249,8 +249,7 @@ public abstract class AbstractCaptcha {
 			min = max;
 			max = tmp;
 		}
-		double diff = max - min;
-		return ((int) (StrictMath.random() * (diff + 1))) + min;
+		return (ThreadLocalRandom.current().doubles(1, min, max)).toArray()[0];
 	}
 
 	private void drawRandomLine(Graphics2D graphics, Dimension dimension, Color lineColorType) {

--- a/core/src/main/java/lucee/commons/lang/NumberUtil.java
+++ b/core/src/main/java/lucee/commons/lang/NumberUtil.java
@@ -18,6 +18,8 @@
  **/
 package lucee.commons.lang;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import lucee.runtime.exp.ExpressionException;
 
 public class NumberUtil {
@@ -117,6 +119,6 @@ public class NumberUtil {
 	}
 
 	public static int randomRange(int min, int max) {
-		return min + (int) (Math.random() * ((max - min) + 1));
+		return min + (int) (ThreadLocalRandom.current().nextInt(max-min+1));
 	}
 }

--- a/core/src/main/java/lucee/runtime/net/ntp/NtpMessage.java
+++ b/core/src/main/java/lucee/runtime/net/ntp/NtpMessage.java
@@ -19,7 +19,9 @@
 package lucee.runtime.net.ntp;
 
 import java.text.DecimalFormat;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.Date;
+
 
 import lucee.commons.i18n.DateFormatPool;
 
@@ -320,7 +322,7 @@ public final class NtpMessage {
 		// low order bits of the timestamp with a random, unbiased
 		// bitstring, both to avoid systematic roundoff errors and as
 		// a means of loop detection and replay detection.
-		array[7] = (byte) (Math.random() * 255.0);
+		array[7] = (byte) ThreadLocalRandom.current().nextInt(256);
 	}
 
 	/**

--- a/core/src/main/java/lucee/transformer/cfml/evaluator/impl/Cache.java
+++ b/core/src/main/java/lucee/transformer/cfml/evaluator/impl/Cache.java
@@ -18,6 +18,8 @@
  **/
 package lucee.transformer.cfml.evaluator.impl;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import lucee.runtime.op.Caster;
 import lucee.transformer.bytecode.statement.tag.Attribute;
 import lucee.transformer.bytecode.statement.tag.Tag;
@@ -28,6 +30,6 @@ public class Cache extends EvaluatorSupport {
 
 	@Override
 	public void evaluate(Tag tag) throws EvaluatorException {
-		tag.addAttribute(new Attribute(false, "_id", tag.getFactory().createLitString(Caster.toString((int) (Math.random() * 100000))), "string"));
+		tag.addAttribute(new Attribute(false, "_id", tag.getFactory().createLitString(Caster.toString(ThreadLocalRandom.current().nextInt(100000))), "string"));
 	}
 }

--- a/core/src/main/java/lucee/transformer/cfml/evaluator/impl/Lock.java
+++ b/core/src/main/java/lucee/transformer/cfml/evaluator/impl/Lock.java
@@ -18,6 +18,8 @@
  **/
 package lucee.transformer.cfml.evaluator.impl;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import lucee.runtime.op.Caster;
 import lucee.transformer.bytecode.statement.tag.Attribute;
 import lucee.transformer.bytecode.statement.tag.Tag;
@@ -28,6 +30,6 @@ public class Lock extends EvaluatorSupport {
 
 	@Override
 	public void evaluate(Tag tag) throws EvaluatorException {
-		tag.addAttribute(new Attribute(false, "id", tag.getFactory().createLitString(Caster.toString((int) (Math.random() * 100000))), "string"));
+		tag.addAttribute(new Attribute(false, "id", tag.getFactory().createLitString(Caster.toString(ThreadLocalRandom.current().nextInt(100000))), "string"));
 	}
 }


### PR DESCRIPTION
Minor change where the jvm synchronized Math.random() is used to fallback to thread local instance