### PR TITLE
LDEV-3865 add support for setting a custom context root via lucee.cli.contextRoot

### DIFF
--- a/loader/src/main/java/lucee/runtime/script/BaseScriptEngineFactory.java
+++ b/loader/src/main/java/lucee/runtime/script/BaseScriptEngineFactory.java
@@ -30,6 +30,7 @@ import lucee.cli.servlet.ServletConfigImpl;
 import lucee.cli.servlet.ServletContextImpl;
 import lucee.loader.engine.CFMLEngine;
 import lucee.loader.engine.CFMLEngineFactory;
+import lucee.loader.util.Util;
 
 public abstract class BaseScriptEngineFactory implements ScriptEngineFactory {
 
@@ -55,7 +56,7 @@ public abstract class BaseScriptEngineFactory implements ScriptEngineFactory {
 				
 				// Allow override of context root
 				String rootPath = System.getProperty("lucee.cli.contextRoot");
-				if( rootPath == null ) {
+				if( Util.isEmpty(rootPath) ) {
 					// working directory that the java command was called from
 					rootPath = ".";
 				}

--- a/loader/src/main/java/lucee/runtime/script/BaseScriptEngineFactory.java
+++ b/loader/src/main/java/lucee/runtime/script/BaseScriptEngineFactory.java
@@ -52,7 +52,14 @@ public abstract class BaseScriptEngineFactory implements ScriptEngineFactory {
 				final String servletName = "";
 				final Map<String, Object> attributes = new HashMap<String, Object>();
 				final Map<String, String> initParams = new HashMap<String, String>();
-				final File root = new File("."); // working directory that the java command was called from
+				
+				// Allow override of context root
+				String rootPath = System.getProperty("lucee.cli.contextRoot");
+				if( rootPath == null ) {
+					// working directory that the java command was called from
+					rootPath = ".";
+				}
+				final File root = new File(rootPath); 
 
 				final ServletContextImpl servletContext = new ServletContextImpl(root, attributes, initParams, 1, 0);
 				final ServletConfigImpl servletConfig = new ServletConfigImpl(servletContext, servletName);


### PR DESCRIPTION
Allow the context root of the script engine to be customized like Lucee 4.x used to do with the pre-JSR-223 method.