### PR TITLE
LDEV-4108 better OSGI bundle exception and console logging

### DIFF
--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -601,23 +601,27 @@ public class OSGiUtil {
 		}
 
 		String bundleError = "";
+		String parentBundle = String.join(",", parents);
 		if (versionsFound.length() > 0){
-			bundleError = "The OSGi Bundle with name [" + name + "] is not available in version ["
+			bundleError = "The OSGi Bundle with name [" + name + "] for [" + parentBundle + "] is not available in version ["
 				+ version + "] locally [" + localDir + "] or from the update provider [" + upLoc
 				+ "], the following versions are available locally [" + versionsFound + "].";
-		} else if (version != null){
+		} 
+		else if (version != null){
 			bundleError = "The OSGi Bundle with name [" + name + "] in version [" + version
-				+ "] is not available locally [" + localDir + "] or from the update provider" + upLoc + ".";
+				+ "] for [" + parentBundle + "] is not available locally [" + localDir + "] or from the update provider" + upLoc + ".";
 			throw new BundleException(bundleError);
-		} else {
-			bundleError = "The OSGi Bundle with name [" + name + "] is not available locally [" + localDir
+		} 
+		else {
+			bundleError = "The OSGi Bundle with name [" + name + "] for [" + parentBundle + "] is not available locally [" + localDir
 				+ "] or from the update provider [" + upLoc + "].";
 		}
 
 		boolean printExceptions = Caster.toBooleanValue(SystemUtil.getSystemPropOrEnvVar("lucee.cli.printExceptions", null), false);
 		try {
 			throw new BundleException(bundleError);
-		} catch (BundleException be){
+		} 
+		catch (BundleException be){
 			if (printExceptions) be.printStackTrace();
 			throw be;
 		}
@@ -631,7 +635,8 @@ public class OSGiUtil {
 				+ " it will need to be manually downloaded and placed in the {{lucee-server}}/context/bundles directory.";
 			try {
 				throw new RuntimeException(bundleError);
-			} catch (RuntimeException re){
+			} 
+			catch (RuntimeException re){
 				if (printExceptions) re.printStackTrace();
 				throw re;
 			}

--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -600,17 +600,41 @@ public class OSGiUtil {
 		catch (IOException e) {
 		}
 
-		if (versionsFound.length() > 0) throw new BundleException("The OSGi Bundle with name [" + name + "] is not available in version [" + version + "] locally" + localDir
-				+ " or from the update provider" + upLoc + ", the following versions are available locally [" + versionsFound + "].");
-		if (version != null) throw new BundleException(
-				"The OSGi Bundle with name [" + name + "] in version [" + version + "] is not available locally" + localDir + " or from the update provider" + upLoc + ".");
-		throw new BundleException("The OSGi Bundle with name [" + name + "] is not available locally" + localDir + " or from the update provider" + upLoc + ".");
+		String bundleError = "";
+		if (versionsFound.length() > 0){
+			bundleError = "The OSGi Bundle with name [" + name + "] is not available in version ["
+				+ version + "] locally [" + localDir + "] or from the update provider [" + upLoc
+				+ "], the following versions are available locally [" + versionsFound + "].";
+		} else if (version != null){
+			bundleError = "The OSGi Bundle with name [" + name + "] in version [" + version
+				+ "] is not available locally [" + localDir + "] or from the update provider" + upLoc + ".";
+			throw new BundleException(bundleError);
+		} else {
+			bundleError = "The OSGi Bundle with name [" + name + "] is not available locally [" + localDir
+				+ "] or from the update provider [" + upLoc + "].";
+		}
+
+		boolean printExceptions = Caster.toBooleanValue(SystemUtil.getSystemPropOrEnvVar("lucee.cli.printExceptions", null), false);
+		try {
+			throw new BundleException(bundleError);
+		} catch (BundleException be){
+			if (printExceptions) be.printStackTrace();
+			throw be;
+		}
 	}
 
 	private static Resource downloadBundle(CFMLEngineFactory factory, final String symbolicName, String symbolicVersion, Identification id) throws IOException, BundleException {
 		if (!Caster.toBooleanValue(SystemUtil.getSystemPropOrEnvVar("lucee.enable.bundle.download", null), true)) {
-			throw (new RuntimeException("Lucee is missing the Bundle jar [" + symbolicName + ":" + symbolicVersion
-					+ "], and has been prevented from downloading it. If this jar is not a core jar, it will need to be manually downloaded and placed in the {{lucee-server}}/context/bundles directory."));
+			boolean printExceptions = Caster.toBooleanValue(SystemUtil.getSystemPropOrEnvVar("lucee.cli.printExceptions", null), false);
+			String bundleError = "Lucee is missing the Bundle jar [" + symbolicName + ":" + symbolicVersion
+				+ "], and has been prevented from downloading it. If this jar is not a core jar,"
+				+ " it will need to be manually downloaded and placed in the {{lucee-server}}/context/bundles directory.";
+			try {
+				throw new RuntimeException(bundleError);
+			} catch (RuntimeException re){
+				if (printExceptions) re.printStackTrace();
+				throw re;
+			}
 		}
 
 		final Resource jarDir = ResourceUtil.toResource(factory.getBundleDirectory());


### PR DESCRIPTION
- log out bundle exceptions to console when `-Dlucee.cli.printExceptions=true`
https://luceeserver.atlassian.net/browse/LDEV-4108

TODO - include actual bundle name in exception