### PR TITLE
Added a fix to always include a charset key in cfhttp result for LDEV-3678

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/Http.java
+++ b/core/src/main/java/lucee/runtime/tag/Http.java
@@ -1202,6 +1202,9 @@ public final class Http extends BodyTagImpl {
 				}
 
 			}
+
+			String charset = HTTPUtil.splitMimeTypeAndCharset(mimetype, null)[1];
+
 			cfhttp.set(RESPONSEHEADER, responseHeader);
 			cfhttp.set(KeyConstants._cookies, cookies);
 			responseHeader.set(STATUS_CODE, new Double(statCode = rsp.getStatusCode()));
@@ -1242,13 +1245,16 @@ public final class Http extends BodyTagImpl {
 				if (Boolean.TRUE == _isText) {
 					String[] types = HTTPUtil.splitMimeTypeAndCharset(mimetype, null);
 					if (types[0] != null) cfhttp.set(KeyConstants._mimetype, types[0]);
-					if (types[1] != null) cfhttp.set(CHARSET, types[1]);
+					if (types[1] != null) charset = types[1];
 
 				}
 				else cfhttp.set(KeyConstants._mimetype, mimetype);
 			}
 			else cfhttp.set(KeyConstants._mimetype, NO_MIMETYPE);
 
+			// charset
+			cfhttp.set(CHARSET, charset != null? charset : "");
+			
 			// File
 			Resource file = null;
 

--- a/test/tickets/LDEV3678.cfc
+++ b/test/tickets/LDEV3678.cfc
@@ -1,0 +1,15 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="http" {
+    function run( testResults, testBox ) {
+        describe("Testcase for LDEV-3678", function() {
+            it( title="checking charset key in cfhttp result with empty charset", body=function( currentSpec ){
+                http url="https://raw.githubusercontent.com/lucee/Lucee/6.0/test/functions/images/lucee.png" result="local.result";
+                expect(result).toHaveKey("charset");
+            });
+            it( title="checking charset key in cfhttp result with charset=UTF-8", body=function( currentSpec ){
+                http url="http://update.lucee.org/rest/update/provider/echoGet" result="local.result";
+                expect(result).toHaveKey("charset");   
+                expect(result.charset).toBe("UTF-8"); 
+            });
+        });
+    }
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3678