### PR TITLE
Update server.regional.cfm

### DIFF
--- a/core/src/main/cfml/context/admin/resources/language/ch-be.xml
+++ b/core/src/main/cfml/context/admin/resources/language/ch-be.xml
@@ -842,7 +842,7 @@ When checked, any requested files will be inspected only once for potential upda
 	<data key="overview.infomail">info@lucee.ch</data>
 	<data key="overview.introdesc.web">Lucee, die CFML engine. Schnell, preiswert und einfach zu bedienen. Mit Lucee haben sie sich für den performanten und qualitativ hochwertigen Weg von CFML entschieden. Passen Sie Ihren Webkontext nach Ihren Bedürfnissen und Wünschen an. Dafür steht Ihnen hier der Web Administrator zur Verfügung.</data>
 	<data key="overview.introdesc.server">Der Server Administrator ermöglicht Ihnen Updates und Patches für Ihre Lucee Edition vorzunehmen und die Engine per Mauklick neu zu starten. Zusätzlich können Sie in der Develop und Enterprise Edition die einzelnen Webkontexte vorkonfigurieren und diverse Beschränkungen und Konfigurationen individuell pro Webkontext einrichten.</data>
-	<data key="overview.servertime">Server Datum/Zeit: </data>
+	<data key="overview.servertime">Server Datum/Zeit (JVM): </data>
 	<data key="overview.version">Version</data>
 	<data key="overview.info">Info</data>
 	<data key="overview.featurerequest">Feature Anfragen</data>

--- a/core/src/main/cfml/context/admin/resources/language/de.xml
+++ b/core/src/main/cfml/context/admin/resources/language/de.xml
@@ -1204,7 +1204,7 @@ When checked, any requested files will be inspected only once for potential upda
 	<data key="overview.infomail">info@lucee.org</data>
 	<data key="overview.introdesc.web">Lucee, die CFML engine. Schnell, preiswert und einfach zu bedienen. Mit Lucee haben sie sich für den performanten und qualitativ hochwertigen Weg von CFML entschieden. Passen Sie Ihren Webkontext nach Ihren Bedürfnissen und Wünschen an. Dafür steht Ihnen hier der Web Administrator zur Verfügung.</data>
 	<data key="overview.introdesc.server">Der Server Administrator ermöglicht Ihnen Updates und Patches für Ihre Lucee Edition vorzunehmen und die Engine per Mauklick neu zu starten. Zusätzlich können Sie in der Develop und Enterprise Edition die einzelnen Webkontexte vorkonfigurieren und diverse Beschränkungen und Konfigurationen individuell pro Webkontext einrichten.</data>
-	<data key="overview.servertime">Server Datum/Zeit: </data>
+	<data key="overview.servertime">Server Datum/Zeit (JVM): </data>
 	<data key="overview.version">Version</data>
 	<data key="overview.Label">Label</data>
 	<data key="overview.Hash">Hash</data>

--- a/core/src/main/cfml/context/admin/resources/language/en.xml
+++ b/core/src/main/cfml/context/admin/resources/language/en.xml
@@ -1362,7 +1362,7 @@ If the timezone of your Lucee instance and your database is different, this can 
 	<data key="overview.introdesc.web">Lucee, the CFML engine - free, open source and easy to use. This Web Administrator is provided in order to customize your web context.</data>
 	<data key="overview.introdesc.server">The Server Administrator allows you to install updates and patches for your Lucee installation and to restart the engine with a mouse click. You can configure new web contexts and define restrictions and configurations per web context individual.</data>
 	<data key="overview.infomail">info@lucee.ch</data>
-	<data key="overview.servertime">Server date/time: </data>
+	<data key="overview.servertime">Server date/time (JVM): </data>
 	<data key="overview.version">Version</data>
 	<data key="overview.Label">Label</data>
 	<data key="overview.Hash">Hash</data>

--- a/core/src/main/cfml/context/admin/resources/language/nl.xml
+++ b/core/src/main/cfml/context/admin/resources/language/nl.xml
@@ -745,7 +745,7 @@ Wanneer aangevinkt zal elk opgevraagd bestand slechts eenmaal in een request voo
 	<data key="overview.introdesc.web">
 Lucee, de CFML engine - gratis, open source en gemakkelijk in gebruik. Deze Web Administrator wordt verstrekt zodat je jouw web context naar wens kunt aanpassen.</data>
 	<data key="overview.introdesc.server">De Server Administrator stelt je in staat om met één klik van de muis updates en patches voor jouw Lucee installatie te installeren en de engine te herstarten. Je kunt nieuwe web contexts alvast configureren en restricties en configuraties individueel per web context definiëren.</data>
-	<data key="overview.servertime">Server datum/tijd: </data>
+	<data key="overview.servertime">Server datum/tijd (JVM): </data>
 	<data key="overview.version">Versie</data>
 	<data key="overview.info">Info</data>
 	<data key="overview.featurerequest">Functionaliteit verzoek</data>

--- a/core/src/main/cfml/context/admin/server.regional.cfm
+++ b/core/src/main/cfml/context/admin/server.regional.cfm
@@ -230,7 +230,7 @@ Create Datasource --->
 		<table class="maintbl" style="width:500px">
 			<tbody>
 				<tr>
-					<th scope="row" nowrap="nowrap">#stText.Overview.ServerTime#</th>
+					<th scope="row" nowrap="nowrap">#stText.Overview.ServerTime# (JVM)</th>
 					<td>#lsdateFormat(date:now(),timezone:"jvm")#
 						#lstimeFormat(time:now(),timezone:"jvm")# (#jvmTZ.isDSTon ? jvmTZ.nameDST : jvmTZ.name#)
 					</td>

--- a/core/src/main/cfml/context/admin/server.regional.cfm
+++ b/core/src/main/cfml/context/admin/server.regional.cfm
@@ -230,7 +230,7 @@ Create Datasource --->
 		<table class="maintbl" style="width:500px">
 			<tbody>
 				<tr>
-					<th scope="row" nowrap="nowrap">#stText.Overview.ServerTime# (JVM)</th>
+					<th scope="row" nowrap="nowrap">#stText.Overview.ServerTime#</th>
 					<td>#lsdateFormat(date:now(),timezone:"jvm")#
 						#lstimeFormat(time:now(),timezone:"jvm")# (#jvmTZ.isDSTon ? jvmTZ.nameDST : jvmTZ.name#)
 					</td>


### PR DESCRIPTION
Add information that  "server date/time" is the JVM time and not related to the server-context timezone setting. 
See this thread: https://dev.lucee.org/t/server-admin-is-showing-a-contexts-date-time-why/11775/7