### PR TITLE
Allow unexpected errors to be logged in admin/restart.cfm

### DIFF
--- a/core/src/main/cfml/context/admin/restart.cfm
+++ b/core/src/main/cfml/context/admin/restart.cfm
@@ -1,12 +1,7 @@
 <!--- create no output here!!! --->
 <cfsetting showdebugoutput="false">
-<cftry>
-	<cfadmin 
-		action="restart"
-		type="#url.adminType#"
-		password="#session["password"&url.adminType]#">
-		<!---remoteClients="#request.getRemoteClients()#"--->
-	<cfcatch>
-		<cfoutput>#cfcatch.stacktrace#</cfoutput>
-	</cfcatch>
-</cftry>
+<cfadmin 
+	action="restart"
+	type="#url.adminType#"
+	password="#session["password"&url.adminType]#">
+	


### PR DESCRIPTION
The current try-catch only has some use for developers working on the code. Instead, let any (unexpected) error trickle through to the logs. Especially after the Application.cfc also does not allow unauthenticated access to this file.