### PR TITLE
LDEV 3742 - CFContent delivers wrong Content-Type

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/Content.java
+++ b/core/src/main/java/lucee/runtime/tag/Content.java
@@ -162,7 +162,10 @@ public final class Content extends BodyTagImpl {
 	private int _doStartTag() throws PageException {
 		// check the file before doing anything else
 		Resource file = null;
-		if (content == null && !StringUtil.isEmpty(strFile)) file = ResourceUtil.toResourceExisting(pageContext, strFile);
+		if (content == null && !StringUtil.isEmpty(strFile)) {
+            file = ResourceUtil.toResourceExisting(pageContext, strFile);
+            type = ResourceUtil.getMimeType(file, "text/html");
+        }
 
 		// get response object
 		HttpServletResponse rsp = pageContext.getHttpServletResponse();

--- a/core/src/main/java/lucee/runtime/tag/Content.java
+++ b/core/src/main/java/lucee/runtime/tag/Content.java
@@ -164,7 +164,10 @@ public final class Content extends BodyTagImpl {
 		Resource file = null;
 		if (content == null && !StringUtil.isEmpty(strFile)) {
             file = ResourceUtil.toResourceExisting(pageContext, strFile);
-            type = ResourceUtil.getMimeType(file, "text/html");
+            // Do not overwrite type-attribute
+            if (StringUtil.isEmpty(type, true)) {
+              type = ResourceUtil.getMimeType(file, "text/html");
+            }
         }
 
 		// get response object


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3742

Set File-Mime-Type as Content-Type (only when type-attribute is not already set)