### PR TITLE
LDEV-3830 remove optimization to ensure distincts

### DIFF
--- a/core/src/main/java/lucee/runtime/db/QoQ.java
+++ b/core/src/main/java/lucee/runtime/db/QoQ.java
@@ -333,11 +333,6 @@ public final class QoQ {
 	 * @throws PageException
 	 */
 	private Query doUnionDistinct(PageContext pc, Query previous, Query target, SQL sql) throws PageException {
-		// If this is the first select in a series of unions, just return it directly. It's column
-		// names now get set in stone as the column names the next union(s) will use!
-		if (previous.getRecordcount() == 0) {
-			return target;
-		}
 		Collection.Key[] previousColKeys = previous.getColumnNames();
 		Collection.Key[] targetColKeys = target.getColumnNames();
 		

--- a/test/tickets/LDEV3830.cfc
+++ b/test/tickets/LDEV3830.cfc
@@ -1,0 +1,25 @@
+component extends = "org.lucee.cfml.test.LuceeTestCase" labels="qoq" {
+
+	function run( testResults, textbox ) {
+
+		describe("testcase for LDEV-3830", function(){
+
+			it(title="QoQ distinct rows with dupes in same original result", body=function( currentSpec ){
+				var a = queryNew("a","varchar");
+				var b = queryNew("a","varchar", [['1'],['2'],['2']]);
+
+				var actual = QueryExecute(
+					sql = "select a from a union select a from b",
+					options = { dbtype: 'query' }
+				);
+				
+				expect( actual ).toBeQuery();
+				expect( actual.recordCount ).toBe( 2 );
+
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
The optimization that tries to skip processing on the first select for a union distinct is allowing duplicates to slip by.  Removing that short circuit ensures we distinct everything.

https://luceeserver.atlassian.net/browse/LDEV-3830