### PR TITLE
LDEV-4198 timezone issue with dateformat iso

### DIFF
--- a/core/src/main/java/lucee/runtime/format/DateFormat.java
+++ b/core/src/main/java/lucee/runtime/format/DateFormat.java
@@ -82,6 +82,7 @@ public final class DateFormat extends BaseFormat implements Format {
 			else if (lcMask.equals("full")) return getAsString(calendar, java.text.DateFormat.FULL, tz);
 			else if ("iso8601".equals(lcMask) || "iso".equals(lcMask)) {
 				SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+				formatter.setTimeZone(tz);
 				return formatter.format(calendar.getTime());
 			}
 


### PR DESCRIPTION
Depending on your local timezone you could get an incorrect date when using the dateformat 'iso' mask.

https://luceeserver.atlassian.net/browse/LDEV-4198