### PR TITLE
update test datasources

### DIFF
--- a/test/datasource/MySQL.cfc
+++ b/test/datasource/MySQL.cfc
@@ -272,44 +272,11 @@ END
 		 	, custom= { useUnicode:true }
 			};
 
-
-
 	}
 
 	private struct function getCredencials() {
-		// getting the credetials from the enviroment variables
-		var mySQL={};
-		if(
-			!isNull(server.system.environment.MYSQL_SERVER) && 
-			!isNull(server.system.environment.MYSQL_USERNAME) && 
-			!isNull(server.system.environment.MYSQL_PASSWORD) && 
-			!isNull(server.system.environment.MYSQL_PORT) && 
-			!isNull(server.system.environment.MYSQL_DATABASE)) {
-			mySQL.server=server.system.environment.MYSQL_SERVER;
-			mySQL.username=server.system.environment.MYSQL_USERNAME;
-			mySQL.password=server.system.environment.MYSQL_PASSWORD;
-			mySQL.port=server.system.environment.MYSQL_PORT;
-			mySQL.database=server.system.environment.MYSQL_DATABASE;
-		}
-		// getting the credetials from the system variables
-		else if(
-			!isNull(server.system.properties.MYSQL_SERVER) && 
-			!isNull(server.system.properties.MYSQL_USERNAME) && 
-			!isNull(server.system.properties.MYSQL_PASSWORD) && 
-			!isNull(server.system.properties.MYSQL_PORT) && 
-			!isNull(server.system.properties.MYSQL_DATABASE)) {
-			mySQL.server=server.system.properties.MYSQL_SERVER;
-			mySQL.username=server.system.properties.MYSQL_USERNAME;
-			mySQL.password=server.system.properties.MYSQL_PASSWORD;
-			mySQL.port=server.system.properties.MYSQL_PORT;
-			mySQL.database=server.system.properties.MYSQL_DATABASE;
-		}
-
-		return mysql;
+		return server.getDatasource("mysql");
 	}
-
-
-
 
 } 
 </cfscript>

--- a/test/datasource/PostgreSQL.cfc
+++ b/test/datasource/PostgreSQL.cfc
@@ -156,38 +156,9 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	}
 
 	private struct function getCredencials() {
-		// getting the credetials from the enviroment variables
-		var pgsql={};
-		if(
-			!isNull(server.system.environment.POSTGRES_SERVER) &&
-			!isNull(server.system.environment.POSTGRES_USERNAME) &&
-			!isNull(server.system.environment.POSTGRES_PASSWORD) &&
-			!isNull(server.system.environment.POSTGRES_PORT) &&
-			!isNull(server.system.environment.POSTGRES_DATABASE)) {
-			pgsql.server=server.system.environment.POSTGRES_SERVER;
-			pgsql.username=server.system.environment.POSTGRES_USERNAME;
-			pgsql.password=server.system.environment.POSTGRES_PASSWORD;
-			pgsql.port=server.system.environment.POSTGRES_PORT;
-			pgsql.database=server.system.environment.POSTGRES_DATABASE;
-		}
-		// getting the credetials from the system variables
-		else if(
-			!isNull(server.system.properties.POSTGRES_SERVER) &&
-			!isNull(server.system.properties.POSTGRES_USERNAME) &&
-			!isNull(server.system.properties.POSTGRES_PASSWORD) &&
-			!isNull(server.system.properties.POSTGRES_PORT) &&
-			!isNull(server.system.properties.POSTGRES_DATABASE)) {
-			pgsql.server=server.system.properties.POSTGRES_SERVER;
-			pgsql.username=server.system.properties.POSTGRES_USERNAME;
-			pgsql.password=server.system.properties.POSTGRES_PASSWORD;
-			pgsql.port=server.system.properties.POSTGRES_PORT;
-			pgsql.database=server.system.properties.POSTGRES_DATABASE;
-		}
-		return pgsql;
+		// getting the credetials from the environment variables
+		return server.getDatasource("postgres");
 	}
-
-
-
 
 }
 </cfscript>

--- a/test/jira/Jira2903.cfc
+++ b/test/jira/Jira2903.cfc
@@ -49,34 +49,8 @@
 
 
 	private struct function getCredencials() {
-		// getting the credetials from the enviroment variables
-		var pgsql={};
-		if(
-			!isNull(server.system.environment.POSTGRES_SERVER) &&
-			!isNull(server.system.environment.POSTGRES_USERNAME) &&
-			!isNull(server.system.environment.POSTGRES_PASSWORD) &&
-			!isNull(server.system.environment.POSTGRES_PORT) &&
-			!isNull(server.system.environment.POSTGRES_DATABASE)) {
-			pgsql.server=server.system.environment.POSTGRES_SERVER;
-			pgsql.username=server.system.environment.POSTGRES_USERNAME;
-			pgsql.password=server.system.environment.POSTGRES_PASSWORD;
-			pgsql.port=server.system.environment.POSTGRES_PORT;
-			pgsql.database=server.system.environment.POSTGRES_DATABASE;
-		}
-		// getting the credetials from the system variables
-		else if(
-			!isNull(server.system.properties.POSTGRES_SERVER) &&
-			!isNull(server.system.properties.POSTGRES_USERNAME) &&
-			!isNull(server.system.properties.POSTGRES_PASSWORD) &&
-			!isNull(server.system.properties.POSTGRES_PORT) &&
-			!isNull(server.system.properties.POSTGRES_DATABASE)) {
-			pgsql.server=server.system.properties.POSTGRES_SERVER;
-			pgsql.username=server.system.properties.POSTGRES_USERNAME;
-			pgsql.password=server.system.properties.POSTGRES_PASSWORD;
-			pgsql.port=server.system.properties.POSTGRES_PORT;
-			pgsql.database=server.system.properties.POSTGRES_DATABASE;
-		}
-		return pgsql;
+		// getting the credetials from the environment variables
+		return server.getDatasource("postgres");
 	}
 
 

--- a/test/tickets/LDEV0637.cfc
+++ b/test/tickets/LDEV0637.cfc
@@ -101,39 +101,8 @@ END;
 	}
 
 	private struct function getCredencials() {
-		// getting the credetials from the enviroment variables
-		var orc={};
-
-		if(
-			!isNull(server.system.environment.ORACLE_SERVER) && 
-			!isNull(server.system.environment.ORACLE_USERNAME) && 
-			!isNull(server.system.environment.ORACLE_PASSWORD) && 
-			!isNull(server.system.environment.ORACLE_PORT) && 
-			!isNull(server.system.environment.ORACLE_DATABASE)) {
-			orc.server=server.system.environment.ORACLE_SERVER;
-			orc.username=server.system.environment.ORACLE_USERNAME;
-			orc.password=server.system.environment.ORACLE_PASSWORD;
-			orc.port=server.system.environment.ORACLE_PORT;
-			orc.database=server.system.environment.ORACLE_DATABASE;
-		}
-		// getting the credetials from the system variables
-		else if(
-			!isNull(server.system.properties.ORACLE_SERVER) && 
-			!isNull(server.system.properties.ORACLE_USERNAME) && 
-			!isNull(server.system.properties.ORACLE_PASSWORD) && 
-			!isNull(server.system.properties.ORACLE_PORT) && 
-			!isNull(server.system.properties.ORACLE_DATABASE)) {
-			orc.server=server.system.properties.ORACLE_SERVER;
-			orc.username=server.system.properties.ORACLE_USERNAME;
-			orc.password=server.system.properties.ORACLE_PASSWORD;
-			orc.port=server.system.properties.ORACLE_PORT;
-			orc.database=server.system.properties.ORACLE_DATABASE;
-		}
-		return orc;
+		return server.getDatasource("oracle");
 	}
-
-
-
 
 } 
 </cfscript>

--- a/test/tickets/LDEV0860.cfc
+++ b/test/tickets/LDEV0860.cfc
@@ -81,39 +81,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 	}
 
 	private struct function getCredencials() {
-		// getting the credetials from the enviroment variables
-		var orc={};
-
-		if(
-			!isNull(server.system.environment.ORACLE_SERVER) && 
-			!isNull(server.system.environment.ORACLE_USERNAME) && 
-			!isNull(server.system.environment.ORACLE_PASSWORD) && 
-			!isNull(server.system.environment.ORACLE_PORT) && 
-			!isNull(server.system.environment.ORACLE_DATABASE)) {
-			orc.server=server.system.environment.ORACLE_SERVER;
-			orc.username=server.system.environment.ORACLE_USERNAME;
-			orc.password=server.system.environment.ORACLE_PASSWORD;
-			orc.port=server.system.environment.ORACLE_PORT;
-			orc.database=server.system.environment.ORACLE_DATABASE;
-		}
-		// getting the credetials from the system variables
-		else if(
-			!isNull(server.system.properties.ORACLE_SERVER) && 
-			!isNull(server.system.properties.ORACLE_USERNAME) && 
-			!isNull(server.system.properties.ORACLE_PASSWORD) && 
-			!isNull(server.system.properties.ORACLE_PORT) && 
-			!isNull(server.system.properties.ORACLE_DATABASE)) {
-			orc.server=server.system.properties.ORACLE_SERVER;
-			orc.username=server.system.properties.ORACLE_USERNAME;
-			orc.password=server.system.properties.ORACLE_PASSWORD;
-			orc.port=server.system.properties.ORACLE_PORT;
-			orc.database=server.system.properties.ORACLE_DATABASE;
-		}
-		return orc;
+		return server.getDatasource("oracle");
 	}
-
-
-
 
 } 
 </cfscript>

--- a/test/tickets/LDEV0902.cfc
+++ b/test/tickets/LDEV0902.cfc
@@ -105,34 +105,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 	private struct function getCredencials() {
 		// getting the credetials from the enviroment variables
-		var orc={};
-
-		if(
-			!isNull(server.system.environment.ORACLE_SERVER) && 
-			!isNull(server.system.environment.ORACLE_USERNAME) && 
-			!isNull(server.system.environment.ORACLE_PASSWORD) && 
-			!isNull(server.system.environment.ORACLE_PORT) && 
-			!isNull(server.system.environment.ORACLE_DATABASE)) {
-			orc.server=server.system.environment.ORACLE_SERVER;
-			orc.username=server.system.environment.ORACLE_USERNAME;
-			orc.password=server.system.environment.ORACLE_PASSWORD;
-			orc.port=server.system.environment.ORACLE_PORT;
-			orc.database=server.system.environment.ORACLE_DATABASE;
-		}
-		// getting the credetials from the system variables
-		else if(
-			!isNull(server.system.properties.ORACLE_SERVER) && 
-			!isNull(server.system.properties.ORACLE_USERNAME) && 
-			!isNull(server.system.properties.ORACLE_PASSWORD) && 
-			!isNull(server.system.properties.ORACLE_PORT) && 
-			!isNull(server.system.properties.ORACLE_DATABASE)) {
-			orc.server=server.system.properties.ORACLE_SERVER;
-			orc.username=server.system.properties.ORACLE_USERNAME;
-			orc.password=server.system.properties.ORACLE_PASSWORD;
-			orc.port=server.system.properties.ORACLE_PORT;
-			orc.database=server.system.properties.ORACLE_DATABASE;
-		}
-		return orc;
+		return server.getDatasource("oracle");
 	}
 
 

--- a/test/tickets/LDEV1116.cfc
+++ b/test/tickets/LDEV1116.cfc
@@ -24,35 +24,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 	}
 
 	private struct function getCredentials() {
-		var orc = {};
-
-		if(
-			!isNull(server.system.environment.ORACLE_SERVER) &&
-			!isNull(server.system.environment.ORACLE_USERNAME) &&
-			!isNull(server.system.environment.ORACLE_PASSWORD) &&
-			!isNull(server.system.environment.ORACLE_PORT) &&
-			!isNull(server.system.environment.ORACLE_DATABASE)
-		) {
-			// getting the credentials from the environment variables
-			orc.server=server.system.environment.ORACLE_SERVER;
-			orc.username=server.system.environment.ORACLE_USERNAME;
-			orc.password=server.system.environment.ORACLE_PASSWORD;
-			orc.port=server.system.environment.ORACLE_PORT;
-			orc.database=server.system.environment.ORACLE_DATABASE;
-		}else if(
-			!isNull(server.system.properties.ORACLE_SERVER) &&
-			!isNull(server.system.properties.ORACLE_USERNAME) &&
-			!isNull(server.system.properties.ORACLE_PASSWORD) &&
-			!isNull(server.system.properties.ORACLE_PORT) &&
-			!isNull(server.system.properties.ORACLE_DATABASE)
-		){
-			// getting the credetials from the system variables
-			orc.server=server.system.properties.ORACLE_SERVER;
-			orc.username=server.system.properties.ORACLE_USERNAME;
-			orc.password=server.system.properties.ORACLE_PASSWORD;
-			orc.port=server.system.properties.ORACLE_PORT;
-			orc.database=server.system.properties.ORACLE_DATABASE;
-		}
-		return orc;
+		return server.getDatasource("oracle");
 	}
 }

--- a/test/tickets/LDEV1760.cfc
+++ b/test/tickets/LDEV1760.cfc
@@ -37,33 +37,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 
 	private struct function getCredentials() {
 		// getting the credentials from the enviroment variables
-
-		var mySQL={};
-		if(
-			!isNull(server.system.environment.MYSQL_SERVER) &&
-			!isNull(server.system.environment.MYSQL_USERNAME) &&
-			!isNull(server.system.environment.MYSQL_PASSWORD) &&
-			!isNull(server.system.environment.MYSQL_PORT) &&
-			!isNull(server.system.environment.MYSQL_DATABASE)) {
-			mySQL.server=server.system.environment.MYSQL_SERVER;
-			mySQL.username=server.system.environment.MYSQL_USERNAME;
-			mySQL.password=server.system.environment.MYSQL_PASSWORD;
-			mySQL.port=server.system.environment.MYSQL_PORT;
-			mySQL.database=server.system.environment.MYSQL_DATABASE;
-		}
-		// getting the credentials from the system variables
-		else if(
-			!isNull(server.system.properties.MYSQL_SERVER) &&
-			!isNull(server.system.properties.MYSQL_USERNAME) &&
-			!isNull(server.system.properties.MYSQL_PASSWORD) &&
-			!isNull(server.system.properties.MYSQL_PORT) &&
-			!isNull(server.system.properties.MYSQL_DATABASE)) {
-			mySQL.server=server.system.properties.MYSQL_SERVER;
-			mySQL.username=server.system.properties.MYSQL_USERNAME;
-			mySQL.password=server.system.properties.MYSQL_PASSWORD;
-			mySQL.port=server.system.properties.MYSQL_PORT;
-			mySQL.database=server.system.properties.MYSQL_DATABASE;
-		}
-		return mysql;
+		return server.getDatasource("mysql");
 	}
 }

--- a/test/tickets/LDEV1917.cfc
+++ b/test/tickets/LDEV1917.cfc
@@ -20,22 +20,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 
 
 	private boolean function hasCredentials() {
-		if(
-			!isNull(server.system.environment.MYSQL_SERVER) &&
-			!isNull(server.system.environment.MYSQL_USERNAME) &&
-			!isNull(server.system.environment.MYSQL_PASSWORD) &&
-			!isNull(server.system.environment.MYSQL_PORT) &&
-			!isNull(server.system.environment.MYSQL_DATABASE)) {
-			return true;
-		}
-		else if(
-			!isNull(server.system.properties.MYSQL_SERVER) &&
-			!isNull(server.system.properties.MYSQL_USERNAME) &&
-			!isNull(server.system.properties.MYSQL_PASSWORD) &&
-			!isNull(server.system.properties.MYSQL_PORT) &&
-			!isNull(server.system.properties.MYSQL_DATABASE)) {
-			return true;
-		}
-		return false;
+		return (structCount(server.getDatasource("postgres")) gt 0);		
 	}
 }

--- a/test/tickets/LDEV1917.cfc
+++ b/test/tickets/LDEV1917.cfc
@@ -20,6 +20,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 
 
 	private boolean function hasCredentials() {
-		return (structCount(server.getDatasource("postgres")) gt 0);		
+		return (structCount(server.getDatasource("mysql")) gt 0);
 	}
 }

--- a/test/tickets/LDEV1942.cfc
+++ b/test/tickets/LDEV1942.cfc
@@ -44,6 +44,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 	}
 
 	private boolean function hasCredentials() {
-		return (structCount(server.getDatasource("postgres")) gt 0);
+		return (structCount(server.getDatasource("mysql")) gt 0);
 	}
 }

--- a/test/tickets/LDEV1942.cfc
+++ b/test/tickets/LDEV1942.cfc
@@ -44,22 +44,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 	}
 
 	private boolean function hasCredentials() {
-		if(
-			!isNull(server.system.environment.MYSQL_SERVER) &&
-			!isNull(server.system.environment.MYSQL_USERNAME) &&
-			!isNull(server.system.environment.MYSQL_PASSWORD) &&
-			!isNull(server.system.environment.MYSQL_PORT) &&
-			!isNull(server.system.environment.MYSQL_DATABASE)) {
-			return true;
-		}
-		else if(
-			!isNull(server.system.properties.MYSQL_SERVER) &&
-			!isNull(server.system.properties.MYSQL_USERNAME) &&
-			!isNull(server.system.properties.MYSQL_PASSWORD) &&
-			!isNull(server.system.properties.MYSQL_PORT) &&
-			!isNull(server.system.properties.MYSQL_DATABASE)) {
-			return true;
-		}
-		return false;
+		return (structCount(server.getDatasource("postgres")) gt 0);
 	}
 }


### PR DESCRIPTION
some of the github action tests services aren't available for non admin PRs, so some datasource tests blow up which are still using the older approach for getting service config, switch to `server.getDatasource("oracle");` which disables any unavailable services