### PR TITLE
Corrected the casting of config to configWebPro instead of configImpl for LDEV-4216 & LDEV-4217

### DIFF
--- a/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
+++ b/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
@@ -187,7 +187,6 @@ public class ChildThreadImpl extends ChildThread implements Serializable {
 				if (ci.hasDebugOptions(ConfigPro.DEBUG_TEMPLATE)) debugEntry = pc.getDebugger().getEntry(pc, page.getPageSource());
 			}
 			
-
 			threadScope = pc.getCFThreadScope();
 			pc.setCurrentThreadScope(new ThreadsImpl(this));
 			pc.setThread(Thread.currentThread());

--- a/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
+++ b/core/src/main/java/lucee/runtime/thread/ChildThreadImpl.java
@@ -36,7 +36,6 @@ import lucee.runtime.PageContext;
 import lucee.runtime.PageContextImpl;
 import lucee.runtime.PageSourceImpl;
 import lucee.runtime.config.Config;
-import lucee.runtime.config.ConfigImpl;
 import lucee.runtime.config.ConfigPro;
 import lucee.runtime.config.ConfigWeb;
 import lucee.runtime.config.ConfigWebPro;
@@ -182,14 +181,12 @@ public class ChildThreadImpl extends ChildThread implements Serializable {
 				pc.addPageSource(p.getPageSource(), true);
 			}
 
-			/*
-			backed our due to regression LDEV-4217 LDEV-4216
-			ConfigImpl ci = (ConfigImpl) pc.getConfig();
+			ConfigWebPro ci = (ConfigWebPro) pc.getConfig();
 			if (!pc.isGatewayContext() && ci.debug()) {
 				((DebuggerImpl) pc.getDebugger()).setThreadName(tagName);
 				if (ci.hasDebugOptions(ConfigPro.DEBUG_TEMPLATE)) debugEntry = pc.getDebugger().getEntry(pc, page.getPageSource());
 			}
-			*/
+			
 
 			threadScope = pc.getCFThreadScope();
 			pc.setCurrentThreadScope(new ThreadsImpl(this));

--- a/test/tickets/LDEV3689.cfc
+++ b/test/tickets/LDEV3689.cfc
@@ -28,7 +28,7 @@ component extends = "org.lucee.cfml.test.LuceeTestCase" {
 					template : "#uri#/LDEV3689.cfm",
 					forms:{Scene=1}
 				);
-				sleep(100);
+				sleep(200);
 				expect(trim(fileread(file))).tobe("$55.00");
 			});
 			it(title="Checking include page inside long running thread", skip="false", body=function( currentSpec ) {
@@ -36,7 +36,7 @@ component extends = "org.lucee.cfml.test.LuceeTestCase" {
 					template : "#uri#/LDEV3689.cfm",
 					forms:{Scene=2}
 				);
-				sleep(100);
+				sleep(200);
 				expect(trim(fileread(file))).tobe("Page included");
 			});
 			it(title="Checking custom tag inside long running thread with Application", body=function( currentSpec ) { 
@@ -44,7 +44,7 @@ component extends = "org.lucee.cfml.test.LuceeTestCase" {
 					template : "#uri#/withApp/LDEV3689.cfm",
 					forms:{Scene=1}
 				);
-				sleep(100);
+				sleep(200);
 				expect(trim(fileread(file2))).tobe("$55.00");
 			});
 			it(title="Checking include page inside long running thread with Application", body=function( currentSpec ) {
@@ -52,7 +52,7 @@ component extends = "org.lucee.cfml.test.LuceeTestCase" {
 					template : "#uri#/withApp/LDEV3689.cfm",
 					forms:{Scene=2}
 				);
-				sleep(100);
+				sleep(200);
 				expect(trim(fileread(file2))).tobe("Page included");
 			});
 		});


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4216
https://luceeserver.atlassian.net/browse/LDEV-4217

After merging the previous fix PR, Some of the thread-related tests failed due to that pc.getConfig in Single context mode not being a type of configImpl
So this PR will fix this issue