### PR TITLE
LDEV-3816 - fix from double slash creation for consistent file access in graph.cfm 

### DIFF
--- a/core/src/main/cfml/context/graph.cfm
+++ b/core/src/main/cfml/context/graph.cfm
@@ -1,5 +1,5 @@
 <cfif structKeyExists(url,"img") && structKeyExists(url,"type")>
-	<cfcontent file="#GetTempDirectory()#/graph/#listLast(url.img,'/\#server.separator.file#')#" type="image/#url.type#"><cfsetting showdebugoutput="no">
+	<cfcontent file="#GetTempDirectory()#graph/#listLast(url.img,'/\#server.separator.file#')#" type="image/#url.type#"><cfsetting showdebugoutput="no">
 <cfelse>
 	<cfheader statuscode="404" statustext="Invalid Access">
 </cfif>


### PR DESCRIPTION
GetTempDirectory() already echos a trailing slash. Thus, the code in graph.cfm creates file location paths with double slashes as follows:
On Ubuntu 20.04 LTS: `/somepath/WEB-INF/lucee/temp//graph/5A650255-8EB7-472A-86D943CE97EAD884.png`
On Windows 10: `C:\somepath\WEB-INF\lucee\temp\/graph/E1F8959F-B1F9-4845-8052502D385FEDF7.png`

This PR removes the preceeding slash for better file path consistency.

Please see also: https://dev.lucee.org/t/error-graph-cfm/9483