### PR TITLE
Added a fix to graph.cfm throw 404 for invalid query string LDEV-4260 (5.3)

### DIFF
--- a/core/src/main/cfml/context/graph.cfm
+++ b/core/src/main/cfml/context/graph.cfm
@@ -1,4 +1,4 @@
-<cfif structKeyExists(url,"img") && structKeyExists(url,"type")>
+<cfif structKeyExists(url,"img") && structKeyExists(url,"type") && fileExists("#GetTempDirectory()#/graph/#listLast(url.img,'/\#server.separator.file#')#")>
 	<cfcontent file="#GetTempDirectory()#/graph/#listLast(url.img,'/\#server.separator.file#')#" type="image/#url.type#"><cfsetting showdebugoutput="no">
 <cfelse>
 	<cfheader statuscode="404" statustext="Invalid Access">

--- a/core/src/main/java/resource/context/graph.cfm
+++ b/core/src/main/java/resource/context/graph.cfm
@@ -1,4 +1,4 @@
-<cfif structKeyExists(url,"img") && structKeyExists(url,"type")>
+<cfif structKeyExists(url,"img") && structKeyExists(url,"type") && fileExists("#GetTempDirectory()#/graph/#listLast(url.img,'/\#server.separator.file#')#")>
 	<cfcontent file="#GetTempDirectory()#/graph/#listLast(url.img,'/\#server.separator.file#')#" type="image/#url.type#"><cfsetting showdebugoutput="no">
 <cfelse>
 	<cfheader statuscode="404" statustext="Invalid Access">


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4260 
**PR for 6.0:** https://github.com/lucee/Lucee/pull/1867