### PR TITLE
Added a fix: isValid(email) to return false rather than throw error for LDEV-3800, LDEV-2461, LDEV-3677

### DIFF
--- a/core/src/main/java/lucee/runtime/net/mail/MailUtil.java
+++ b/core/src/main/java/lucee/runtime/net/mail/MailUtil.java
@@ -140,42 +140,43 @@ public final class MailUtil {
 	 * @return
 	 */
 	public static boolean isValidEmail(Object value) {
+		try {
+			InternetAddress addr = parseEmail(value, null);
+			if (addr != null) {
 
-		InternetAddress addr = parseEmail(value, null);
+				String address = addr.getAddress();
 
-		if (addr != null) {
+				if (address.contains("..")) return false;
 
-			String address = addr.getAddress();
+				int pos = address.indexOf('@');
 
-			if (address.contains("..")) return false;
+				if (pos < 1 || pos == address.length() - 1) return false;
 
-			int pos = address.indexOf('@');
+				String local = address.substring(0, pos);
+				String domain = address.substring(pos + 1);
 
-			if (pos < 1 || pos == address.length() - 1) return false;
+				if (local.length() > 64) return false; // local part may only be 64 characters
+				if (domain.length() > 255) return false; // domain may only be 255 characters
 
-			String local = address.substring(0, pos);
-			String domain = address.substring(pos + 1);
+				if (domain.charAt(0) == '.' || local.charAt(0) == '.' || local.charAt(local.length() - 1) == '.') return false;
 
-			if (local.length() > 64) return false; // local part may only be 64 characters
-			if (domain.length() > 255) return false; // domain may only be 255 characters
+				pos = domain.lastIndexOf('.');
 
-			if (domain.charAt(0) == '.' || local.charAt(0) == '.' || local.charAt(local.length() - 1) == '.') return false;
-
-			pos = domain.lastIndexOf('.');
-
-			if (pos > 0 && pos < domain.length() - 2) { // test TLD to be at
-				// least 2 chars all
-				// alpha characters
-				if (StringUtil.isAllAlpha(domain.substring(pos + 1))) return true;
-				try {
-					addr.validate();
-					return true;
-				}
-				catch (AddressException e) {
+				if (pos > 0 && pos < domain.length() - 2) { // test TLD to be at
+					// least 2 chars all
+					// alpha characters
+					if (StringUtil.isAllAlpha(domain.substring(pos + 1))) return true;
+					try {
+						addr.validate();
+						return true;
+					}
+					catch (AddressException e) {
+					}
 				}
 			}
 		}
-
+		catch (Exception e) {
+		}
 		return false;
 	}
 

--- a/test/tickets/LDEV3800.cfc
+++ b/test/tickets/LDEV3800.cfc
@@ -1,4 +1,4 @@
-component extends = "org.lucee.cfml.test.LuceeTestCase" skip="true"{
+component extends = "org.lucee.cfml.test.LuceeTestCase" {
 	function run( testResults, testBox ){
 		describe( "Test case for LDEV-3800",function() {
 			it( title = "Checking isvalid(email , email with german characters)",body = function( currentSpec ){

--- a/test/tickets/LDEV3800.cfc
+++ b/test/tickets/LDEV3800.cfc
@@ -1,0 +1,22 @@
+component extends = "org.lucee.cfml.test.LuceeTestCase" skip="true"{
+	function run( testResults, testBox ){
+		describe( "Test case for LDEV-2382",function() {
+			it( title = "Checking isvalid(email , email with german characters)",body = function( currentSpec ){
+				expect(isValid("email","test@müller.de")).toBeTrue(); 
+				expect(isValid("email","test@müller.çöm")).toBeTrue();
+				expect(isValid("email","somthingçöm@gmail.com")).toBeTrue();
+				expect(isValid("email","somthingçöm@çöm.com")).toBeTrue();  
+				expect(isValid("email","somthingçöm@gmail..com")).toBeFalse();  
+				try {
+					hasError = "false"
+					res = isValid("email","somthing@gmail..çöm");
+				}
+				catch(any e) {
+					hasError = true;
+				}
+				expect(hasError).toBeFalse();
+				expect(res).toBeFalse();
+			});
+		});
+	}
+}

--- a/test/tickets/LDEV3800.cfc
+++ b/test/tickets/LDEV3800.cfc
@@ -1,6 +1,6 @@
 component extends = "org.lucee.cfml.test.LuceeTestCase" skip="true"{
 	function run( testResults, testBox ){
-		describe( "Test case for LDEV-2382",function() {
+		describe( "Test case for LDEV-3800",function() {
 			it( title = "Checking isvalid(email , email with german characters)",body = function( currentSpec ){
 				expect(isValid("email","test@müller.de")).toBeTrue(); 
 				expect(isValid("email","test@müller.çöm")).toBeTrue();

--- a/test/tickets/LDEV3800.cfc
+++ b/test/tickets/LDEV3800.cfc
@@ -5,17 +5,11 @@ component extends = "org.lucee.cfml.test.LuceeTestCase" skip="true"{
 				expect(isValid("email","test@müller.de")).toBeTrue(); 
 				expect(isValid("email","test@müller.çöm")).toBeTrue();
 				expect(isValid("email","somthingçöm@gmail.com")).toBeTrue();
-				expect(isValid("email","somthingçöm@çöm.com")).toBeTrue();  
-				expect(isValid("email","somthingçöm@gmail..com")).toBeFalse();  
-				try {
-					hasError = "false"
-					res = isValid("email","somthing@gmail..çöm");
-				}
-				catch(any e) {
-					hasError = true;
-				}
-				expect(hasError).toBeFalse();
-				expect(res).toBeFalse();
+				expect(isValid("email","somthingçöm@çöm.com")).toBeTrue();
+				expect(isValid("email","somthingçöm@gmail..com")).toBeFalse();
+				expect(isValid("email","somthing@gmail..çöm")).toBeFalse();
+				expect(isValid("email", "error@domain.com 😄")).toBeFalse(); // LDEV-2461
+				expect(isValid('email','foo@bar'&chr(8207) )).toBeFalse(); // LDEV-3677
 			});
 		});
 	}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3800
https://luceeserver.atlassian.net/browse/LDEV-2491
https://luceeserver.atlassian.net/browse/LDEV-3677

Note: this fix doesn't affect the current behavior of cfmail tag attributes(from, to, cc & bcc).