### PR TITLE
LDEV-3906 allow web admin to function when file access mode is set to local

### DIFF
--- a/core/src/main/cfml/context/admin/admin_layout.cfm
+++ b/core/src/main/cfml/context/admin/admin_layout.cfm
@@ -67,7 +67,7 @@
 					<td id="<cfif !hasNavigation>logintd<cfelse>contenttd</cfif>" class="lotd">
 						<div id="content">
 							 <div id="maintitle">
-								<cfif hasNavigation>
+								<cfif hasNavigation && application.adminfunctions.canAccessContext()>
 									<div id="logouts">
 									<a class="sprite tooltipMe logout" href="#request.self#?action=logout" title="Logout"></a>
 									</div>

--- a/core/src/main/cfml/context/admin/adminfunctions.cfc
+++ b/core/src/main/cfml/context/admin/adminfunctions.cfc
@@ -45,10 +45,26 @@
 		<cfset setdata('favorites', data) />
 	</cffunction>
 	
+	<cffunction name="canAccessContext" returntype="boolean">
+		<cfif !StructKeyExists(session,"password"&request.adminType)>
+			<cfreturn false>
+		</cfif>
+		<cfset var smAction=(request.adminType != "web") ? "getDefaultSecurityManager" : "getSecurityManager">
+		<cfadmin 
+			action="#smAction#"
+			type="#request.adminType#"
+			password="#session["password"&request.adminType]#"
+			returnVariable="local.access">
+		<cfreturn (access.file eq "all")>
+	</cffunction>
 	
 	<cffunction name="getdata" returntype="any" output="no">
 		<cfargument name="key" type="string" required="yes" />
 		<cfargument name="defaultvalue" type="any" required="no" default="" />
+		<cfif !canAccessContext()>
+			<!-- file systen access is restricted -->
+			<cfreturn arguments.defaultvalue />
+		</cfif>
 		<cfset var data = loadData() />
 		<cfif structKeyExists(data, arguments.key)>
 			<cfreturn data[arguments.key] />

--- a/core/src/main/cfml/context/admin/adminfunctions.cfc
+++ b/core/src/main/cfml/context/admin/adminfunctions.cfc
@@ -49,13 +49,7 @@
 		<cfif !StructKeyExists(session,"password"&request.adminType)>
 			<cfreturn false>
 		</cfif>
-		<cfset var smAction=(request.adminType != "web") ? "getDefaultSecurityManager" : "getSecurityManager">
-		<cfadmin 
-			action="#smAction#"
-			type="#request.adminType#"
-			password="#session["password"&request.adminType]#"
-			returnVariable="local.access">
-		<cfreturn (access.file eq "all")>
+		<cfreturn getApplicationSettings().security.file>
 	</cffunction>
 	
 	<cffunction name="getdata" returntype="any" output="no">

--- a/core/src/main/cfml/context/admin/web.cfm
+++ b/core/src/main/cfml/context/admin/web.cfm
@@ -234,7 +234,9 @@
 <cfset navigation = stText.MenuStruct[request.adminType]>
 
 <cfset plugins = []>
-<cfif structKeyExists(session, "password" & request.adminType)>
+<!--- plugins aren't accessible when file access is restricted to local --->
+<cfif structKeyExists(session, "password" & request.adminType) 
+		and application.adminfunctions.canAccessContext()>
 	<cftry>
 	<cfadmin action="getPluginDirectory"
 		type="#request.adminType#"

--- a/core/src/main/java/lucee/runtime/config/ConfigWebFactory.java
+++ b/core/src/main/java/lucee/runtime/config/ConfigWebFactory.java
@@ -1251,6 +1251,8 @@ public final class ConfigWebFactory extends ConfigFactory {
 				log(config, log, t);
 			}
 		}
+		// temp directory should be always accessible, even when access is local
+		reses.add(config.getTempDirectory());
 		return reses.toArray(new Resource[reses.size()]);
 	}
 

--- a/core/src/main/java/lucee/runtime/functions/system/GetApplicationSettings.java
+++ b/core/src/main/java/lucee/runtime/functions/system/GetApplicationSettings.java
@@ -59,6 +59,8 @@ import lucee.runtime.net.proxy.ProxyData;
 import lucee.runtime.net.s3.Properties;
 import lucee.runtime.op.Caster;
 import lucee.runtime.orm.ORMConfiguration;
+import lucee.runtime.security.SecurityManager;
+import lucee.runtime.security.SecurityManagerImpl;
 import lucee.runtime.tag.listener.TagListener;
 import lucee.runtime.type.Array;
 import lucee.runtime.type.ArrayImpl;
@@ -417,6 +419,15 @@ public class GetApplicationSettings extends BIF {
 				}
 			}
 		}
+		
+		StructImpl secSct = new StructImpl(Struct.TYPE_LINKED);
+		SecurityManager sm = pc.getConfig().getSecurityManager();
+		short access = sm.getAccess(SecurityManager.TYPE_FILE);
+		boolean hasAccess = access == SecurityManager.VALUE_YES;
+		secSct.set(KeyConstants._file, hasAccess);
+		sct.put("security", secSct);
+		// TODO re-use of_fillSecData()_from admin.java / move to sm?
+
 		return sct;
 	}
 


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3906

this PR 
- adds security.file to getApplicationSettings()
- disables local file access to userdata in the admin when file access is local
- adds the context temp directory to allowed directories when file access is set to local for web contexts as the web context way not be under the webroot (for security reasons)