### PR TITLE
experiment, targeting java 11 (don't merge) with 6.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       LUCEE_BUILD_JAVA_VERSION:
         required: true
         type: string
-        default: '8'
+        default: '11'
   push:
     branches:
       - '**' # thus ignoring tagging
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DO_DEPLOY: "${{ github.event_name == 'push' && github.ref == 'refs/heads/6.0' }}"
-      LUCEE_BUILD_JAVA_VERSION: 8
+      LUCEE_BUILD_JAVA_VERSION: 11
       LUCEE_TEST_JAVA_VERSION: ''
     services:
       ldap:

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -313,8 +313,8 @@
     <!-- compie the source -->
     <javac 
       srcdir="${srcInst}" 
-      source="1.8" 
-      target="1.8" 
+      source="1.8"
+      target="1.8"
       destdir="${temp}/agent"
       debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
     </javac>

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -312,9 +312,7 @@
     
     <!-- compie the source -->
     <javac 
-      srcdir="${srcInst}" 
-      source="1.8"
-      target="1.8"
+      srcdir="${srcInst}"
       destdir="${temp}/agent"
       debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
     </javac>
@@ -332,9 +330,7 @@
     <echots message="compile loader"/>
     <!-- compie the source -->
     <javac 
-      srcdir="${srcLoader}" 
-      source="1.8" 
-      target="1.8" 
+      srcdir="${srcLoader}"
       destdir="${temp}/loader"
       debug="true" debuglevel="lines,vars,source" classpath="${dependencies}">
     </javac>
@@ -364,9 +360,7 @@
    <echo level="info" message="Using Java version ${ant.java.version}."/>
     <!-- compile the core -->
     <javac 
-      srcdir="${srcCore}" 
-      source="1.8" 
-      target="1.8" 
+      srcdir="${srcCore}"
       destdir="${core}"
       debug="true" debuglevel="lines,vars,source">
        <classpath refid="classpath" />


### PR DESCRIPTION
Lucee currently still supports java 8, let's try targeting java 11 and see how the build performs

first run only has whitespace changes with target 1.8
second run targets and tests with target 11

Related, same tests with 5.4 https://github.com/lucee/Lucee/pull/2316