### PR TITLE
LDEV-4295 throw meaning exception when datasource config is empty

### DIFF
--- a/core/src/main/java/lucee/runtime/listener/AppListenerUtil.java
+++ b/core/src/main/java/lucee/runtime/listener/AppListenerUtil.java
@@ -196,6 +196,7 @@ public final class AppListenerUtil {
 	}
 
 	public static DataSource toDataSource(Config config, String name, Struct data, Log log) throws PageException {
+		if (data.isEmpty()) throw new ApplicationException("Datasource config for [" + name + "] was empty");
 		String user = Caster.toString(data.get(KeyConstants._username, null), null);
 		String pass = Caster.toString(data.get(KeyConstants._password, ""), "");
 		if (StringUtil.isEmpty(user)) {

--- a/test/tickets/LDEV4295.cfc
+++ b/test/tickets/LDEV4295.cfc
@@ -1,0 +1,18 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" {
+
+	function run( testResults , testBox ) {
+		describe( "Test suite for LDEV4295", function() {
+
+			it( title='when a datasource config struct is empty, throw a meaningful exception', body=function( currentSpec ) {
+				try {
+					var ds = {};
+					application action="update" datasource="#ds#";
+				} catch (e) {
+					expect(e.message).toInclude("was empty");
+				}
+			});
+
+		});
+	}
+
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4295