### PR TITLE
Added a fix and testcase to cfafmin action=getcharset() to return vaues correctly for LDEV-3224 (lucee 6.0l)

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/Admin.java
+++ b/core/src/main/java/lucee/runtime/tag/Admin.java
@@ -5233,7 +5233,7 @@ public final class Admin extends TagImpl implements DynamicAttributes {
 		pageContext.setVariable(getString("admin", action, "returnVariable"), sct);
 		sct.set("resourceCharset", config.getResourceCharset().name());
 		sct.set("templateCharset", config.getTemplateCharset().name());
-		sct.set("webCharset", ((PageContextImpl) pageContext).getWebCharset().name());
+		sct.set("webCharset", config.getWebCharset().name());
 		sct.set("jreCharset", SystemUtil.getCharset().name());
 	}
 

--- a/test/tickets/LDEV3224.cfc
+++ b/test/tickets/LDEV3224.cfc
@@ -1,0 +1,26 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="admin" {
+
+	function beforeAll() {
+		variables.adm = new Administrator("server",request.SERVERADMINPASSWORD?:server.SERVERADMINPASSWORD);
+		variables.defaultCharset = adm.getCharset();
+	}
+
+	function run( testResults, testBox ) {
+		describe("Testcase for LDEV-3224", function() {
+			it(title="checking admin getCharset()", body=function( currentSpec ){
+				variables.adm.updateCharset(templateCharset="ISO-8859-1",webCharset="ISO-8859-1",resourceCharset="ISO-8859-1");
+
+				var charset = variables.adm.getCharset();
+
+				expect(charset.webCharset).toBe("ISO-8859-1");
+				expect(charset.templateCharset).toBe("ISO-8859-1");
+				expect(charset.resourceCharset).toBe("ISO-8859-1");
+			});
+		});
+	}
+
+	function afterAll() {
+		variables.adm.updateCharset(argumentCollection=variables.defaultCharset);
+	}
+
+} 


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3224

PR for 5.3: https://github.com/lucee/Lucee/pull/1658