### PR TITLE
Pull hardcoded text to lang resource files, fix translations

### DIFF
--- a/core/src/main/cfml/context/admin/resources/language/de.xml
+++ b/core/src/main/cfml/context/admin/resources/language/de.xml
@@ -681,38 +681,78 @@ Diese werden dann am Ende eines Request ausgegeben, falls sie ein Debug Template
   
 	<data key="general.enabled">Enabled</data>
 
-	<data key="compiler.nullSupport">Null Support</data>
+
+    <!-- *** server.compiler.cfm/partially in overview.cfm *** -->
+
+
+    <!-- template charset -->
+    <!-- uses key=charset.templatecharset, 
+         and key=charset.templateCharsetDescription-->
+	
+	<!-- Externalize strings -->
+	<data key="setting.externalizeStringGTE">Zeichenketten externalisieren</data>
+	<data key="setting.externalizeStringGTEDesc">Externalsiere Zeichenketten aus generierten Klassen-Dateien in gesonderte Dateien. Dies kann den Template-Speicherbedarf erheblich reduzieren, aber eine negative Auswirkung auf die Ausführungszeit haben. Ein geringerer "Breakpoint" wird eine langsamere Ausführungszeit benötigen als ein höherer Breakpoint.</data>
+	<data key="setting.externalizeString_1">keine Zeichenketten externalisieren</data>
+	<data key="setting.externalizeString10">externalisiere Zeichenketten mit mehr als 10 Zeichen</data>
+	<data key="setting.externalizeString100">externalisiere Zeichenketten mit mehr als 100 Zeichen</data>
+	<data key="setting.externalizeString1000">externalisiere Zeichenketten mit mehr als 1000 Zeichen</data>
+	<data key="setting.externalizeStringDisabled">deaktiviert</data>
+
+
+    <!-- Null Support -->
+    <data key="compiler.nullSupport">Null Support</data>
 	<data key="compiler.nullSupportOnlyServer">Diese Einstellung ist nur im Lucee Server Administrator möglich.</data>
 	<data key="compiler.nullSupportDesc">Definiert wie Lucee null unterstützt.</data>
 	<data key="compiler.nullSupportFull">Volle Unterstützung</data>
 	<data key="compiler.nullSupportFullDesc">Lucee hat volle Unterstützung für "null", dies beinhaltet "null" Literale. Im Lucee Wiki finden Sie mehr Details dazu.</data>
-	<data key="compiler.nullSupportPartial">Partial Support (CFML Default)</data>
-	<data key="compiler.nullSupportPartialDesc">Lucee has only a partial null support.</data>
+	<data key="compiler.nullSupportPartial">Partieller Support (CFML Standard)</data>
+	<data key="compiler.nullSupportPartialDesc">Lucee unterstützt null nur teilweise</data>
 
-
-	<data key="setting.compiler">Lucee Regular Expression (regex) Einstellungen.</data>
-	<data key="setting.compiler">Lucee Compiler Einstellungen, dies beeinflusst wie der Lucee Compiler den Source Code übersetzt. Das ändern dieser Einstellungen löscht alle existierenden Class Files.</data>
-	<data key="setting.dotNotation">Key case</data>
-
-
+  
+    <!-- Key Case -->
+    <data key="setting.dotNotation">Key case</data>
 	<data key="setting.dotNotationUpperCaseDesc">Konvertiert Struct Keys definiert mit "Dot Notation" als grossgeschrieben (CFML Standard).
-Beispiel:
-sct.dotNotation --> keyname: "DOTNOTATION"
-sct[""bracketNotation""] --> keyname: "bracketNotation"</data>
+        &lt;br&gt;
+        Beispiel:&lt;br&gt;
+        sct.dotNotation --&amp;gt; keyname: "DOTNOTATION"&lt;br&gt;
+        sct["bracketNotation"] --&gt; keyname: "bracketNotation"</data>
 
-<data key="setting.dotNotationOriginalCaseDesc">Belässt Struct Keys definiert mit "Dot Notation" wie sie sind (wie "Bracked Notation").
-
-Beispiel:
-sct.dotNotation --> keyname: "dotNotation"
-sct[""bracketNotation""] --> keyname: "bracketNotation"</data>
-
-
-	<data key="setting.dotNotationUpperCase">Übersetzt zu grossgeschrieben (CFML Standard)</data>
+        <data key="setting.dotNotationOriginalCaseDesc">Belässt Struct Keys definiert mit "Dot Notation" wie sie sind (wie "Bracked Notation").
+        &lt;br&gt;
+        Beispiel:&lt;br&gt;
+        sct.dotNotation --&amp;gt; keyname: "dotNotation"&lt;br&gt;
+        sct["bracketNotation"] --&amp;gt; keyname: "bracketNotation"</data>
+    <data key="setting.dotNotationUpperCase">Übersetzt zu grossgeschrieben (CFML Standard)</data>
 	<data key="setting.dotNotationOriginalCase">Behält die Keys wie sie sind (wie "Bracked Notation")</data>
-	<data key="setting.suppressWSBeforeArg">Unterdrückt White-Space vor cfargument</data>
+	
+    
+
+    <!-- precise math -->
+    <data key="setting.preciseMath">Präzise Mathematik</data>
+    <data key="setting.preciseMathDesc">Bei Aktivierung wird die Genauigkeit von Fließkommaberechnungen verbessert, macht sie aber auch etwas langsamer.</data>
+	
+	 <!-- WhiteSpace Management -->
+    <data key="setting.suppressWSBeforeArg">Unterdrückt White-Space vor cfargument</data>
 	<data key="setting.suppressWSBeforeArgDesc">Wenn gesetzt, unterdrückt Lucee White-Spaces definiert zwischen dem "cffunction" Starttag und dem letzten "cfargument" Tag.
 	Dieses Setting wird ignoriert wenn es zwischen den Tags ein andere Ausgabe als White-Spaces hat.</data>
-	<data key="setting.templatecache">Page Pool Cache</data>
+	
+
+    <!-- Handle unquoted Tag attribute values -->
+    <data key="setting.handleUnquotedAttrValueAsString">Tag-Attributwerte</data>
+    <data key="setting.handleUnquotedAttrValueAsStringDesc">Behandle Tag-Attributwerte, die nicht in Anführungszeichen gesetzt sind, als Zeichenketten.
+        &lt;br&gt;
+        Beispiel:&lt;br&gt;
+        &amp;lt;cfmail subject=sub from="#f#" to="#t#"/&amp;gt;&lt;br&gt;
+        Der Tag-Attributwert "subject" steht nicht in Anführungzeichen. 
+        Bei Aktivierung wird die Zeichenkette "sub" dem Tag übertragen.
+        Falls deaktiviert wird Lucee nach der Variablen "sub" suchen.</data>
+
+
+    
+    <data key="setting.compiler">Lucee Regular Expression (regex) Einstellungen.</data>
+	<data key="setting.compiler">Lucee Compiler Einstellungen, dies beeinflusst wie der Lucee Compiler den Source Code übersetzt. Das ändern dieser Einstellungen löscht alle existierenden Class Files.</data>
+	
+    <data key="setting.templatecache">Page Pool Cache</data>
 	<data key="setting.querycache">Query Cache</data>
 	<data key="setting.objectcache">Object Cache</data>
 	<data key="setting.web">Kontrolle der Ausgabe von Lucee</data>

--- a/core/src/main/cfml/context/admin/resources/language/en.xml
+++ b/core/src/main/cfml/context/admin/resources/language/en.xml
@@ -905,39 +905,69 @@ you can see the log result at the end of every request, if a debug template is d
 	<data key="Scopes.cgiReadOnlyFalse">Writable</data>
 	<data key="Scopes.cgiReadOnlyFalseDesc">The CGI Scope can be changed like other scopes.</data>
 
+   
+    <!-- *** server.compiler.cfm/partially in overview.cfm *** -->
+
+    <!-- template charset -->
+    <!-- uses key=charset.templatecharset, 
+         and key=charset.templateCharsetDescription-->
+	
+	<!-- Externalize strings -->
+	<data key="setting.externalizeStringGTE">Externalize strings</data>
+	<data key="setting.externalizeStringGTEDesc">Externalize strings from generated class files to separate files. This can drastically reduce the memory footprint for templates but can have a negative impact on execution times. A lower "breakpoint" will cause slower execution than a higher breakpoint.</data>
+	<data key="setting.externalizeString_1">do not externalize any strings</data>
+	<data key="setting.externalizeString10">externalize strings larger than 10 characters</data>
+	<data key="setting.externalizeString100">externalize strings larger than 100 characters</data>
+	<data key="setting.externalizeString1000">externalize strings larger than 1000 characters</data>
+	<data key="setting.externalizeStringDisabled">disabled</data>
 
 
-	<data key="compiler.nullSupport">Null Support</data>
+    <!-- Null Support -->
+    <data key="compiler.nullSupport">Null Support</data>
 	<data key="compiler.nullSupportOnlyServer">This setting is only possible in the Lucee Server Administrator.</data>
-	<data key="compiler.nullSupportDesc">Definiert wie Lucee null unterstützt.</data>
+	<data key="compiler.nullSupportDesc">Defines how Lucee supports null.</data>
 	<data key="compiler.nullSupportFull">Complete Support</data>
 	<data key="compiler.nullSupportFullDesc">Lucee has a complete support for null, including "null" literal. Find more details in the Lucee Wiki.</data>
 	<data key="compiler.nullSupportPartial">Partial Support (CFML Default)</data>
 	<data key="compiler.nullSupportPartialDesc">Lucee has only a partial null support.</data>
 
-	<data key="setting.regex">Lucee regular expression (regex) settings.</data>
-	<data key="setting.compiler">Lucee compiler settings, this affects how the Lucee Compiler parses the source code. Changing this settings flushes all existing class files and triggers a recompilation.</data>
-	<data key="setting.dotNotation">Key case</data>
-	<!-- server.compiler.cfm -->
-	<data key="setting.handleUnquotedAttrValueAsString">Tag attribute values</data>
-
+    <!-- Key Case -->
+    <data key="setting.dotNotation">Key case</data>
 	<data key="setting.dotNotationUpperCaseDesc">Convert all struct keys defined with "dot notation" to upper case.
-Example:
-sct.dotNotation --> keyname: "DOTNOTATION"
-sct[""bracketNotation""] --> keyname: "bracketNotation"</data>
-
-<data key="setting.dotNotationOriginalCaseDesc">Keep all struct keys defined with "dot notation" in original case (according to the "bracket notation").
-Example:
-sct.dotNotation --> keyname: "dotNotation"
-sct[""bracketNotation""] --> keyname: "bracketNotation"</data>
-
-	<data key="setting.dotNotationUpperCase">Convert to upper case (CFML Default)</data>
+    &lt;br&gt;Example:&lt;br&gt;
+    sct.dotNotation --&amp;gt; keyname: "DOTNOTATION"&lt;br&gt;
+    sct["bracketNotation"] --&amp;gt; keyname: "bracketNotation"</data>
+    <data key="setting.dotNotationOriginalCaseDesc">Keep all struct keys defined with "dot notation" in original case (according to the "bracket notation").
+    &lt;br&gt;Example: &lt;br&gt;
+    sct.dotNotation --&amp;gt; keyname: "dotNotation" &lt;br&gt;
+    sct["bracketNotation"] --&amp;gt; keyname: "bracketNotation" &lt;br&gt;</data>
+    <data key="setting.dotNotationUpperCase">Convert to upper case (CFML Default)</data>
 	<data key="setting.dotNotationOriginalCase">Preserve case</data>
 
+    
+    <!-- precise math -->
+    <data key="setting.preciseMath">Precise Math</data>
+    <data key="setting.preciseMathDesc">If enabled this improves the accuracy of floating point calculations, but makes them slightly slower.</data>
+	
+    
+    <!-- WhiteSpace Management -->
 	<data key="setting.suppressWSBeforeArg">Suppress whitespace before cfargument</data>
-
-	<data key="setting.suppressWSBeforeArgDesc">If set, Lucee suppresses whitespace defined between the "cffunction" starting tag  and the last "cfargument" tag.
+    <data key="setting.suppressWSBeforeArgDesc">If set, Lucee suppresses whitespace defined between the "cffunction" starting tag  and the last "cfargument" tag.
 	This setting is ignored when there is a different output between this tags as white space.</data>
+	
+
+    <!-- Handle unquoted Tag attribute values -->
+    <data key="setting.handleUnquotedAttrValueAsString">Tag attribute values</data>
+    <data key="setting.handleUnquotedAttrValueAsStringDesc">Handle unquoted tag attribute values as strings.
+        &lt;br&gt;
+        Example:&lt;br&gt;
+        &amp;lt;cfmail subject=sub from="#f#" to="#t#"/&amp;gt;&lt;br&gt;
+        The value from attribute "subject" is not quoted. If enabled the string "sub" is submitted to the tag. If disabled Lucee looks for a variable "sub".</data>
+
+
+
+	<data key="setting.regex">Lucee regular expression (regex) settings.</data>
+	<data key="setting.compiler">Lucee compiler settings, this affects how the Lucee Compiler parses the source code. Changing this settings flushes all existing class files and triggers a recompilation.</data>
 	<data key="setting.templatecache">Page Pool Cache</data>
 	<data key="setting.querycache">Query Cache</data>
 	<data key="setting.objectcache">Object Cache</data>

--- a/core/src/main/cfml/context/admin/server.compiler.cfm
+++ b/core/src/main/cfml/context/admin/server.compiler.cfm
@@ -16,11 +16,6 @@ Defaults --->
 <cfparam name="form.mainAction" default="none">
 <cfparam name="form.subAction" default="none">
 
-<cfset stText.setting.handleUnquotedAttrValueAsStringDesc='Handle unquoted tag attribute values as strings.
-<br>Example:<br>
-&lt;cfmail subject=sub from="##f##" to="##t##"/><br>
-<br>The value from attribute "subject" is not quoted, in that case if enabled the string "sub" submitted to the tag, if not enabled Lucee looks for a variable "sub".'>
-
 <cftry>
 	<cfswitch expression="#form.mainAction#">
 	<!--- UPDATE --->
@@ -135,14 +130,6 @@ Redirtect to entry --->
 				</tr>
 
 				<!--- Externalize Strings --->
-				<cfset stText.settings.externalizeStringGTE="Externalize strings">
-				<cfset stText.settings.externalizeStringGTEDesc="Externalize strings from generated class files to separate files. This can drastically reduce the memory footprint for templates but can have a negative impact on execution times. A lower ""breakpoint"" will cause slower execution than a higher breakpoint.">
-
-				<cfset stText.settings.externalizeString_1="do not externalize any strings">
-				<cfset stText.settings.externalizeString10="externalize strings larger than 10 characters">
-				<cfset stText.settings.externalizeString100="externalize strings larger than 100 characters">
-				<cfset stText.settings.externalizeString1000="externalize strings larger than 1000 characters">
-				<cfset stText.settings.externalizeStringDisabled="disabled">
 				<cfscript>
 					if(setting.externalizeStringGTE < 10)setting.externalizeStringGTE=-1;
 					else if(setting.externalizeStringGTE < 100)setting.externalizeStringGTE=10;
@@ -151,7 +138,7 @@ Redirtect to entry --->
 				</cfscript>
 				
 				<tr>
-					<th scope="row">#stText.settings.externalizeStringGTE#</th>
+					<th scope="row">#stText.setting.externalizeStringGTE#</th>
 					<td>
 						<!---<div class="warning nofocus">
 					This feature is experimental.
@@ -170,7 +157,7 @@ Redirtect to entry --->
 									<li>
 										<label>
 											<input class="radio" type="radio" name="externalizeStringGTE" value="#val#"<cfif setting.externalizeStringGTE == val> checked="checked"</cfif>>
-											<b>#stText.settings["externalizeString"&replace(val,"-","_")]#</b>
+											<b>#stText.setting["externalizeString"&replace(val,"-","_")]#</b>
 										</label>
 									</li>
 								</cfloop>
@@ -179,9 +166,9 @@ Redirtect to entry --->
 							</ul>
 						<cfelse>
 							<input type="hidden" name="externalizeStringGTE" value="#setting.externalizeStringGTE#">
-							<b><cfif setting.externalizeStringGTE==-1>#yesNoFormat(false)#<cfelse>#stText.settings["externalizeString"&replace(setting.externalizeStringGTE,"-","_")]#</cfif></b>
+							<b><cfif setting.externalizeStringGTE==-1>#yesNoFormat(false)#<cfelse>#stText.setting["externalizeString"&replace(setting.externalizeStringGTE,"-","_")]#</cfif></b>
 						</cfif>
-						<div class="comment">#stText.settings.externalizeStringGTEDesc#</div>
+						<div class="comment">#stText.setting.externalizeStringGTEDesc#</div>
 						
 					</td>
 				</tr>
@@ -268,8 +255,6 @@ Redirtect to entry --->
 				</tr>
 				
 				<!--- precise math --->
-				<cfset stText.setting.preciseMath="Precise Math">
-				<cfset stText.setting.preciseMathDesc="If enabled this improves the accuracy of floating point calculations, but makes them sligthly slower.">
 				<tr>
 					<th scope="row">#stText.setting.preciseMath#</th>
 					<td>


### PR DESCRIPTION
This PR moves hardcoded text variables from server.compile.cfm to the language resource files en.xml and de.xml, and adds translations to german. Also, fixed german content that was wrongly set in the en.xml. 