### PR TITLE
Disallow unauthenticated access to /admin/restart.cfm

### DIFF
--- a/core/src/main/cfml/context/admin/Application.cfc
+++ b/core/src/main/cfml/context/admin/Application.cfc
@@ -34,19 +34,19 @@ this.tag.cookie.sameSite = "strict";
 
 this.xmlFeatures = {
 	externalGeneralEntities: false,
-    secure: true,
-    disallowDoctypeDecl: true
+	secure: true,
+	disallowDoctypeDecl: true
 };
 
 public function onRequestStart() {
 	// if not logged in, we only allow access to admin|web|server[.cfm]
 	if(!structKeyExists(session, "passwordWeb") && !structKeyExists(session, "passwordServer")){
 		var fileName=listLast(cgi.script_name,"/");
-		if(fileName!="admin.cfm" && fileName!="web.cfm" && fileName!="server.cfm" && fileName!="restart.cfm") {
+		if(fileName!="admin.cfm" && fileName!="web.cfm" && fileName!="server.cfm") {
 			cfsetting(showdebugoutput:false);
 			cfheader(statuscode="404" statustext="Invalid access");
 			cfcontent(reset="true");
-        	abort;
+			abort;
 		}
 	}
 }
@@ -54,7 +54,7 @@ public function onRequestStart() {
 public function onApplicationStart(){
 	if(structKeyExists(server.system.environment,"LUCEE_ADMIN_ENABLED") && server.system.environment.LUCEE_ADMIN_ENABLED EQ false){
 		cfheader(statuscode="404" statustext="Invalid access");
-        abort;
+		abort;
 	}
 }
 


### PR DESCRIPTION
In admin Application.cfc, it has no use to allow unauthenticated access to "restart.cfm", because the restart script itself does need the authentication (the session.passwordWeb/Server) to work properly.
Weak ref. to #LDEV-3497 