### PR TITLE
Added support for passing LUCEE_BUILD_ENV to ANT

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -79,6 +79,8 @@
     <property name="testDebug" value=""/>
     <!-- allow running tests with a different java version (ant needs the exe not java home)  -->
     <property name="testJavaVersionExec" value=""/>
+    <!-- specify the build file to use  -->
+    <property name="LUCEE_BUILD_ENV" value=""/>
     
     <property name="temp" location="${rootDir}/temp"/>
     <property name="loader" location="${temp}/loader"/>
@@ -587,6 +589,7 @@
       <jvmarg value="-Dlucee.extensions.install=true"/>
       <jvmarg value="-Dlucee.full.null.support=false"/>
       <jvmarg value="-Dlucee.cli.printExpections=true"/>
+      <jvmarg value="-DLUCEE_BUILD_ENV=${LUCEE_BUILD_ENV}"/>
       <!--
       <jvmarg value="-XX:StartFlightRecording=disk=true,dumponexit=true,filename=${temp}/../lucee-testcases.jfr,maxsize=1024m,maxage=1d,settings=profile,path-to-gc-roots=true"/>
       <jvmarg value="-Dlucee.system.out=file:.../out.txt"/>

--- a/test/_setupTestServices.cfc
+++ b/test/_setupTestServices.cfc
@@ -24,7 +24,9 @@ component {
 	then add an ENV var pointing to the .json file
 	
 	LUCEE_BUILD_ENV=c:\work\lucee_build_env.json"
-	
+
+	You can also pass "-DLUCEE_BUILD_ENV=c:/work/lucee_build_env.json" directly to ANT
+	to have it passed to the JVM.
 	*/
 
 	public function init (){


### PR DESCRIPTION
I've added support for passing the LUCEE_BUILD_ENV environmental variable to ANT, so you can specify it on the command line when building Lucee.