### PR TITLE
Added a fix to thread debug logging to entry the total time and include thread name for LDEV-4216 & LDEV-4217

### DIFF
--- a/core/src/main/cfml/context/admin/debugging.logs.list.cfm
+++ b/core/src/main/cfml/context/admin/debugging.logs.list.cfm
@@ -133,7 +133,7 @@
 								doFilterMin(session.debugFilter.app,_app) and 
 								doFilterMin(session.debugFilter.total,_total)> 
 								<tr>
-									<td><a href="#request.self#?action=#url.action#&action2=detail&id=#hash(el.id&":"&el.startTime)#">#_path#</a></td>
+									<td><a href="#request.self#?action=#url.action#&action2=detail&id=#hash(el.id&":"&el.startTime)#">#_path#</a>#structKeyExists(el, "threadName")?" (thread-#el.threadName#)":""#</td>
 									<td>#LSDateFormat(el.starttime)# #LSTimeFormat(el.starttime)#</td>
 									<td nowrap align="right"><cfif listFirst(formatUnit(_query)," ") gt 0>#formatUnit(_query)#<cfelse>-</cfif></td>
 									<td nowrap align="right">#formatUnit(_app)#</td>

--- a/core/src/main/java/lucee/runtime/PageContextImpl.java
+++ b/core/src/main/java/lucee/runtime/PageContextImpl.java
@@ -3244,6 +3244,10 @@ public final class PageContextImpl extends PageContext {
 		return endTimeNS;
 	}
 
+	public void setEndTimeNS(long endTimeNS) {
+		this.endTimeNS = endTimeNS;
+	}
+
 	@Override
 	public Thread getThread() {
 		return thread;

--- a/core/src/main/java/lucee/runtime/debug/DebuggerImpl.java
+++ b/core/src/main/java/lucee/runtime/debug/DebuggerImpl.java
@@ -114,6 +114,8 @@ public final class DebuggerImpl implements Debugger {
 
 	private long queryTime = 0;
 
+	private String threadName;
+
 	final static Comparator DEBUG_ENTRY_TEMPLATE_COMPARATOR = new DebugEntryTemplateComparator();
 	final static Comparator DEBUG_ENTRY_TEMPLATE_PART_COMPARATOR = new DebugEntryTemplatePartComparator();
 
@@ -157,6 +159,7 @@ public final class DebuggerImpl implements Debugger {
 		abort = null;
 		outputContext = null;
 		queryTime = 0;
+		threadName = null;
 	}
 
 	public DebuggerImpl() {
@@ -299,6 +302,10 @@ public final class DebuggerImpl implements Debugger {
 			this.outputContext = new ApplicationException("");
 		}
 	}
+
+	public void setThreadName(String threadName) {
+		this.threadName = threadName;
+	} 
 
 	// FUTURE add to inzerface
 	public boolean getOutput() {
@@ -762,6 +769,11 @@ public final class DebuggerImpl implements Debugger {
 			scopes.setEL(KeyConstants._cgi, pc.cgiScope());
 			debugging.setEL(KeyConstants._scope, scopes);
 		}
+
+		//////////////////////////////////////////
+		//////// THREAD NAME ////////////////////
+		//////////////////////////////////////////
+		if (threadName != null) debugging.setEL(KeyImpl.getInstance("threadName"), threadName);
 
 		HttpServletResponse rsp = pc.getHttpServletResponse();
 		debugging.setEL(KeyImpl.getInstance("statusCode"), rsp.getStatus());

--- a/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
+++ b/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
@@ -41,6 +41,7 @@ import lucee.runtime.config.ConfigPro;
 import lucee.runtime.config.ConfigWeb;
 import lucee.runtime.config.ConfigWebPro;
 import lucee.runtime.debug.DebugEntryTemplate;
+import lucee.runtime.debug.DebuggerImpl;
 import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.Abort;
 import lucee.runtime.exp.PageException;
@@ -182,8 +183,10 @@ public class ChildThreadImpl extends ChildThread implements Serializable {
 			}
 
 			ConfigImpl ci = (ConfigImpl) pc.getConfig();
-			if (!pc.isGatewayContext() && ci.debug() && ci.hasDebugOptions(ConfigPro.DEBUG_TEMPLATE)) 
-				debugEntry = pc.getDebugger().getEntry(pc, page.getPageSource());
+			if (!pc.isGatewayContext() && ci.debug()) {
+				((DebuggerImpl) pc.getDebugger()).setThreadName(tagName);
+				if (ci.hasDebugOptions(ConfigPro.DEBUG_TEMPLATE)) debugEntry = pc.getDebugger().getEntry(pc, page.getPageSource());
+			}
 
 			threadScope = pc.getCFThreadScope();
 			pc.setCurrentThreadScope(new ThreadsImpl(this));

--- a/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
+++ b/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
@@ -36,8 +36,11 @@ import lucee.runtime.PageContext;
 import lucee.runtime.PageContextImpl;
 import lucee.runtime.PageSourceImpl;
 import lucee.runtime.config.Config;
+import lucee.runtime.config.ConfigImpl;
+import lucee.runtime.config.ConfigPro;
 import lucee.runtime.config.ConfigWeb;
 import lucee.runtime.config.ConfigWebPro;
+import lucee.runtime.debug.DebugEntryTemplate;
 import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.Abort;
 import lucee.runtime.exp.PageException;
@@ -151,6 +154,8 @@ public class ChildThreadImpl extends ChildThread implements Serializable {
 		PageContext oldPc = ThreadLocalPageContext.get();
 		Page p = page;
 		PageContextImpl pc = null;
+		DebugEntryTemplate debugEntry = null;
+		long time = System.nanoTime();
 		try {
 			// daemon
 			if (this.pc != null) {
@@ -175,6 +180,10 @@ public class ChildThreadImpl extends ChildThread implements Serializable {
 				}
 				pc.addPageSource(p.getPageSource(), true);
 			}
+
+			ConfigImpl ci = (ConfigImpl) pc.getConfig();
+			if (!pc.isGatewayContext() && ci.debug() && ci.hasDebugOptions(ConfigPro.DEBUG_TEMPLATE)) 
+				debugEntry = pc.getDebugger().getEntry(pc, page.getPageSource());
 
 			threadScope = pc.getCFThreadScope();
 			pc.setCurrentThreadScope(new ThreadsImpl(this));
@@ -236,6 +245,8 @@ public class ChildThreadImpl extends ChildThread implements Serializable {
 			}
 		}
 		finally {
+			if (debugEntry != null) debugEntry.updateExeTime(System.nanoTime() - time);
+			pc.setEndTimeNS(System.nanoTime());
 			endTime = System.currentTimeMillis();
 			pc.getConfig().getFactory().releaseLuceePageContext(pc, true);
 			pc = null;


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4216
https://luceeserver.atlassian.net/browse/LDEV-4217
By this PR
- Thread total execution time will log in debugging (either with template options is true or false)
- The thread name will be included in debugging result as a key **threadName** 