### PR TITLE
Added a fix for new HTTP().send() method to work with url argument for LDEV-2468

### DIFF
--- a/core/src/main/java/resource/component/org/lucee/cfml/Http.cfc
+++ b/core/src/main/java/resource/component/org/lucee/cfml/Http.cfc
@@ -3,6 +3,7 @@ component extends="HelperBase"{
 	variables.tagname = "http";
 					
 	public any function send(){
+		this.setAttributes(argumentCollection=arguments);
 		return super.invokeTag();
 	}
 						


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-2468