### PR TITLE
Add failing test for getMetadata on UDFs

### DIFF
--- a/test/functions/GetMetaData.cfc
+++ b/test/functions/GetMetaData.cfc
@@ -62,7 +62,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 				assertEquals("soft",meta.type);
 			});
 
-			it( "Checking UDFs", () => {
+			it( title = "Checking UDFs", body = () => {
 				var metaA = getMetadata( exampleFunctionWithDescriptionInAnnotation );
 				expect( metaA ).toBeStruct();
 				expect( metaA ).toHaveKey( "description" );
@@ -72,7 +72,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 				expect( metaB ).toBeStruct();
 				expect( metaB ).toHaveKey( "description" );
 				expect( metaB.description ).toBe( "Description does not show up." );
-			} );
+			}, labels = [ "metadata" ], skip = true );
 
 		});
 

--- a/test/functions/GetMetaData.cfc
+++ b/test/functions/GetMetaData.cfc
@@ -1,7 +1,7 @@
 component extends="org.lucee.cfml.test.LuceeTestCase" {
 
 	function run( testResults , testBox ) {
-		
+
 		describe( title = "Test suite for getMetaData", body = function() {
 
 			it( title = 'Checking regular array', body = function( currentSpec ) {
@@ -62,7 +62,27 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 				assertEquals("soft",meta.type);
 			});
 
+			it( "Checking UDFs", () => {
+				var metaA = getMetadata( exampleFunctionWithDescriptionInAnnotation );
+				expect( metaA ).toBeStruct();
+				expect( metaA ).toHaveKey( "description" );
+				expect( metaA.description ).toBe( "Description shows up." );
+
+				var metaB = getMetadata( exampleFunctionWithDescriptionInDocblock );
+				expect( metaB ).toBeStruct();
+				expect( metaB ).toHaveKey( "description" );
+				expect( metaB.description ).toBe( "Description does not show up." );
+			} );
+
 		});
 
 	}
+
+	function exampleFunctionWithDescriptionInAnnotation() description="Description shows up." {}
+
+	/**
+	 * @description Description does not show up.
+	 */
+	function exampleFunctionWithDescriptionInDocblock() {}
+
 }


### PR DESCRIPTION
Lucee does not respect a `@description` in a docblock but does as a function annotation.

I tried to find where I would adjust this in code but no luck.  Hopefully the failing test case helps.