### PR TITLE
LDEV-4013 require all labels to match when filtering by tests by labels

### DIFF
--- a/test/_testRunner.cfc
+++ b/test/_testRunner.cfc
@@ -107,11 +107,16 @@ component {
 			if ( arrayLen (request.testLabels) eq 0 )
 				return "";
 			var labels = meta.labels ?: "";
+			var labelsMatched = 0;
 			loop array="#request.testLabels#" item="local.f" {
-				if ( FindNoCase( f, labels ) gt 0 )
-					return "";
+				if ( ListFindNoCase( f, labels ) gt 0 )
+					labelsMatched++;
 			}
-			return "no matching labels";
+			if ( labelsMatched neq arrayLen(request.testLabels) )
+				return "didn't match all label(s)";
+			else {
+				return ""; //ok	
+			}
 		};
 
 		allowed = isValidTestCase( arguments.path );


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4013

otherwise, for example the ehcache tests fail  due to ORM not being available, when only ehcache is specified 

https://github.com/lucee/Lucee/blob/6.0/test/tickets/LDEV1741.cfc#L1