### PR TITLE
QoQ shouldn't fall back to HSQLDB after queryparam error

### DIFF
--- a/core/src/main/java/lucee/runtime/db/HSQLDBHandler.java
+++ b/core/src/main/java/lucee/runtime/db/HSQLDBHandler.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package lucee.runtime.db;
 
@@ -40,6 +40,7 @@ import lucee.runtime.PageContext;
 import lucee.runtime.config.ConfigPro;
 import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.DatabaseException;
+import lucee.runtime.exp.IllegalQoQException;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.op.Caster;
 import lucee.runtime.op.date.DateCaster;
@@ -88,7 +89,7 @@ public final class HSQLDBHandler {
 
 	/**
 	 * adds a table to the memory database
-	 * 
+	 *
 	 * @param conn
 	 * @param pc
 	 * @param name name of the new table
@@ -201,7 +202,7 @@ public final class HSQLDBHandler {
 
 	/**
 	 * remove a table from the memory database
-	 * 
+	 *
 	 * @param conn
 	 * @param name
 	 * @throws DatabaseException
@@ -215,7 +216,7 @@ public final class HSQLDBHandler {
 
 	/**
 	 * remove all table inside the memory database
-	 * 
+	 *
 	 * @param conn
 	 */
 	private static void removeAll(Connection conn, ArrayList<String> usedTables) {
@@ -236,7 +237,7 @@ public final class HSQLDBHandler {
 
 	/**
 	 * executes a query on the queries inside the cfml environment
-	 * 
+	 *
 	 * @param pc Page Context
 	 * @param sql
 	 * @param maxrows
@@ -277,7 +278,8 @@ public final class HSQLDBHandler {
 		}
 
 		// Debugging option to completely disable HyperSQL for testing
-		if (qoqException != null && hsqldbDisable) {
+		// Or if it's an IllegalQoQException that means, stop trying and throw the original message.
+		if ( qoqException != null && ( hsqldbDisable || qoqException instanceof IllegalQoQException ) ) {
 			throw Caster.toPageException(qoqException);
 		}
 

--- a/core/src/main/java/lucee/runtime/exp/DatabaseException.java
+++ b/core/src/main/java/lucee/runtime/exp/DatabaseException.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package lucee.runtime.exp;
 
@@ -37,7 +37,7 @@ import lucee.runtime.type.util.KeyConstants;
  * Database Exception Object
  */
 
-public final class DatabaseException extends PageExceptionImpl {
+public class DatabaseException extends PageExceptionImpl {
 
 	private SQL sql;
 	private String sqlstate = "";
@@ -62,7 +62,7 @@ public final class DatabaseException extends PageExceptionImpl {
 
 	/**
 	 * Constructor of the class
-	 * 
+	 *
 	 * @param message error message
 	 * @param detail detailed error message
 	 * @param sqle
@@ -132,18 +132,18 @@ public final class DatabaseException extends PageExceptionImpl {
 
 	/**
 	 * Constructor of the class
-	 * 
+	 *
 	 * @param message
 	 * @param sqle
 	 * @param sql
-	 * 
+	 *
 	 *            public DatabaseException(String message, SQLException sqle, SQL
 	 *            sql,DatasourceConnection dc) { this(message,null,sqle,sql,dc); }
 	 */
 
 	/**
 	 * Constructor of the class
-	 * 
+	 *
 	 * @param sqle
 	 * @param sql
 	 */
@@ -153,7 +153,7 @@ public final class DatabaseException extends PageExceptionImpl {
 
 	/**
 	 * Constructor of the class
-	 * 
+	 *
 	 * @param sqle
 	 */
 

--- a/core/src/main/java/lucee/runtime/exp/IllegalQoQException.java
+++ b/core/src/main/java/lucee/runtime/exp/IllegalQoQException.java
@@ -1,0 +1,44 @@
+/**
+ *
+ * Copyright (c) 2014, the Railo Company Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+package lucee.runtime.exp;
+
+/**
+ * Illegal QoQ Exception Object
+ * This subtype of DatabaseException is to signal when a QoQ cannot
+ * continue due to a fatal error and should NOT attempt to fall back to HSQLDB
+ */
+import java.sql.SQLException;
+import lucee.runtime.db.SQL;
+import lucee.runtime.db.DatasourceConnection;
+
+public final class IllegalQoQException extends DatabaseException {
+
+	public IllegalQoQException(SQLException sqle, DatasourceConnection dc) {
+		super( sqle, dc );
+	}
+
+	public IllegalQoQException(String message, String detail, SQL sql, DatasourceConnection dc) {
+		super( message, detail, sql, dc );
+	}
+
+	public IllegalQoQException(PageException e, SQL sql, DatasourceConnection dc) {
+		super( e.getMessage(), e.getDetail(), sql, dc );
+	}
+
+}

--- a/core/src/main/java/lucee/runtime/tag/util/QueryParamConverter.java
+++ b/core/src/main/java/lucee/runtime/tag/util/QueryParamConverter.java
@@ -5,17 +5,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package lucee.runtime.tag.util;
 
@@ -253,7 +253,7 @@ public class QueryParamConverter {
 		return false;
 	}
 
-	private static class NamedSQLItem extends SQLItemImpl {
+	public static class NamedSQLItem extends SQLItemImpl {
 		public final String name;
 
 		public NamedSQLItem(String name, Object value, int type, int maxlength, Charset charset) {
@@ -354,41 +354,41 @@ public class QueryParamConverter {
 	}
 
 	/*
-	 * 
+	 *
 	 * public static void main(String[] args) throws PageException { List<SQLItem> one=new
 	 * ArrayList<SQLItem>(); one.add(new SQLItemImpl("aaa",1)); one.add(new SQLItemImpl("bbb",1));
-	 * 
+	 *
 	 * List<NamedSQLItem> two=new ArrayList<NamedSQLItem>(); two.add(new
 	 * NamedSQLItem("susi","sorglos",1)); two.add(new NamedSQLItem("peter","Petrus",1));
-	 * 
+	 *
 	 * SQL sql = convert(
 	 * "select ? as x, 'aa:a' as x from test where a=:susi and b=:peter and c=? and d=:susi", one, two);
-	 * 
+	 *
 	 * print.e(sql);
-	 * 
+	 *
 	 * // array with simple values Array arr=new ArrayImpl(); arr.appendEL("aaa"); arr.appendEL("bbb");
 	 * sql = convert( "select * from test where a=? and b=?", arr); print.e(sql);
-	 * 
+	 *
 	 * // array with complex values arr=new ArrayImpl(); Struct val1=new StructImpl(); val1.set("value",
 	 * "Susi Sorglos"); Struct val2=new StructImpl(); val2.set("value", "123"); val2.set("type",
 	 * "integer"); arr.append(val1); arr.append(val2); sql = convert(
 	 * "select * from test where a=? and b=?", arr); print.e(sql);
-	 * 
+	 *
 	 * // array with mixed values arr.appendEL("ccc"); arr.appendEL("ddd"); sql = convert(
 	 * "select * from test where a=? and b=? and c=? and d=?", arr); print.e(sql);
-	 * 
+	 *
 	 * // array mixed with named values Struct val3=new StructImpl(); val3.set("value", "456");
 	 * val3.set("type", "integer"); val3.set("name", "susi"); arr.append(val3); sql = convert(
 	 * "select :susi as name from test where a=? and b=? and c=? and d=?", arr); print.e(sql);
-	 * 
-	 * 
+	 *
+	 *
 	 * // struct with simple values Struct sct=new StructImpl(); sct.set("abc", "Sorglos"); sql =
 	 * convert( "select * from test where a=:abc", sct); print.e(sql);
-	 * 
+	 *
 	 * // struct with mixed values sct.set("peter", val1); sct.set("susi", val3); sql = convert(
 	 * "select :peter as p, :susi as s from test where a=:abc", sct); print.e(sql);
-	 * 
-	 * 
+	 *
+	 *
 	 * }
 	 */
 

--- a/test/tickets/LDEV3878.cfc
+++ b/test/tickets/LDEV3878.cfc
@@ -1,0 +1,135 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" skip="false" labels="qoq" {
+	q = queryNew("id","numeric",[[1]]);
+
+	function run( testResults , testBox ) {
+		describe( title="LDEV-3878 QoQ should not fall back to HSQLDB and throw meaningful errors", body=function() {
+
+			aroundEach(function( spec, suite ){
+				try {
+					arguments.spec.body();
+				} catch( any e ) {
+					// These should not be failing back to HSQLDB
+					expect( e.getPageException().getClass().getName() )
+						.toBe( 'lucee.runtime.exp.IllegalQoQException' );
+					return;
+				}
+				fail( 'Test did not throw exception as expected' );
+			});
+
+			it(title="should throw for mod zero ", body = function( currentSpec ) {
+				queryExecute( "
+					select 1%0
+					from q
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for divide by zero ", body = function( currentSpec ) {
+				queryExecute( "
+					select 1/0
+					from q
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for too many count() columns ", body = function( currentSpec ) {
+				queryExecute( "
+					select count( id, id )
+					from q
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for too many count distinct columns ", body = function( currentSpec ) {
+				queryExecute( "
+					select count( distinct id, id )
+					from q
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for cast missing the type ", body = function( currentSpec ) {
+				queryExecute( "
+					select cast( id )
+					from q
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for Union with mismatched column counts ", body = function( currentSpec ) {
+				queryExecute( "
+					select id, ''
+					from q
+					UNION
+					select id
+					from q
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for union with invalid order by", body = function( currentSpec ) {
+				queryExecute( "
+					select id
+					from q
+					UNION
+					select id
+					from q
+					ORDER BY 'TEST'
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for invalid order by ordinal position ", body = function( currentSpec ) {
+				queryExecute( "
+					select id
+					from q
+					ORDER BY 5
+					",
+					[],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for positional param value with wrong type", body = function( currentSpec ) {
+				queryExecute( "
+					select id
+					from q
+					where id= ?
+					",
+					[
+						{type="integer", value=""}
+					],
+					{dbtype:"query"}
+				);
+			});
+
+			it(title="should throw for named param value with wrong type", body = function( currentSpec ) {
+				queryExecute("
+					select id
+					from q
+					where id= :id
+					",
+					{
+						'id': {type="integer", value=""}
+					},
+					{dbtype:"query"}
+				);
+			});
+
+		});
+	}
+}


### PR DESCRIPTION
This pull adds a new exception type `IllegalQoQException` which indicates a QoQ is illegal and needs to fail right away without attempting to fail back to HSQLDB which will obfuscate the original error.  I have added test cases for every place QoQ currently fails and we know there is no reason to try again with HSQLDB.