### PR TITLE
experiment, targeting java 11 (don't merge) with 5.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       LUCEE_BUILD_JAVA_VERSION:
         required: true
         type: string
-        default: '8'
+        default: '11'
   push:
     branches:
       - '**' # thus ignoring tagging
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DO_DEPLOY: "${{ github.event_name == 'push' && github.ref == 'refs/heads/5.4' }}"
-      LUCEE_BUILD_JAVA_VERSION: 8
+      LUCEE_BUILD_JAVA_VERSION: 11
       LUCEE_TEST_JAVA_VERSION: ''
     services:
       sql-server:

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -651,8 +651,6 @@
     <!-- compie the source -->
     <javac 
       srcdir="${srcInst}" 
-      source="1.8"
-      target="1.8"
       destdir="${temp}/agent"
       debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
     </javac>
@@ -671,8 +669,6 @@
     <!-- compie the source -->
     <javac 
       srcdir="${srcLoader}" 
-      source="1.8" 
-      target="1.8" 
       destdir="${temp}/loader"
       debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
     </javac>
@@ -707,8 +703,6 @@
     <!-- compile the core -->
     <javac 
       srcdir="${srcCore}" 
-      source="1.8" 
-      target="1.8" 
       destdir="${core}"
       debug="true" debuglevel="lines,vars,source">
        <classpath refid="classpath" />

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -651,8 +651,8 @@
     <!-- compie the source -->
     <javac 
       srcdir="${srcInst}" 
-      source="1.8" 
-      target="1.8" 
+      source="1.8"
+      target="1.8"
       destdir="${temp}/agent"
       debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
     </javac>


### PR DESCRIPTION
Lucee currently still supports java 8, let's try targeting java 11 and see how the build performs

first run only has whitespace changes
second run targets and tests with 11