### PR TITLE
Correct spelling / grammar for PRECISE argument.

### DIFF
--- a/core/src/main/java/resource/fld/core-base.fld
+++ b/core/src/main/java/resource/fld/core-base.fld
@@ -1604,7 +1604,7 @@ sort direction:
 			<type>boolean</type>
 			<required>no</required>
 			<default>true</default>
-		<description>if set to true the input must follow the rule for that encoding a 100%, the decryptor will not try to interpret inputs that are not a 100% correct. This should be used to avoud false positives.</description>
+		<description>If set to true the input must follow the rule for that encoding, 100%, the decryptor will not try to interpret inputs that are not 100% correct. This should be used to avoid false positives.</description>
     </argument>
 		<return>
 			<type>binary</type>
@@ -3439,7 +3439,7 @@ You may also specify other algorithm names as well as the feedback mode and padd
 			<type>boolean</type>
 			<required>no</required>
 			<default>true</default>
-		<description>if set to true the input must follow the rule for that encoding a 100%, the decryptor will not try to interpret inputs that are not a 100% correct. This should be used to avoud false positives.</description>
+		<description>If set to true the input must follow the rule for that encoding, 100%, the decryptor will not try to interpret inputs that are not 100% correct. This should be used to avoid false positives.</description>
     </argument>
 		<return>
 			<type>string</type>
@@ -3499,7 +3499,7 @@ You may also specify other algorithm names as well as the feedback mode and padd
 			<type>boolean</type>
 			<required>no</required>
 			<default>true</default>
-		<description>if set to true the input must follow the rule for that encoding a 100%, the decryptor will not try to interpret inputs that are not a 100% correct. This should be used to avoud false positives.</description>
+		<description>If set to true the input must follow the rule for that encoding, 100%, the decryptor will not try to interpret inputs that are not 100% correct. This should be used to avoid false positives.</description>
     </argument>
 		<return>
 			<type>any</type>
@@ -4092,7 +4092,7 @@ You may also specify other algorithm names as well as the feedback mode and padd
 			<type>boolean</type>
 			<required>no</required>
 			<default>true</default>
-		<description>if set to true the input must follow the rule for that encoding a 100%, the decryptor will not try to interpret inputs that are not a 100% correct. This should be used to avoud false positives.</description>
+		<description>If set to true the input must follow the rule for that encoding, 100%, the decryptor will not try to interpret inputs that are not 100% correct. This should be used to avoid false positives.</description>
     </argument>
 		<return>
 			<type>string</type>
@@ -4150,7 +4150,7 @@ You may also specify other algorithm names as well as the feedback mode and padd
 			<type>boolean</type>
 			<required>no</required>
 			<default>true</default>
-		<description>if set to true the input must follow the rule for that encoding a 100%, the decryptor will not try to interpret inputs that are not a 100% correct. This should be used to avoud false positives.</description>
+		<description>If set to true the input must follow the rule for that encoding, 100%, the decryptor will not try to interpret inputs that are not 100% correct. This should be used to avoid false positives.</description>
     </argument>
 		<return>
 			<type>any</type>


### PR DESCRIPTION
Correct the grammar and spelling for the new precise argument / attribute.