### PR TITLE
Fixing a minor formatting issue.

### DIFF
--- a/core/src/main/java/lucee/runtime/interpreter/CFMLExpressionInterpreter.java
+++ b/core/src/main/java/lucee/runtime/interpreter/CFMLExpressionInterpreter.java
@@ -1017,7 +1017,7 @@ public class CFMLExpressionInterpreter {
 				str = "... " + str.substring(pos - 10, pos + 10) + " ...";
 			}
 		}
-		throw new InterpreterException("Syntax Error, Invalid Construct", "at position " + (pos + 1) + " in [" + str + "]");
+		throw new InterpreterException("Syntax Error, Invalid Construct", " at position " + (pos + 1) + " in [" + str + "]");
 	}
 
 	protected Ref json(FunctionLibFunction flf, char start, char end) throws PageException {


### PR DESCRIPTION
This is currently rendering like so: "Syntax Error, Invalid Constructat position 47 in..."  -- it needed an extra space before the word "at". (Same problem exists in Lucee 5.)