### PR TITLE
LDEV-4358 fix resource leak opening db connections

### DIFF
--- a/core/src/main/java/lucee/runtime/db/DCStack.java
+++ b/core/src/main/java/lucee/runtime/db/DCStack.java
@@ -214,11 +214,9 @@ class DCStack {
 
 	private Boolean isValidEL(Connection conn) {
 		try {
-			// value is in ms but method expect s
-			int ms = datasource.getNetworkTimeout();
-			int s = DEFAULT_TIMEOUT;
-			if (ms > 0) s = (int) Math.ceil(ms / 1000);
-
+			int s = datasource.getNetworkTimeout();
+			//if timeout is unreasonable, use default
+			if (s < 1 || s > 60) s = DEFAULT_TIMEOUT;	
 			return conn.isValid(s) ? Boolean.TRUE : Boolean.FALSE;
 		}
 		catch (Exception e) {

--- a/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
+++ b/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
@@ -110,18 +110,17 @@ public class DatasourceConnectionPool {
 						break;
 					}
 				}
-
-				_inc(stack, datasource, user, pass); // if new or fine we increase in any case
-				// create a new instance
+				if (rtn != null) {
+					_inc(stack, datasource, user, pass); // increment now if using existing connection
+				}				
 			}
 			if (rtn == null) {
+				// create a new connection instance
 				try {
 					rtn = loadDatasourceConnection(config, (DataSourcePro) datasource, user, pass);
+					_inc(stack, datasource, user, pass); // increment only if creating connection succeeds 
 				}
 				catch (PageException pe) {
-					synchronized (stack) {
-						_dec(stack, datasource, user, pass);
-					}
 					throw pe;
 				}
 				if (rtn instanceof DatasourceConnectionPro) ((DatasourceConnectionPro) rtn).using();


### PR DESCRIPTION
When getDatasourceConnection() decides to create a new connection, it first calls _inc() to increment the connection count. If loadDatasourceConnection() throws a page error, _dec() is called. But if the thread is killed by a timeout _dec() never gets called and so we lose a connection slot. If enough connection slots are lost lucee will not be able to recover when the db comes back.

This changes getDatasourceConnection() so that it only calls _inc() after the connection is successfully opened. This is not a perfect solution since it could allow the ConnectionLimit to be temporarily exceeded.


Also DCStack.isValidEL was doing an incorrect conversion from miliseconds to seconds, that ended up using a timeout of zero.    DataSourceSupport.NETWORK_TIMEOUT_IN_SECONDS  is set at 10,   so a conversion is not needed.   


See https://dev.lucee.org/t/resource-leak-in-datasourceconnectionpool-5-3-10/11853

https://luceeserver.atlassian.net/browse/LDEV-4358