### PR TITLE
fix build process on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,16 +129,15 @@ jobs:
         # used by travis-settings.xml
         CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
         CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
-        CI_DEPLOY_PASSPHRASE: ${{ secrets.CI_DEPLOY_PASSPHRASE }}
-        testJavaVersionExec: ${{ env.LUCEE_TEST_JAVA_EXEC }}
+        CI_DEPLOY_PASSPHRASE: ${{ secrets.CI_DEPLOY_PASSPHRASE }}        
       #run: ant -noinput -buildfile loader/build.xml
       run: |
         if [ "${DO_DEPLOY}" == "true" ]; then
           echo "------- Maven Deploy on ${{ github.event_name }} -------";
-          mvn -B -e -f loader/pom.xml clean deploy --settings travis-settings.xml;
+          mvn -B -e -f loader/pom.xml clean deploy --settings travis-settings.xml -DtestJavaVersionExec="${{ env.LUCEE_TEST_JAVA_EXEC }}";
         else
           echo "------- Maven Install on ${{ github.event_name }} ---------";
-          mvn -B -e -f loader/pom.xml clean install
+          mvn -B -e -f loader/pom.xml clean install -DtestJavaVersionExec="${{ env.LUCEE_TEST_JAVA_EXEC }}"
         fi
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
         CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
         CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
         CI_DEPLOY_PASSPHRASE: ${{ secrets.CI_DEPLOY_PASSPHRASE }}
-        testJavaVersionHome: ${{ env.LUCEE_TEST_JAVA_EXEC }}
+        testJavaVersionExec: ${{ env.LUCEE_TEST_JAVA_EXEC }}
       #run: ant -noinput -buildfile loader/build.xml
       run: |
         if [ "${DO_DEPLOY}" == "true" ]; then

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -79,7 +79,7 @@
     <!-- enable debug output from tests (i.e tests which crash are normally silently skipped)  -->
     <property name="testDebug" value=""/>
     <!-- allow running tests with a different java version (ant needs the exe not java home)  -->
-    <property name="testJavaVersionExec" value="${testJavaVersionExec}"/>
+    <property name="testJavaVersionExec" value=""/>
     
     <property name="temp" location="${rootDir}/temp"/>
     <property name="loader" location="${temp}/loader"/>

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -557,7 +557,7 @@
       deploydir="${temp}/archive/base/lucee-server/deploy/"/>
 
     <listDirectory directory="${test}/lib" delimiter=":" returnvalue="test_jars"/>
-    <echots message="execute testcases ${testcases} with java ${testJavaVersionHome}"/>
+    <echots message="execute testcases ${testcases} with java ${testJavaVersionExec}"/>
     <!-- execute CFML testcases -->
     <java classname="org.apache.tools.ant.launch.Launcher" dir="${ant}" fork="true" failonerror="true" errorproperty="exc2" jvm="${testJavaVersionExec}">
       <classpath path="${java.class.path}">

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -201,7 +201,7 @@
     <echo message="Required-Extensions: ${reqExt.labels}"/>
     <echo message="Java: ${java.version}" />
     <echo message="Java: ${java.home}" />
-    <echo message="Optional Java Version for tests: ${testJavaVersionHome}" />
+    <echo message="Optional Java Version for tests: ${testJavaVersionExec}" />
 
     <!-- Create the time stamp -->
     <tstamp/>

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -78,9 +78,8 @@
     <property name="testSkip" value=""/>
     <!-- enable debug output from tests (i.e tests which crash are normally silently skipped)  -->
     <property name="testDebug" value=""/>
-    <!-- allow running tests with a different java version  -->
-    <property environment="env"/>
-    <property name="testJavaVersionHome" value="${env.testJavaVersionHome}"/>
+    <!-- allow running tests with a different java version (ant needs the exe not java home)  -->
+    <property name="testJavaVersionExec" value="${testJavaVersionExec}"/>
     
     <property name="temp" location="${rootDir}/temp"/>
     <property name="loader" location="${temp}/loader"/>
@@ -560,7 +559,7 @@
     <listDirectory directory="${test}/lib" delimiter=":" returnvalue="test_jars"/>
     <echots message="execute testcases ${testcases} with java ${testJavaVersionHome}"/>
     <!-- execute CFML testcases -->
-    <java classname="org.apache.tools.ant.launch.Launcher" dir="${ant}" fork="true" failonerror="true" errorproperty="exc2" jvm="${testJavaVersionHome}">
+    <java classname="org.apache.tools.ant.launch.Launcher" dir="${ant}" fork="true" failonerror="true" errorproperty="exc2" jvm="${testJavaVersionExec}">
       <classpath path="${java.class.path}">
           <pathelement location="${temp}/lucee.jar"/>
           <pathelement path="${runtime_classpath}"/>


### PR DESCRIPTION
on windows, ant `<property environment="env"/>` didn't work

switch to passing in the -DtestJavaVersionExec as a command line property