### PR TITLE
LDEV-3947 http resource exists() stricter status code checks  v3

### DIFF
--- a/core/src/main/java/lucee/commons/io/res/type/http/HTTPResource.java
+++ b/core/src/main/java/lucee/commons/io/res/type/http/HTTPResource.java
@@ -92,7 +92,7 @@ public class HTTPResource extends ReadOnlyResourceSupport {
 		try {
 			provider.read(this);
 			int code = getStatusCode();// getHttpMethod().getStatusCode();
-			return code != 404;
+			return code >= 200 && code <= 299;
 		}
 		catch (Exception e) {
 			return false;
@@ -126,7 +126,11 @@ public class HTTPResource extends ReadOnlyResourceSupport {
 			throw ExceptionUtil.toIOException(e);
 		}
 		try {
-			return IOUtil.toBufferedInputStream(method.getContentAsStream());
+			int code = method.getStatusCode();
+			if (code >= 200 && code <= 299) return IOUtil.toBufferedInputStream(method.getContentAsStream());
+			else {
+				throw new IOException("HTTP request [" + getParentResource().toString() + " returned [" + code + "]");
+			}
 		}
 		finally {
 			HTTPEngine.closeEL(method);

--- a/test/tickets/LDEV3947.cfc
+++ b/test/tickets/LDEV3947.cfc
@@ -1,0 +1,50 @@
+component extends = "org.lucee.cfml.test.LuceeTestCase" labels="http" {
+
+	// requires LDEV-4861 to support rest httpmethod="get,head" and on update provider
+	// as the exists check does a HEAD request
+	variables.endpoint = "https://update.lucee.org/rest/update/provider/echoGet?";
+	
+	function run( testresults , testbox ) {
+		describe( "testcase for LDEV-3947, http resource provider should error with non 20x status codes", function () {
+			it( title="Check reading an http resource",body = function ( currentSpec ) {
+				expect( fileRead("#variables.endpoint#") ).notToBeEmpty();
+			});
+
+			it( title="Check reading an http resource with 200 status code",body = function ( currentSpec ) {
+				expect( fileRead("#variables.endpoint#&statusCode=200") ).notToBeEmpty();
+			});
+			
+			it( title="Check reading an http resource with 401 status code",body = function ( currentSpec ) {
+				expect(function(){
+					fileRead("#variables.endpoint#&statusCode=401");
+				}).toThrow();
+			});
+			
+			it( title="Check reading an http resource with 403 status code",body = function ( currentSpec ) {
+				expect(function(){
+					fileRead("#variables.endpoint#&statusCode=403");
+				}).toThrow();
+			});
+
+			it( title="Check reading an http resource with 404 status code",body = function ( currentSpec ) {
+				expect(function(){
+					fileRead("#variables.endpoint#&statusCode=404");
+				}).toThrow();
+			});
+			
+			it( title="Check reading an http resource with 500 status code",body = function ( currentSpec ) {
+				expect(function(){
+					fileRead("#variables.endpoint#&statusCode=500");
+				}).toThrow();
+			});
+
+			it( title="Check reading an http resource with 503 status code",body = function ( currentSpec ) {
+				expect(function(){
+					fileRead("#variables.endpoint#&statusCode=503");
+				}).toThrow();
+			});
+
+		});
+	}
+
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3947

needs https://luceeserver.atlassian.net/browse/LDEV-4861 and https://github.com/lucee/Lucee/pull/2371 for test to pass