### PR TITLE
LDEV-4249 try alternate encoding for mail attachment filenames

### DIFF
--- a/core/src/main/java/lucee/runtime/net/smtp/SMTPClient.java
+++ b/core/src/main/java/lucee/runtime/net/smtp/SMTPClient.java
@@ -736,7 +736,7 @@ public final class SMTPClient implements Serializable {
 		String fileName = att.getFileName();
 		if (!StringUtil.isAscii(fileName)) {
 			try {
-				fileName = MimeUtility.encodeText(fileName, "UTF-8", null);
+				fileName = MimeUtility.encodeText(fileName, "UTF-8", "B");
 			}
 			catch (UnsupportedEncodingException e) {
 			} // that should never happen!


### PR DESCRIPTION
try the "B" encoding

https://docs.oracle.com/javaee/1.3/api/javax/mail/internet/MimeUtility.html#encodeText%28java.lang.String,%20java.lang.String,%20java.lang.String%29

https://luceeserver.atlassian.net/browse/LDEV-4249