### PR TITLE
CFMail splitting long HTML lines into multiple lines breaking the HTML

### DIFF
--- a/core/src/main/java/lucee/runtime/net/smtp/SMTPClient.java
+++ b/core/src/main/java/lucee/runtime/net/smtp/SMTPClient.java
@@ -989,10 +989,54 @@ public final class SMTPClient implements Serializable {
 		return html;
 	}
 
+
+	/*
+	 * Users can opt-in to the old Lucee behavior of allowing HTML emails to be sent
+	 * using 7bit encoding. When 7bit transfer encoding is used, content must be
+	 * wrapped to less than 1,000 characters per line.
+	 * 
+	 * The new default behavior for sending HTML emails is to use "quoted-printable"
+	 * encoding, encodings non-ASCII characters and automatically wraps lines to 76
+	 * characters wide, but encodes word breaks. This allows for strings longer than
+	 * 1000 characters to be included in the output and still have the output
+	 * conform to the SMTP RFCs.
+	 * 
+	 * https://stackoverflow.com/questions/25710599/content-transfer-encoding-7bit-or-8-bit/28531705#28531705
+	 */
+	private boolean isUse7bitHtmlEncoding() {
+		try {
+			return Caster.toBoolean(SystemUtil.getSystemPropOrEnvVar("lucee.mail.use.7bit.transfer.encoding.for.html.parts", "false"));
+		} catch (Throwable t){
+			return false;
+		}
+	}
+
 	private void fillHTMLText(Config config, MimePart mp) throws MessagingException {
 		if (htmlTextCharset == null) htmlTextCharset = getMailDefaultCharset(config);
-		mp.setDataHandler(new DataHandler(new StringDataSource(htmlText, TEXT_HTML, htmlTextCharset, 998)));
-		mp.setHeader("Content-Transfer-Encoding", "7bit");
+
+		String transferEncoding;
+
+		/*
+		 * Set the "lucee.mail.use.7bit.transfer.encoding.for.html.parts" system property to "false"
+		 * to force the previous behavior of using 7bit transfer encoding.
+		 */
+		if( isUse7bitHtmlEncoding() ){
+			transferEncoding = "7bit";
+			// when using 7bit, we must always wrap lines
+			mp.setDataHandler(new DataHandler(new StringDataSource(htmlText, TEXT_HTML, htmlTextCharset, 998)));
+		/*
+		 * The default behavior is to using "quoted-printable" for HTML emails. This will force
+		 * wrapping of lines to 76 characters and encoded any non-ASCII characters.
+		 * 
+		 * ACF uses this encoded for all HTML parts.
+		 */
+		} else {
+			transferEncoding = "quoted-printable";
+			mp.setDataHandler(new DataHandler(new StringDataSource(htmlText, TEXT_HTML, htmlTextCharset)));
+		}
+		
+		// headers must always be set after data handler is set or the headers will be replaced
+		mp.setHeader("Content-Transfer-Encoding", transferEncoding);
 		mp.setHeader("Content-Type", TEXT_HTML + "; charset=" + htmlTextCharset);
 	}
 
@@ -1005,6 +1049,7 @@ public final class SMTPClient implements Serializable {
 	private void fillPlainText(Config config, MimePart mp) throws MessagingException {
 		if (plainTextCharset == null) plainTextCharset = getMailDefaultCharset(config);
 		mp.setDataHandler(new DataHandler(new StringDataSource(plainText != null ? plainText : "", TEXT_PLAIN, plainTextCharset, 998)));
+		// headers must always be set after data handler is set or the headers will be replaced
 		mp.setHeader("Content-Transfer-Encoding", "7bit");
 		mp.setHeader("Content-Type", TEXT_PLAIN + "; charset=" + plainTextCharset);
 	}
@@ -1013,9 +1058,20 @@ public final class SMTPClient implements Serializable {
 		CharSet cs = CharsetUtil.toCharSet(part.getCharset());
 		if (cs == null) cs = getMailDefaultCharset(config);
 		MimeBodyPart mbp = new MimeBodyPart();
-		mbp.setDataHandler(new DataHandler(new StringDataSource(part.getBody(), part.getType(), cs, 998)));
-		// mbp.setHeader("Content-Transfer-Encoding", "7bit");
-		// mbp.setHeader("Content-Type", TEXT_PLAIN+"; charset="+plainTextCharset);
+
+		StringDataSource partSource = null;
+		/*
+		 * HTML parts are encoded as "quoted-printable", which is automatically wrapped to 76 characters
+		 * per line, so we do not need to wrap these lines.
+		 */
+		if( (part.getType() == "text/html") && !isUse7bitHtmlEncoding() ){
+			partSource = new StringDataSource(part.getBody(), part.getType(), cs);
+		} else {
+			partSource = new StringDataSource(part.getBody(), part.getType(), cs, 998);
+		}
+
+
+		mbp.setDataHandler(new DataHandler(partSource));
 		return mbp;
 	}
 

--- a/core/src/main/java/lucee/runtime/net/smtp/StringDataSource.java
+++ b/core/src/main/java/lucee/runtime/net/smtp/StringDataSource.java
@@ -41,8 +41,18 @@ public final class StringDataSource implements DataSource {
 	public final static char CR = (char) 13;
 	public final static char LF = (char) 10;
 
-	public StringDataSource(String text, String ct, CharSet charset, int maxLineLength) {
+	/*
+	 * Some types of transfer encoding such as "quoted-printable" and "base64"
+	 * do not require wrapping of lines, because it's handled automatically
+	 * in the encoding.
+	 */
+	public StringDataSource(String text, String ct, CharSet charset) {
+		this.text = text;
+		this.ct = ct;
+		this.charset = charset;
+	}
 
+	public StringDataSource(String text, String ct, CharSet charset, int maxLineLength) {
 		this.text = wrapText(text, maxLineLength);
 		this.ct = ct;
 		this.charset = charset;


### PR DESCRIPTION
I've refactored CFMAIL to use `quoted-printable` content transfer encoding for all HTML parts. On the suggestion of @zspitzer, I added a system property/environment variable (i.e. `lucee.mail.use.7bit.transfer.encoding.for.html.parts`) which allows switching back to the old behavior. This defaults to `false` which changes the behavior, but the only downside I can see to switching to `quoted-printable` as the default encoding is the message size will be a little larger. However, it fixes issues like:

* **Line wrapping** — `quoted-printable` always wraps lines to 76 characters.
* **Does not break long strings** — Long strings are encoded in the line wrapping, which means you could have a string (like a link) longer than 1000 characters without CFMAIL breaking the string after 997 characters.
* **Encodes non-ASCII characters** — `quoted-printable` will encode characters you cannot normally send with 7bit encoding, such as 8bit UTF characters.

https://luceeserver.atlassian.net/browse/LDEV-4039

https://github.com/lucee/Lucee/pull/1706