### PR TITLE
LDEV-4178 DirectoryCreate allow any storageLocation (passthru)

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/Directory.java
+++ b/core/src/main/java/lucee/runtime/tag/Directory.java
@@ -235,10 +235,10 @@ public final class Directory extends TagImpl {
 	}
 
 	public static String improveStorage(String storage) throws ApplicationException {
-		storage = improveStorage(storage, null);
+		storage = improveStorage(storage, storage==null?null:storage.trim());
 		if (storage != null) return storage;
 
-		throw new ApplicationException("Invalid storage value, valid values are [eu, us, us-west]");
+		throw new ApplicationException("Invalid storageLocation value");
 	}
 
 	public static String improveStorage(String storage, String defaultValue) {

--- a/test/functions/StoreGetMetaData.cfc
+++ b/test/functions/StoreGetMetaData.cfc
@@ -1,67 +1,87 @@
-<!--- 
+<!---
  *
  * Copyright (c) 2015, Lucee Assosication Switzerland. All rights reserved.
  * Copyright (c) 2014, the Railo Company LLC. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  ---><cfscript>
 component extends="org.lucee.cfml.test.LuceeTestCase"	{
-	
+
 	//public function beforeTests(){}
-	
+
 	//public function afterTests(){}
 
 
-	private struct function getCredencials() {
+	private struct function getCredentials() {
 		return server.getTestService("s3");
 	}
-	  
+
 	public function setUp(){
-		var s3=getCredencials();
+		var s3=getCredentials();
 		if(!isNull(s3.accessKeyId)) {
 			application action="update" s3={
 				accessKeyId: s3.ACCESS_KEY_ID,
 				awsSecretKey: s3.SECRET_KEY
-			}; 
+			};
 			variables.s3Supported=true;
 		}
-		else 
+		else
 			variables.s3Supported=false;
 	}
 
 	public function testStoreMetadata() localMode=true {
 		if(!variables.s3Supported) return;
-		
+
 		var dir="s3://lucee-testsuite-metadata/object/";
 		if(DirectoryExists(dir)) directoryDelete(dir,true);
 		try {
 			assertFalse(DirectoryExists(dir));
 			directoryCreate(dir);
 
-		
 			var md=storeGetMetaData(dir);
 			var countBefore=structCount(md);
 			storesetMetaData(dir,{"susi":"Susanne"});
-    		var md=storeGetMetaData(dir);
-    		assertEquals(countBefore+1,structCount(md));
+			var md=storeGetMetaData(dir);
+			assertEquals(countBefore+1,structCount(md));
 			assertEquals("Susanne",md.susi);
 		}
 		finally {
-    		if(DirectoryExists(dir))
-    			directoryDelete(dir,true);
-    	}  
+			if(DirectoryExists(dir))
+				directoryDelete(dir,true);
+		}
 	}
-} 
+
+	private string function getTestBucketUrl() localmode=true {
+		s3Details = getCredentials();
+		bucketName = lcase("lucee-storeGetMetaData-#lcase(hash(CreateGUID()))#");
+		return "s3://#s3Details.ACCESS_KEY_ID#:#s3Details.SECRET_KEY#@/#bucketName#";
+	}
+
+	public function testS3Url(){
+		var bucket = getTestBucketUrl();
+		try {
+			expect( directoryExists( bucket ) ).toBeFalse();
+			directory action="create" directory="#bucket#";
+			expect( directoryExists( bucket ) ).toBeTrue();
+			var info = StoreGetMetadata( bucket );
+			expect( info ).toHaveKey( "region" );
+			expect( info.region ).toBe( "us-east-1" );
+		} finally {
+			if ( directoryExists( bucket ) )
+				directoryDelete( bucket );
+		}
+	}
+}
 </cfscript>

--- a/test/functions/StoreGetMetaData.cfc
+++ b/test/functions/StoreGetMetaData.cfc
@@ -69,7 +69,16 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 		return "s3://#s3Details.ACCESS_KEY_ID#:#s3Details.SECRET_KEY#@/#bucketName#";
 	}
 
+	private numeric function checkS3Version(){
+		var s3Version = extensionList().filter(function(row){
+			return (row.name contains "s3");
+		}).version;
+		return listFirst( s3Version, "." ) ;
+	};
+
 	public function testS3Url(){
+		if ( checkS3Version() eq 0 )
+			return; // only works with v2 due to https://luceeserver.atlassian.net/browse/LDEV-4202
 		var bucket = getTestBucketUrl();
 		try {
 			expect( directoryExists( bucket ) ).toBeFalse();

--- a/test/tickets/LDEV4178.cfc
+++ b/test/tickets/LDEV4178.cfc
@@ -25,11 +25,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="s3" {
 				}).toThrow();
 			} else {
 				directory action="create" directory="#bucket#" storelocation="#arguments.storelocation#";
+				expect( directoryExists( bucket ) ).toBeTrue();
+				var info = StoreGetMetadata( bucket );
+				expect( info ).toHaveKey( "region" );
+				expect( info.region ).toBe( arguments.storelocation );
 			}
-			expect( directoryExists( bucket ) ).toBeTrue();
-			var info = StoreGetMetadata( bucket );
-			expect( info ).toHaveKey( "region" );
-			expect( info.region ).toBe( arguments.storelocation );
 		} finally {
 			if ( directoryExists( bucket ) )
 				directoryDelete( bucket );
@@ -38,10 +38,6 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="s3" {
 
 	public function run( testResults , testBox ) {
 		describe( title="Test suite for LDEV-1489 ( checking s3 file operations )", body=function() {
-			it(title="Creating a new s3 bucket, valid region name [us]", skip=isNotSupported(), body=function( currentSpec ) {
-				createBucket( "us" );
-			});
-
 			it(title="Creating a new s3 bucket, valid region name [us-east-1]", skip=isNotSupported(), body=function( currentSpec ) {
 				createBucket( "us-east-1" );
 			});

--- a/test/tickets/LDEV4178.cfc
+++ b/test/tickets/LDEV4178.cfc
@@ -1,0 +1,61 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="s3" {
+	// skip closure
+	function isNotSupported() {
+		variables.s3Details=getCredentials();
+		return structIsEmpty(s3Details);
+	}
+
+	function beforeAll() skip="isNotSupported"{
+		if(isNotSupported()) return;
+	}
+
+	private string function getTestBucketUrl() localmode=true {
+		s3Details = getCredentials();
+		bucketName = lcase("lucee-ldev4178-#lcase(hash(CreateGUID()))#");
+		return "s3://#s3Details.ACCESS_KEY_ID#:#s3Details.SECRET_KEY#@/#bucketName#";
+	}
+
+	private function createBucket( required string storelocation, boolean invalid=false ){
+		var bucket = getTestBucketUrl();
+		try {
+			expect( directoryExists( bucket ) ).toBeFalse();
+			if ( arguments.invalid ) {
+				expect( function(){
+					directory action="create" directory="#bucket#" storelocation="#arguments.storelocation#";
+				}).toThrow();
+			} else {
+				directory action="create" directory="#bucket#" storelocation="#arguments.storelocation#";
+			}
+			expect( directoryExists( bucket ) ).toBeTrue();
+			var info = StoreGetMetadata( bucket );
+			expect( info ).toHaveKey( "region" );
+			expect( info.region ).toBe( arguments.storelocation );
+		} finally {
+			if ( directoryExists( bucket ) )
+				directoryDelete( bucket );
+		}
+	}
+
+	public function run( testResults , testBox ) {
+		describe( title="Test suite for LDEV-1489 ( checking s3 file operations )", body=function() {
+			it(title="Creating a new s3 bucket, valid region name [us]", skip=isNotSupported(), body=function( currentSpec ) {
+				createBucket( "us" );
+			});
+
+			it(title="Creating a new s3 bucket, valid region name [us-east-1]", skip=isNotSupported(), body=function( currentSpec ) {
+				createBucket( "us-east-1" );
+			});
+
+			it(title="Creating a new s3 bucket, invalid region name [down-under]", skip=isNotSupported(), body=function( currentSpec ){
+				createBucket( "down-under", true );
+			});
+		});
+	}
+
+		// Private functions
+	private struct function getCredentials() {
+		return server.getTestService("s3");
+	}
+
+}
+

--- a/test/tickets/LDEV4178.cfc
+++ b/test/tickets/LDEV4178.cfc
@@ -15,6 +15,14 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="s3" {
 		return "s3://#s3Details.ACCESS_KEY_ID#:#s3Details.SECRET_KEY#@/#bucketName#";
 	}
 
+	private numeric function checkS3Version(){
+		var s3Version = extensionList().filter(function(row){
+			return (row.name contains "s3");
+		}).version;
+		return listFirst( s3Version, "." ) ;
+	};
+
+
 	private function createBucket( required string storelocation, boolean invalid=false ){
 		var bucket = getTestBucketUrl();
 		try {
@@ -26,9 +34,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="s3" {
 			} else {
 				directory action="create" directory="#bucket#" storelocation="#arguments.storelocation#";
 				expect( directoryExists( bucket ) ).toBeTrue();
-				var info = StoreGetMetadata( bucket );
-				expect( info ).toHaveKey( "region" );
-				expect( info.region ).toBe( arguments.storelocation );
+				if ( checkS3Version() neq 0 ) {				
+					var info = StoreGetMetadata( bucket ); // only works with v2 due to https://luceeserver.atlassian.net/browse/LDEV-4202
+					expect( info ).toHaveKey( "region" );
+					expect( info.region ).toBe( arguments.storelocation );
+				}
 			}
 		} finally {
 			if ( directoryExists( bucket ) )


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4178

currently failing as  `StoreGetMetadata(s3Bucket)` isn't returning `region`

CI passes as there are no s3 creds for PRs

error i get locally is
```
     [java]    [script]         Failed: Creating a new s3 bucket, valid region name [us] --> The key [region] does not exist in the target object. Found keys are [[Date, owner]]
     [java]    [script]                 at
     [java]    [script]         C:\work\lucee\test\tickets\LDEV4178.cfc:25
     [java]    [script]         C:\work\lucee\test\tickets\LDEV4178.cfc:36
     [java]    [script]
     [java]    [script]         Failed: Creating a new s3 bucket, valid region name [us-east-1] --> The key [region] does not exist in the target object. Found keys are [[Date, owner]]
     [java]    [script]                 at
     [java]    [script]         C:\work\lucee\test\tickets\LDEV4178.cfc:25
     [java]    [script]         C:\work\lucee\test\tickets\LDEV4178.cfc:40
```

**update:** works with s3 extension 2.0.0.93RC but not 0.9.4.155-SNAPSHOT