### PR TITLE
LDEV-3050 - Enhanced scriptprotect

### DIFF
--- a/core/src/main/cfml/context/admin/server.request.cfm
+++ b/core/src/main/cfml/context/admin/server.request.cfm
@@ -270,6 +270,18 @@ Error Output --->
 							<!---<input type="hidden" name="scriptProtect" value="#appSettings.scriptProtect#">--->
 							<b>#appSettings.scriptProtect#</b>
 						</cfif>
+            <table class="maintbl">
+              <tbody>
+                <th scope="row">Regex-Filter</th>
+                <td>
+                  <cfloop array="#appSettings.scriptProtectRegexList#" index="tmpScriptProtectRegex">
+                    <div class="scriptprotect-regex-filter-wrapper">
+                      <input type="text" name="scriptProtectRegex" style="width: 100%;" value="#tmpScriptProtectRegex#" readonly disabled>
+                    </div>
+                  </cfloop>
+                </td>
+              </tbody>
+            </table>
 <cfsavecontent variable="codeSample">
 	this.scriptprotect="#appSettings.scriptProtect#";
 </cfsavecontent>

--- a/core/src/main/java/lucee/runtime/config/ConfigImpl.java
+++ b/core/src/main/java/lucee/runtime/config/ConfigImpl.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Version;
@@ -306,6 +307,7 @@ public abstract class ConfigImpl extends ConfigBase implements ConfigPro {
 	private ApplicationListener applicationListener;
 
 	private int scriptProtect = ApplicationContext.SCRIPT_PROTECT_ALL;
+    private ArrayList<Pattern> scriptProtectRegexList = new ArrayList<>();
 
 	private ProxyData proxy = null;
 
@@ -2321,6 +2323,18 @@ public abstract class ConfigImpl extends ConfigBase implements ConfigPro {
 	protected void setScriptProtect(int scriptProtect) {
 		this.scriptProtect = scriptProtect;
 	}
+
+    public ArrayList<Pattern> getScriptProtectRegexList() {
+        return scriptProtectRegexList;
+    }
+
+    public void setScriptProtectRegexList(ArrayList<Pattern> scriptProtectRegexList) {
+        this.scriptProtectRegexList = scriptProtectRegexList;
+    }
+
+    public void addScriptProtectRegex(Pattern scriptProtectRegex) {
+        this.scriptProtectRegexList.add(scriptProtectRegex);
+    }
 
 	/**
 	 * @return the proxyPassword

--- a/core/src/main/java/lucee/runtime/config/SingleContextConfigWeb.java
+++ b/core/src/main/java/lucee/runtime/config/SingleContextConfigWeb.java
@@ -4,14 +4,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TimeZone;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -609,7 +604,12 @@ public class SingleContextConfigWeb extends ConfigBase implements ConfigWebPro {
 		return cs.getScriptProtect();
 	}
 
-	@Override
+    @Override
+    public ArrayList<Pattern> getScriptProtectRegexList() {
+        return cs.getScriptProtectRegexList();
+    }
+
+    @Override
 	public ProxyData getProxyData() {
 		return cs.getProxyData();
 	}

--- a/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
+++ b/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
@@ -726,13 +726,6 @@ public final class XMLConfigWebFactory extends XMLConfigFactory {
 
     private static void _loadScriptProtect(ConfigServerImpl configServer, ConfigImpl config, Document doc, Log log) {
         try {
-            boolean hasCS = configServer != null;
-
-            // add scriptprotect-regex from server context to web context
-            if (hasCS) {
-                config.setScriptProtectRegexList(configServer.getScriptProtectRegexList());
-            }
-
             Element root = doc == null ? null : getChildByName(doc.getDocumentElement(), "scriptprotect");
             Element[] regexFilters = root == null ? null : getChildren(root, "filter-regex");
             if (!ArrayUtil.isEmpty(regexFilters)) {

--- a/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
+++ b/core/src/main/java/lucee/runtime/config/XMLConfigWebFactory.java
@@ -726,6 +726,7 @@ public final class XMLConfigWebFactory extends XMLConfigFactory {
 
     private static void _loadScriptProtect(ConfigServerImpl configServer, ConfigImpl config, Document doc, Log log) {
         try {
+            config.setScriptProtectRegexList(new ArrayList<>());
             Element root = doc == null ? null : getChildByName(doc.getDocumentElement(), "scriptprotect");
             Element[] regexFilters = root == null ? null : getChildren(root, "filter-regex");
             if (!ArrayUtil.isEmpty(regexFilters)) {

--- a/core/src/main/java/lucee/runtime/tag/Admin.java
+++ b/core/src/main/java/lucee/runtime/tag/Admin.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.jsp.tagext.Tag;
@@ -4411,6 +4412,11 @@ public final class Admin extends TagImpl implements DynamicAttributes {
 		Struct sct = new StructImpl();
 		pageContext.setVariable(getString("admin", action, "returnVariable"), sct);
 		sct.set("scriptProtect", AppListenerUtil.translateScriptProtect(config.getScriptProtect()));
+        ArrayList<String> scriptProtectRegexList = new ArrayList<>();
+        for(Pattern pattern : config.getScriptProtectRegexList()) {
+            scriptProtectRegexList.add(pattern.pattern());
+        }
+        sct.set("scriptProtectRegexList", scriptProtectRegexList);
 
 		// request timeout
 		TimeSpan ts = config.getRequestTimeout();

--- a/core/src/main/java/resource/config/server.xml
+++ b/core/src/main/java/resource/config/server.xml
@@ -320,7 +320,14 @@ Path placeholders:
 	-->
 	<regional
 		timeserver="pool.ntp.org"/>
-	
+
+  <!--
+  Filters variables via regex due of scriptprotect setting
+  -->
+  <scriptprotect>
+    <filter-regex value="&lt;s*(object|embed|script|applet|meta|iframe)" />
+  </scriptprotect>
+
 	<!--
 	orm configuration:
 		

--- a/loader/src/main/java/lucee/runtime/config/Config.java
+++ b/loader/src/main/java/lucee/runtime/config/Config.java
@@ -22,9 +22,11 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 
 import lucee.commons.io.log.Log;
 import lucee.commons.io.res.Resource;
@@ -475,7 +477,12 @@ public interface Config {
 	 */
 	public int getScriptProtect();
 
-	/**
+    /**
+     * @return scriptProtect Regex-Filter-Pattern-List
+     */
+    public ArrayList<Pattern> getScriptProtectRegexList();
+
+    /**
 	 * return default proxy setting password
 	 * 
 	 * @return the password for proxy


### PR DESCRIPTION
I changed the current scriptprotect implementation to a configurable regex (acf have this also in a config-file).  
That way the user can configure the filter-regex.
The filter-regex is displayed in the admin.  
Because of possible regression issues, I just took the current tag list as the regex filter.
In Lucee 6 we could change the filter to a more aggressive filter, something like this:
```xml
  <scriptprotect>
    <filter-regex value="&lt;s*(object|embed|script|applet|meta|svg|img|body|bgsound|input|video|isindex|iframe|audio|a)"/>
    <filter-regex value="(src|onabort|onactivate|onbeforeunload|onchange|onclick|oncontextmenu|oncopy|oncut|ondblclick|onload|onkeydown|onkeypress|onkeyuponload|onmousedown|onmouseenter|onmouseleave|onmousemove|onmouseout|onmouseover|onmouseup|onreset|onresize|onstart|onstop|onsubmit|onunload)s*="/> <!-- Adjust this list -->
    <filter-regex value="(expression|eval)s*\("/>
  </scriptprotect>
```

https://luceeserver.atlassian.net/browse/LDEV-3050