### PR TITLE
Added a fix and testcase for CFC Metadata to trim implements and extends attributes in LDEV-3338

### DIFF
--- a/core/src/main/java/lucee/runtime/type/util/ListUtil.java
+++ b/core/src/main/java/lucee/runtime/type/util/ListUtil.java
@@ -1606,7 +1606,7 @@ public final class ListUtil {
 				}
 			}
 		}
-		if (last <= len) set.add(list.substring(last));
+		if (last <= len) set.add(trim ? list.substring(last).trim() : list.substring(last));
 		return set;
 	}
 
@@ -1624,7 +1624,7 @@ public final class ListUtil {
 				last = i + 1;
 			}
 		}
-		if (last <= len) set.add(list.substring(last));
+		if (last <= len) set.add(trim ? list.substring(last).trim() : list.substring(last));
 		return set;
 	}
 

--- a/test/tickets/LDEV3338.cfc
+++ b/test/tickets/LDEV3338.cfc
@@ -1,0 +1,22 @@
+component extends="org.lucee.cfml.test.LuceeTestCase"{
+    function run( testResults, testBox ){
+        describe(title="Testcase for LDEV-3338", body=function( currentSpec ) {
+            variables.CFCwithoutSpace = getComponentMetadata(new LDEV3338.IMPLwithoutSpace());
+            variables.CFCwithSpace = getComponentMetadata(new LDEV3338.IMPLwithSpace());
+            it(title="Check getComponentMetadata() result with CFC implements attribute without spaces", body=function( currentSpec )  {
+                expect(structKeyExists(CFCwithoutSpace.implements,"A")).toBe(true);
+                expect(structKeyExists(CFCwithoutSpace.implements,"B")).toBe(true);
+            });
+            it(title="Check getComponentMetadata() result with CFC implements attribute with spaces", body=function( currentSpec )  {
+                expect(structKeyExists(CFCwithSpace.implements,"A")).toBe(true);
+                expect(structKeyExists(CFCwithSpace.implements,"B")).toBe(true);
+            });
+            it(title="Check getComponentMetadata() result with interface extends attribute without spaces", body=function( currentSpec )  {
+                expect(structKeyExists(CFCwithoutSpace.implements.A.extends,"X")).toBe(true);
+            });
+            it(title="Check getComponentMetadata() result with interface extends attribute with spaces", body=function( currentSpec )  {
+                expect(structKeyExists(CFCwithoutSpace.implements.B.extends,"X")).toBe(true);
+            });
+        });
+    }
+} 

--- a/test/tickets/LDEV3338/A.cfc
+++ b/test/tickets/LDEV3338/A.cfc
@@ -1,0 +1,2 @@
+interface extends="X"{
+}

--- a/test/tickets/LDEV3338/B.cfc
+++ b/test/tickets/LDEV3338/B.cfc
@@ -1,0 +1,2 @@
+interface extends=" X "{
+}

--- a/test/tickets/LDEV3338/IMPLwithSpace.cfc
+++ b/test/tickets/LDEV3338/IMPLwithSpace.cfc
@@ -1,0 +1,2 @@
+component implements="A, B" {
+}

--- a/test/tickets/LDEV3338/IMPLwithoutSpace.cfc
+++ b/test/tickets/LDEV3338/IMPLwithoutSpace.cfc
@@ -1,0 +1,2 @@
+component implements="A,B" {
+}

--- a/test/tickets/LDEV3338/X.cfc
+++ b/test/tickets/LDEV3338/X.cfc
@@ -1,0 +1,2 @@
+interface {
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3338

The same PR for 6.0: https://github.com/lucee/Lucee/pull/1500