### PR TITLE
Resolve LDEV-3736 & LDEV-3734

### DIFF
--- a/core/src/main/java/lucee/runtime/db/QoQ.java
+++ b/core/src/main/java/lucee/runtime/db/QoQ.java
@@ -1336,7 +1336,7 @@ public final class QoQ {
 			}
 			
 			return new Double( dLeft + dRight );
-		// If casting fails, we assume the inpiuts are strings and concat instead
+		// If casting fails, we assume the inputs are strings and concat instead
 		// Unlike SQL, we're not going to return null for a null string concat
 		} catch (PageException e) {
 			return Caster.toString(left) + Caster.toString(right);

--- a/core/src/main/java/lucee/runtime/db/QoQ.java
+++ b/core/src/main/java/lucee/runtime/db/QoQ.java
@@ -719,8 +719,8 @@ public final class QoQ {
 				return executeDivide(pc, sql, source, op2, row);
 			case Operation.OPERATION2_MULTIPLY:
 				return executeMultiply(pc, sql, source, op2, row);
-			case Operation.OPERATION2_EXP:
-				return executeExponent(pc, sql, source, op2, row);
+			case Operation.OPERATION2_BITWISE:
+				return executeBitwise(pc, sql, source, op2, row);
 			case Operation.OPERATION2_LIKE:
 				return Caster.toBoolean(executeLike(pc, sql, source, op2, row));
 			case Operation.OPERATION2_NOT_LIKE:
@@ -915,7 +915,23 @@ public final class QoQ {
 				if (op.equals("isnull")) return executeCoalesce(pc, sql, source, operators, row);
 				break;
 			case 'm':
-				if (op.equals("mod")) return new Double(Operator.modulus(Caster.toDoubleValue(left), Caster.toDoubleValue(right)));
+				if (op.equals("mod")) {
+					// The result of any mathmatical operation involving a null is null
+					if( left == null || right == null ) {
+						return null;
+					}
+					
+					return new Double( castForMathDouble(left) % castForMathDouble(right) );
+				}
+				break;
+			case 'p':
+				if (op.equals("power")) {
+					// The result of any mathmatical operation involving a null is null
+					if( left == null || right == null ) {
+						return null;
+					}
+					return Math.pow(castForMathDouble(left), castForMathDouble(right));	
+				}
 				break;
 
 			}
@@ -1146,9 +1162,15 @@ public final class QoQ {
 	}
 
 	private Object executeMod(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
-
-		return Caster.toDouble(
-				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) % Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
+		Object left = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right = executeExp(pc, sql, source, expression.getRight(), row);
+		
+		// The result of any mathmatical operation involving a null is null
+		if( left == null || right == null ) {
+			return null;
+		}
+		
+		return new Double( castForMathDouble(left) % castForMathDouble(right) );
 	}
 
 	/**
@@ -1173,6 +1195,31 @@ public final class QoQ {
 	}
 
 	/**
+	 * Cast value to Double, accounting for logic such as turning empty strings into zero.
+	 * @param value Value for casting. Must be non-null
+	 * @return Value cast to a Double
+	 */
+	private Double castForMathDouble( Object value ) throws PageException {
+		if( Caster.toString( value ).equals( "" ) ) {
+			return Double.valueOf(0);
+		}
+		return Caster.toDoubleValue(value);
+	}
+
+
+	/**
+	 * Cast value to Int, accounting for logic such as turning empty strings into zero.
+	 * @param value Value for casting. Must be non-null
+	 * @return Value cast to a Int
+	 */
+	private Integer castForMathInt( Object value ) throws PageException {
+		if( Caster.toString( value ).equals( "" ) ) {
+			return Integer.valueOf(0);
+		}
+		return Caster.toIntValue(value);
+	}
+	
+	/**
 	 * 
 	 * execute a minus operation
 	 * 
@@ -1184,8 +1231,15 @@ public final class QoQ {
 	 * @throws PageException
 	 */
 	private Object executeMinus(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
-		return new Double(
-				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) - Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
+		Object left = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right = executeExp(pc, sql, source, expression.getRight(), row);
+		
+		// The result of any mathmatical operation involving a null is null
+		if( left == null || right == null ) {
+			return null;
+		}
+		
+		return new Double( castForMathDouble(left) - castForMathDouble(right) );
 	}
 
 	/**
@@ -1200,8 +1254,15 @@ public final class QoQ {
 	 * @throws PageException
 	 */
 	private Object executeDivide(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
-		return new Double(
-				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) / Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
+		Object left = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right = executeExp(pc, sql, source, expression.getRight(), row);
+		
+		// The result of any mathmatical operation involving a null is null
+		if( left == null || right == null ) {
+			return null;
+		}
+		
+		return new Double( castForMathDouble(left) / castForMathDouble(right) );
 	}
 
 	/**
@@ -1216,13 +1277,20 @@ public final class QoQ {
 	 * @throws PageException
 	 */
 	private Object executeMultiply(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
-		return new Double(
-				Caster.toDoubleValue(executeExp(pc, sql, source, expression.getLeft(), row)) * Caster.toDoubleValue(executeExp(pc, sql, source, expression.getRight(), row)));
+		Object left = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right = executeExp(pc, sql, source, expression.getRight(), row);
+		
+		// The result of any mathmatical operation involving a null is null
+		if( left == null || right == null ) {
+			return null;
+		}
+		
+		return new Double( castForMathDouble(left) * castForMathDouble(right) );
 	}
 
 	/**
 	 * 
-	 * execute a multiply operation
+	 * execute a bitwise operation
 	 * 
 	 * @param sql
 	 * @param source QueryResult to execute on it
@@ -1231,9 +1299,16 @@ public final class QoQ {
 	 * @return result
 	 * @throws PageException
 	 */
-	private Object executeExponent(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
-		return Integer
-				.valueOf(Caster.toIntValue(executeExp(pc, sql, source, expression.getLeft(), row)) ^ Caster.toIntValue(executeExp(pc, sql, source, expression.getRight(), row)));
+	private Object executeBitwise(PageContext pc, SQL sql, Query source, Operation2 expression, int row) throws PageException {
+		Object left = executeExp(pc, sql, source, expression.getLeft(), row);
+		Object right = executeExp(pc, sql, source, expression.getRight(), row);
+		
+		// The result of any mathmatical operation involving a null is null
+		if( left == null || right == null ) {
+			return null;
+		}
+		
+		return Integer.valueOf(castForMathInt(left) ^ castForMathInt(right));
 	}
 
 	/**
@@ -1252,9 +1327,18 @@ public final class QoQ {
 		Object right = executeExp(pc, sql, source, expression.getRight(), row);
 
 		try {
-			return new Double(Caster.toDoubleValue(left) + Caster.toDoubleValue(right));
-		}
-		catch (PageException e) {
+			Double dLeft = Caster.toDoubleValue(left);
+			Double dRight = Caster.toDoubleValue(right);
+
+			// The result of any mathmatical operation involving a null is null
+			if( left == null || right == null ) {
+				return null;
+			}
+			
+			return new Double( dLeft + dRight );
+		// If casting fails, we assume the inpiuts are strings and concat instead
+		// Unlike SQL, we're not going to return null for a null string concat
+		} catch (PageException e) {
 			return Caster.toString(left) + Caster.toString(right);
 		}
 	}

--- a/core/src/main/java/lucee/runtime/sql/SelectParser.java
+++ b/core/src/main/java/lucee/runtime/sql/SelectParser.java
@@ -514,7 +514,7 @@ public class SelectParser {
 		// Modulus Operation
 		while (raw.forwardIfCurrent('^')) {
 			raw.removeSpace();
-			exp = new Operation2(exp, negateMinusOp(raw), Operation.OPERATION2_EXP);
+			exp = new Operation2(exp, negateMinusOp(raw), Operation.OPERATION2_BITWISE);
 		}
 		return exp;
 	}

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation.java
@@ -26,7 +26,7 @@ public interface Operation extends Expression {
 	public static final int OPERATION2_MINUS = 1;
 	public static final int OPERATION2_MULTIPLY = 2;
 	public static final int OPERATION2_DIVIDE = 3;
-	public static final int OPERATION2_EXP = 4;
+	public static final int OPERATION2_BITWISE = 4;
 	public static final int OPERATION2_MOD = 5;
 
 	public static final int OPERATION2_XOR = 10;

--- a/core/src/main/java/lucee/runtime/sql/exp/op/Operation2.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/Operation2.java
@@ -43,7 +43,7 @@ public class Operation2 extends ExpressionSupport implements Operation {
 			return "*";
 		case Operation.OPERATION2_PLUS:
 			return "+";
-		case Operation.OPERATION2_EXP:
+		case Operation.OPERATION2_BITWISE:
 			return "^";
 		case Operation.OPERATION2_MOD:
 			return "%";

--- a/core/src/main/java/lucee/runtime/sql/exp/op/OperationUtil.java
+++ b/core/src/main/java/lucee/runtime/sql/exp/op/OperationUtil.java
@@ -29,7 +29,7 @@ public class OperationUtil {
 			return "*";
 		case Operation.OPERATION2_PLUS:
 			return "+";
-		case Operation.OPERATION2_EXP:
+		case Operation.OPERATION2_BITWISE:
 			return "^";
 		case Operation.OPERATION2_MOD:
 			return "%";

--- a/test/tickets/LDEV3734.cfc
+++ b/test/tickets/LDEV3734.cfc
@@ -1,0 +1,140 @@
+component extends = "org.lucee.cfml.test.LuceeTestCase" {
+
+    function beforeAll() {
+        application enableNullSupport=true;
+    }
+
+    function afterAll() {
+        application enableNullSupport=false;
+    }
+
+    function run( testResults, textbox ) {
+
+        describe("testcase for LDEV-3734", function(){
+
+            it(title="Arithmetic addition with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 5+5 AS result,
+                      NULL+5 as result2,
+                      5+NULL as result3,
+                      NULL+NULL as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+            });
+
+            it(title="Arithmetic subtraction with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 20-10 AS result,
+                      NULL-5 as result2,
+                      5-NULL as result3,
+                      NULL-NULL as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+            });
+
+            it(title="Arithmetic multiplication with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 2*5 AS result,
+                      NULL*5 as result2,
+                      5*NULL as result3,
+                      NULL*NULL as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+            });
+
+            it(title="Arithmetic division with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 20/2 AS result,
+                      NULL/5 as result2,
+                      5/NULL as result3,
+                      NULL/NULL as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+            });
+
+            it(title="Arithmetic bitwise with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 4^2 AS result,
+                      NULL^5 as result2,
+                      5^NULL as result3,
+                      NULL^NULL as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 6 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+            });
+
+            it(title="Arithmetic modulus with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                // Note % and mod() have different implemntations
+                var actual = queryExecute(
+                    "SELECT 21%11 AS result,
+                      NULL%5 as result2,
+                      5%NULL as result3,
+                      NULL%NULL as result4,
+                      mod( 21, 11 ) AS result5,
+                      mod( NULL, 5 ) as result6,
+                      mod( 5, NULL ) as result7,
+                      mod( NULL, NULL ) as result8
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+				expect( actual.result5 ).toBe( 10 );
+				expect( actual.result6 ).toBeNull();
+				expect( actual.result7 ).toBeNull();
+				expect( actual.result8 ).toBeNull();
+            });
+
+            it(title="Arithmetic exponent with NULL in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT power( 4, 2 ) AS result,
+                      power( NULL, 5 ) as result2,
+                      power( 5, NULL ) as result3,
+                      power( NULL, NULL ) as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 16 );
+				expect( actual.result2 ).toBeNull();
+				expect( actual.result3 ).toBeNull();
+				expect( actual.result4 ).toBeNull();
+            });
+
+        });
+
+    }
+
+}

--- a/test/tickets/LDEV3736.cfc
+++ b/test/tickets/LDEV3736.cfc
@@ -3,7 +3,7 @@ component extends = "org.lucee.cfml.test.LuceeTestCase" {
 
     function run( testResults, textbox ) {
 
-        describe("testcase for LDEV-3734", function(){
+        describe("testcase for LDEV-3736", function(){
 
             it(title="Arithmetic addition with empty string in QoQ", body=function( currentSpec ){
                 qry = QueryNew('foo','integer',[[40]]);

--- a/test/tickets/LDEV3736.cfc
+++ b/test/tickets/LDEV3736.cfc
@@ -1,0 +1,121 @@
+component extends = "org.lucee.cfml.test.LuceeTestCase" {
+
+
+    function run( testResults, textbox ) {
+
+        describe("testcase for LDEV-3734", function(){
+
+            it(title="Arithmetic addition with empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 5+5 AS result,
+                      ''+5 as result2,
+                      5+'' as result3,
+                      ''+'' as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBe( 5 );
+				expect( actual.result3 ).toBe( 5 );
+				expect( actual.result4 ).toBe( '' );
+            });
+
+            it(title="Arithmetic subtraction empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 20-10 AS result,
+                      ''-5 as result2,
+                      5-'' as result3,
+                      ''-'' as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBe( -5 );
+				expect( actual.result3 ).toBe( 5 );
+				expect( actual.result4 ).toBe( 0 );
+            });
+
+            it(title="Arithmetic multiplication empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 2*5 AS result,
+                      ''*5 as result2,
+                      5*'' as result3,
+                      ''*'' as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBe( 0 );
+				expect( actual.result3 ).toBe( 0 );
+				expect( actual.result4 ).toBe( 0 );
+            });
+
+            it(title="Arithmetic division empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 20/2 AS result,
+                      ''/5 as result2
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBe( 0 );
+            });
+
+            it(title="Arithmetic bitwise empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT 4^2 AS result,
+                      ''^5 as result2,
+                      5^'' as result3,
+                      ''^'' as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 6 );
+				expect( actual.result2 ).toBe( 5 );
+				expect( actual.result3 ).toBe( 5 );
+				expect( actual.result4 ).toBe( 0 );
+            });
+
+            it(title="Arithmetic modulus empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                // Note % and mod() have different implemntations
+                var actual = queryExecute(
+                    "SELECT 21%11 AS result,
+                      ''%5 as result2,
+                      mod( 21, 11 ) AS result3,
+                      mod( '', 5 ) as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 10 );
+				expect( actual.result2 ).toBe( 0 );
+				expect( actual.result3 ).toBe( 10 );
+				expect( actual.result4 ).toBe( 0 );
+            });
+
+            it(title="Arithmetic exponent empty string in QoQ", body=function( currentSpec ){
+                qry = QueryNew('foo','integer',[[40]]);
+                var actual = queryExecute(
+                    "SELECT power( 4, 2 ) AS result,
+                      power( '', 5 ) as result2,
+                      power( 5, '' ) as result3,
+                      power( '', '' ) as result4
+                    FROM qry",
+                    [],
+                    {dbtype="query"} );
+				expect( actual.result ).toBe( 16 );
+				expect( actual.result2 ).toBe( 0 );
+				expect( actual.result3 ).toBe( 1 );
+				expect( actual.result4 ).toBe( 1 );
+            });
+
+        });
+
+    }
+
+}


### PR DESCRIPTION
This pull resolves both LDEV-3736 & LDEV-3734.  The logic is tightly intertwined, so the changes are combined.  There are full unit tests covering every code path for both tickets.

Note, I cleaned up some incorrectly-named methods internally since `^` is a bitwise operator, not an exponent.  I also added the `power()` function to complete the arithmetic operations and since this logic needed to apply to it as well so it all made sense to put it together.
