### PR TITLE
LDEV-3617 test cases for internalRequest

### DIFF
--- a/test/functions/InternalRequest.cfc
+++ b/test/functions/InternalRequest.cfc
@@ -1,0 +1,109 @@
+<!--- 
+ *
+ * Copyright (c) 2014, the Railo Company LLC. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ ---><cfscript>
+    component extends="org.lucee.cfml.test.LuceeTestCase"	{
+    
+        public void function testUrlStruct() localmode=true {
+            uri = createURI("internalRequest/echo.cfm");
+            result =_InternalRequest(
+                template: uri,
+                url: {test=1}
+            );
+            expect( result.filecontent ).toBe( '{"FORM":{},"URL":{"TEST":"1"}}' );
+        }
+
+        public void function testUrlQueryString() localmode=true {
+            uri = createURI("internalRequest/echo.cfm");
+            result =_InternalRequest(
+                template: uri,
+                url: "test=1"
+            );
+            expect( result.filecontent ).toBe( '{"FORM":{},"URL":{"TEST":"1"}}' );
+        }
+
+        public void function testFormStruct() localmode=true {
+            uri = createURI("internalRequest/echo.cfm");
+            result = _InternalRequest(
+                template: uri,
+                form: {test=1}
+            );
+            expect( result.filecontent ).toBe( '{"FORM":{"TEST":1},"URL":{}}' );
+        }
+
+        public void function testFormQueryString() localmode=true {
+            uri = createURI("internalRequest/echo.cfm");
+            result =_InternalRequest(
+                template: uri,
+                form: "test=1"
+            );
+            expect( result.filecontent ).toBe( '{"FORM":{"TEST":1},"URL":{}}' );
+        }
+
+        /*
+        TODO throws
+        lucee.runtime.exp.Abort: Page request is aborted
+        [java]    [script]         at lucee.runtime.tag.Abort.doStartTag(Abort.java:69)
+        */
+
+        public void function testAbort() localmode=true skip=true {
+            uri = createURI("internalRequest/abort.cfm");
+            result = _InternalRequest(
+                template: uri,
+                form: {test=1}
+            );
+            expect( result.filecontent ).toBe( '{"FORM":{"TEST":1},"URL":{}}' );
+        }
+
+        /*
+        TODO throws
+        lucee.runtime.exp.Abort: Page request is aborted
+        [java]    [script]         at lucee.runtime.tag.Abort.doStartTag(Abort.java:69)
+        */
+
+
+        public void function testContent() localmode=true skip=true {
+            uri = createURI("internalRequest/cfcontent.cfm");
+            result = _InternalRequest(
+                template: uri,
+                form: {test=1}
+            );
+            expect( result.filecontent ).toBe( '{"FORM":{"TEST":1},"URL":{}}' );
+        }
+
+        /*
+        TODO throws
+        lucee.runtime.exp.Abort: Page request is aborted
+        [java]    [script]         at lucee.runtime.tag.Abort.doStartTag(Abort.java:69)
+        */
+
+        public void function testContentFile() localmode=true skip=true {
+            uri = createURI("internalRequest/cfcontent-file.cfm");
+            result = _InternalRequest(
+                template: uri,
+                form: {test=1}
+            );
+            expect( result.filecontent ).toContain( 'getCurrentTemplatePath()' );
+        }
+    
+        private string function createURI(string calledName){
+            var baseURI="/test/#listLast(getDirectoryFromPath(getCurrentTemplatePath()),"\/")#/";
+            return baseURI&""&calledName;
+        }
+        
+    } 
+    </cfscript>

--- a/test/functions/internalRequest/abort.cfm
+++ b/test/functions/internalRequest/abort.cfm
@@ -1,0 +1,10 @@
+<cfscript>
+    result = [
+        form: form,
+        url: url
+    ];
+
+    content type="application/json";
+    echo(result.toJson());
+    abort;
+</cfscript>

--- a/test/functions/internalRequest/cfcontent-file.cfm
+++ b/test/functions/internalRequest/cfcontent-file.cfm
@@ -1,0 +1,3 @@
+<cfscript>
+    content type="text/plain" file="#getCurrentTemplatePath()#";
+</cfscript>

--- a/test/functions/internalRequest/cfcontent.cfm
+++ b/test/functions/internalRequest/cfcontent.cfm
@@ -1,0 +1,10 @@
+<cfscript>
+    result = [
+        form: form,
+        url: url
+    ];
+
+    json = result.toJson();
+
+    content type="application/json" variable="json";
+</cfscript>

--- a/test/functions/internalRequest/echo.cfm
+++ b/test/functions/internalRequest/echo.cfm
@@ -1,0 +1,9 @@
+<cfscript>
+    result = [
+        form: form,
+        url: url
+    ];
+
+    content type="application/json";
+    echo(result.toJson());
+</cfscript>


### PR DESCRIPTION
checks 
- support for url and form as structs or query strings (fails in 6)
- whether cfcontent works (fails)
- whether cfabort works (fails)

https://luceeserver.atlassian.net/browse/LDEV-3617
https://luceeserver.atlassian.net/browse/LDEV-3761