### PR TITLE
Added a fix to make this.blockedextforfileupload work with the file uploads for LDEV-4237 (5.3)

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/FileTag.java
+++ b/core/src/main/java/lucee/runtime/tag/FileTag.java
@@ -1099,7 +1099,9 @@ public final class FileTag extends BodyTagImpl {
 						blocklistedTypes = SystemUtil.getSystemPropOrEnvVar(SystemUtil.SETTING_UPLOAD_EXT_BLACKLIST, SystemUtil.DEFAULT_UPLOAD_EXT_BLOCKLIST);
 					if (StringUtil.isEmpty(blocklistedTypes))
 						blocklistedTypes = SystemUtil.getSystemPropOrEnvVar(SystemUtil.SETTING_UPLOAD_EXT_BLOCKLIST, SystemUtil.DEFAULT_UPLOAD_EXT_BLOCKLIST);
-					NotResourceFilter filter = new NotResourceFilter(new ExtensionResourceFilter(blocklistedTypes));
+
+					NotResourceFilter filter = new NotResourceFilter(new ExtensionResourceFilter(ListUtil.trimItems(ListUtil.listToStringArray(blocklistedTypes, ',')), false, true, false));
+
 					if (!filter.accept(clientFile)) throw new ApplicationException("Upload of files with extension [" + ext + "] is not permitted.", DETAIL);
 				}
 			}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4237
**PR for 6.0:** https://github.com/lucee/Lucee/pull/1847