### PR TITLE
fix LDEV-3333, LDEV-3731

### DIFF
--- a/core/src/main/java/lucee/runtime/converter/JSONConverter.java
+++ b/core/src/main/java/lucee/runtime/converter/JSONConverter.java
@@ -63,6 +63,7 @@ import lucee.runtime.op.Decision;
 import lucee.runtime.orm.ORMUtil;
 import lucee.runtime.reflection.Reflector;
 import lucee.runtime.text.xml.XMLCaster;
+import lucee.runtime.util.ObjectIdentityHashSet;
 import lucee.runtime.type.Array;
 import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
@@ -142,7 +143,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @throws ConverterException
 	 */
 
-	private void _serializeClass(PageContext pc, Set test, Class clazz, Object obj, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeClass(PageContext pc, Set test, Class clazz, Object obj, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 
 		Struct sct = new StructImpl(Struct.TYPE_LINKED);
 		if (test == null) test = new HashSet();
@@ -153,7 +154,7 @@ public final class JSONConverter extends ConverterSupport {
 		for (int i = 0; i < fields.length; i++) {
 			field = fields[i];
 			if (obj != null || (field.getModifiers() & Modifier.STATIC) > 0) try {
-				sct.setEL(field.getName(), testRecusrion(test, field.get(obj)));
+				sct.setEL(field.getName(), testRecursion(test, field.get(obj)));
 			}
 			catch (Exception e) {
 				LogUtil.log(ThreadLocalPageContext.getConfig(pc), Controler.class.getName(), e);
@@ -169,7 +170,7 @@ public final class JSONConverter extends ConverterSupport {
 			Method[] getters = Reflector.getGetters(clazz);
 			for (int i = 0; i < getters.length; i++) {
 				try {
-					sct.setEL(getters[i].getName().substring(3), testRecusrion(test, getters[i].invoke(obj, ArrayUtil.OBJECT_EMPTY)));
+					sct.setEL(getters[i].getName().substring(3), testRecursion(test, getters[i].invoke(obj, ArrayUtil.OBJECT_EMPTY)));
 
 				}
 				catch (Exception e) {
@@ -182,7 +183,7 @@ public final class JSONConverter extends ConverterSupport {
 		_serializeStruct(pc, test, sct, sb, queryFormat, true, done);
 	}
 
-	private Object testRecusrion(Set test, Object obj) {
+	private Object testRecursion(Set test, Object obj) {
 		if (test.contains(obj.getClass())) return obj.getClass().getName();
 		return obj;
 	}
@@ -226,7 +227,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	private void _serializeArray(PageContext pc, Set test, Array array, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeArray(PageContext pc, Set test, Array array, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 		_serializeList(pc, test, array.toList(), sb, queryFormat, done);
 	}
 
@@ -239,7 +240,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	private void _serializeList(PageContext pc, Set test, List list, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeList(PageContext pc, Set test, List list, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 
 		sb.append("[");
 		indentPlus(sb);
@@ -257,7 +258,7 @@ public final class JSONConverter extends ConverterSupport {
 		sb.append(']');
 	}
 
-	private void _serializeArray(PageContext pc, Set test, Object[] arr, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeArray(PageContext pc, Set test, Object[] arr, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 
 		sb.append("[");
 		indentPlus(sb);
@@ -282,7 +283,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	public void _serializeStruct(PageContext pc, Set test, Struct struct, StringBuilder sb, int queryFormat, boolean addUDFs, Set<Object> done) throws ConverterException {
+	public void _serializeStruct(PageContext pc, Set test, Struct struct, StringBuilder sb, int queryFormat, boolean addUDFs, ObjectIdentityHashSet done) throws ConverterException {
 
 		// preserve case by default for Struct
 		boolean preserveCase = getPreserveCase(pc, false);
@@ -406,7 +407,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	private void _serializeMap(PageContext pc, Set test, Map map, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeMap(PageContext pc, Set test, Map map, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 
 		sb.append("{");
 		indentPlus(sb);
@@ -436,12 +437,12 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	private void _serializeComponent(PageContext pc, Set test, Component component, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeComponent(PageContext pc, Set test, Component component, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 		ComponentSpecificAccess cw = ComponentSpecificAccess.toComponentSpecificAccess(Component.ACCESS_PRIVATE, component);
 		_serializeStruct(pc, test, cw, sb, queryFormat, false, done);
 	}
 
-	private void _serializeUDF(PageContext pc, Set test, UDF udf, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeUDF(PageContext pc, Set test, UDF udf, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 		Struct sct = new StructImpl();
 		try {
 			// Meta
@@ -478,7 +479,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	private void _serializeQuery(PageContext pc, Set test, Query query, StringBuilder sb, int queryFormat, Set<Object> done) throws ConverterException {
+	private void _serializeQuery(PageContext pc, Set test, Query query, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 
 		boolean preserveCase = getPreserveCase(pc, true); // UPPERCASE column keys by default for Query
 
@@ -635,7 +636,7 @@ public final class JSONConverter extends ConverterSupport {
 	 * @param done
 	 * @throws ConverterException
 	 */
-	private void _serialize(PageContext pc, Set test, Object object, StringBuilder sb, int queryFormat, Set done) throws ConverterException {
+	private void _serialize(PageContext pc, Set test, Object object, StringBuilder sb, int queryFormat, ObjectIdentityHashSet done) throws ConverterException {
 
 		// NULL
 		if (object == null || object == CollectionUtil.NULL) {
@@ -814,7 +815,7 @@ public final class JSONConverter extends ConverterSupport {
 	 */
 	public String serialize(PageContext pc, Object object, int queryFormat) throws ConverterException {
 		StringBuilder sb = new StringBuilder(256);
-		_serialize(pc, null, object, sb, queryFormat, new HashSet());
+		_serialize(pc, null, object, sb, queryFormat, new ObjectIdentityHashSet());
 		return sb.toString();
 	}
 

--- a/core/src/main/java/lucee/runtime/dump/ThreadLocalDump.java
+++ b/core/src/main/java/lucee/runtime/dump/ThreadLocalDump.java
@@ -23,33 +23,36 @@ import java.util.Map;
 
 public class ThreadLocalDump {
 
-	private static ThreadLocal<Map<Object, String>> local = new ThreadLocal<Map<Object, String>>();
+	private static ThreadLocal<Map<Integer, String>> local = new ThreadLocal<Map<Integer, String>>();
 
 	public static void set(Object o, String c) {
-
-		touch().put(o, c);
+		touch().put(hash(o), c);
 	}
 
-	public static Map<Object, String> getMap() {
+	public static Map<Integer, String> getMap() {
 		return touch();
 	}
 
 	public static void remove(Object o) {
-		touch().remove(o);
+		touch().remove(hash(o));
 	}
 
-	public static String get(Object obj) {
-		Map<Object, String> list = touch();
-		return list.get(obj);
+	public static String get(Object o) {
+		Map<Integer, String> list = touch();
+		return list.get(hash(o));
 	}
 
-	private static Map<Object, String> touch() {
-		Map<Object, String> set = local.get();
+	private static Map<Integer, String> touch() {
+		Map<Integer, String> set = local.get();
 		if (set == null) {
-			set = new HashMap<Object, String>();
+			set = new HashMap<Integer, String>();
 			local.set(set);
 		}
 		return set;
 	}
 
+	// LDEV-3731 - use System.identityHashCode to avoid problems with hashing "arrays that contain themselves"
+	private static Integer hash(Object o) {
+		return System.identityHashCode(o);
+	}
 }

--- a/core/src/main/java/lucee/runtime/reflection/Reflector.java
+++ b/core/src/main/java/lucee/runtime/reflection/Reflector.java
@@ -67,6 +67,7 @@ import lucee.runtime.reflection.pairs.MethodInstance;
 import lucee.runtime.reflection.storage.SoftMethodStorage;
 import lucee.runtime.reflection.storage.WeakConstructorStorage;
 import lucee.runtime.reflection.storage.WeakFieldStorage;
+import lucee.runtime.util.ObjectIdentityHashSet;
 import lucee.runtime.type.Array;
 import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
@@ -758,35 +759,17 @@ public final class Reflector {
 		return null;
 	}
 
-	// LDEV-3333 / LDEV-3731
-	// this is just a partial implementation of HashSet<Object>, using System.identityHashCode
-	// instead of the default virtually dispatched <object-impl>.hashCode; this avoids the probelm
-	// of "hashing arrays which contain themselves causing a stackoverflow" 
-	private static class ObjectIdentitySet {
-		private HashSet<Integer> elements = new HashSet<Integer>();
-
-		public boolean contains(Object object) {
-			return elements.contains(System.identityHashCode(object));
-		}
-		public void add(Object object) {
-			elements.add(System.identityHashCode(object));
-		}
-		public void remove(Object object) {
-			elements.remove(System.identityHashCode(object));
-		}
-	}
-
 	private static Object[] cleanArgs(Object[] args) {
 		if (args == null) return args;
 
-		ObjectIdentitySet done = new ObjectIdentitySet();
+		ObjectIdentityHashSet done = new ObjectIdentityHashSet();
 		for (int i = 0; i < args.length; i++) {
 			args[i] = _clean(done, args[i]);
 		}
 		return args;
 	}
 
-	private static Object _clean(ObjectIdentitySet done, Object obj) {
+	private static Object _clean(ObjectIdentityHashSet done, Object obj) {
 		if (done.contains(obj)) return obj;
 		done.add(obj);
 		try {
@@ -809,7 +792,7 @@ public final class Reflector {
 		return obj;
 	}
 
-	private static Object _clean(ObjectIdentitySet done, Collection coll) {
+	private static Object _clean(ObjectIdentityHashSet done, Collection coll) {
 		Iterator<Object> vit = coll.valueIterator();
 		Object v;
 		boolean change = false;
@@ -832,7 +815,7 @@ public final class Reflector {
 		return coll;
 	}
 
-	private static Object _clean(ObjectIdentitySet done, Map map) {
+	private static Object _clean(ObjectIdentityHashSet done, Map map) {
 		Iterator vit = map.values().iterator();
 		Object v;
 		boolean change = false;
@@ -856,7 +839,7 @@ public final class Reflector {
 		return map;
 	}
 
-	private static Object _clean(ObjectIdentitySet done, List list) {
+	private static Object _clean(ObjectIdentityHashSet done, List list) {
 		Iterator it = list.iterator();
 		Object v;
 		boolean change = false;
@@ -878,7 +861,7 @@ public final class Reflector {
 		return list;
 	}
 
-	private static Object _clean(ObjectIdentitySet done, Object[] src) {
+	private static Object _clean(ObjectIdentityHashSet done, Object[] src) {
 		boolean change = false;
 		for (int i = 0; i < src.length; i++) {
 			if (src[i] != _clean(done, src[i])) {

--- a/core/src/main/java/lucee/runtime/util/ObjectIdentityHashSet.java
+++ b/core/src/main/java/lucee/runtime/util/ObjectIdentityHashSet.java
@@ -1,0 +1,22 @@
+package lucee.runtime.util;
+
+import java.util.HashSet;
+
+// LDEV-3333 / LDEV-3731
+// this is just a partial implementation of HashSet<Object>, using System.identityHashCode
+// instead of the default virtually dispatched <object-impl>.hashCode; this avoids the problem
+// of "hashing arrays which contain themselves causing a stackoverflow" 
+
+public class ObjectIdentityHashSet {
+    private HashSet<Integer> elements = new HashSet<Integer>();
+
+    public boolean contains(Object object) {
+        return elements.contains(System.identityHashCode(object));
+    }
+    public boolean add(Object object) {
+        return elements.add(System.identityHashCode(object));
+    }
+    public boolean remove(Object object) {
+        return elements.remove(System.identityHashCode(object));
+    }
+}

--- a/test/tickets/LDEV3333.cfc
+++ b/test/tickets/LDEV3333.cfc
@@ -1,27 +1,75 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" skip="true" {
+component extends="org.lucee.cfml.test.LuceeTestCase" {
 	function run( testResults, testBox ){
 		describe( "Test case for LDEV-3333", function() {
             it( title="Circular references with struct", body=function(){
-                    sctOne = {one="one",two="two"};
-                    sctTwo = {three="three",four="four"};
-                    sctOne.append(sctTwo);
-                    sctTwo.append(sctOne);
-                    res = serializeJSON(sctTwo);
-                expect(res).toBe('{"TWO":"two","THREE":"three","ONE":"one","FOUR":"four"}');
+                var x = {};
+                x.circular = x;
+
+                try {
+                    // note:
+                    // acf behavior is to recursively expand this up to some limit, to `{circular: {circular: {circular: ... {circular: {} }}}}`
+                    // lucee writes out {circular: <indicator-of-circularity>}
+                    var didThrow = false;
+                    savecontent variable="_" { writedump(x); } 
+                }
+                catch (any e) {
+                    didThrow = true;
+                }
+                expect(didThrow).toBe(false, "Did not throw during `writeDump(<circular-struct>)`");
+
+                try {
+                    // acf behavior is to recursively expand this up to some limit, to `{circular: {circular: {circular: ... {circular: null}}}}`
+                    // lucee just writes out {circular: null}
+                    var didThrow = false;
+                    serializeJSON(x);
+                }
+                catch (any e) {
+                    var didThrow = true;
+                }
+                expect(didThrow).toBe(false, "Did not throw during `serializeJSON(<circular-struct>)`");
             });
             it( title="Circular references with array", body=function(){
-                try{
-                    arrOne = [1,2,3];
-                    arrTwo = ["one","two","three"];
-                    arrOne.append(arrTwo);
-                    arrTwo.append(arrOne)
-                    res = serializeJSON(arrTwo);
+                // note:
+                // acf appends a copy
+                // lucee appends a reference
+                var x = [];
+                x.append(x);
+
+                try {
+                    // acf has no problem with this, there is no recursion
+                    // lucee should write out similar to a circular struct reference, i.e. `[<indicator-of-circularity>]`
+                    var didThrow = false;
+                    savecontent variable="_" { writedump(x); }
                 }
-                catch(any e){
-                    res = e.message;
+                catch (any e) {
+                    didThrow = true;
                 }
-                expect(res).toBe('["one","two","three",[1,2,3,["one","two","three"]]]');
+
+                expect(didThrow).toBe(false, "Did not throw during `writeDump(<circular-array>)`");
+
+                try {
+                    // acf has no problem with this, there is no recursion
+                    // for lucee, we have a circularity; current behavior is to serialize it to JSON as `null`
+                    var didThrow = false;
+                    serializeJSON(x);
+                }
+                catch (any e) {
+                    didThrow = true;
+                }
+
+                expect(didThrow).toBe(false, "Did not throw during `serializeJSON(<circular-array>)`")
             });
+            it ( title="CF engine reflective call to `System.identityHashCode` for 'arrays that contain themselves'", body = function() {
+                x = createObject("java", "java.util.ArrayList").init();
+                y = createObject("java", "java.util.ArrayList").init();
+                x.add(y);
+                y.add(x);
+                System = createObject("java", "java.lang.System");
+                hc = System.identityHashCode(x);
+                expect(isValid("integer", hc)).toBe(true);
+            });
+
+
         });
     }
 }


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3333
https://luceeserver.atlassian.net/browse/LDEV-3731

There are a few places where objects are placed into maps or sets in order to determine if they have been visited during some possibly-recursive algorithm. In these places, if the Object happens to extend `AbstractList` or similar, the default java hash implementation triggers a stack overflow, because hashing a list requires knowing the hashcode of all the list's elements. So if a list contains itself, it won't terminate.

This changeset updates instances of this pattern to use Maps or Sets keyed on `Integer`s derived from calls to `System.identityHashCode`.