### PR TITLE
Related to https://luceeserver.atlassian.net/browse/LDEV-5099 - Issue with REReplace()

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/string/REReplace.java
+++ b/core/src/main/java/lucee/runtime/functions/string/REReplace.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 /**
  * Implements the CFML Function rereplace
@@ -23,7 +23,6 @@ package lucee.runtime.functions.string;
 
 import lucee.runtime.PageContext;
 import lucee.runtime.PageContextImpl;
-import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.FunctionException;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.ext.function.BIF;
@@ -34,18 +33,13 @@ public final class REReplace extends BIF {
 
 	private static final long serialVersionUID = -1140669656936340678L;
 
-	public static String call(String string, String regExp, String replace) throws PageException { // MUST is this really needed?
-		Regex regex = ((PageContextImpl) ThreadLocalPageContext.get()).getRegex();
-		return regex.replace(string, regExp, replace, true, false);
-	}
-
 	public static String call(PageContext pc, String string, String regExp, String replace) throws PageException {
 		Regex regex = ((PageContextImpl) pc).getRegex();
 		return regex.replace(string, regExp, replace, true, false);
 	}
 
 	public static String call(PageContext pc, String string, String regExp, String replace, String scope) throws PageException {
-		Regex regex = ((PageContextImpl) ThreadLocalPageContext.get()).getRegex();
+		Regex regex = ((PageContextImpl) pc).getRegex();
 		if (scope.equalsIgnoreCase("all")) return regex.replaceAll(string, regExp, replace, true, false);
 		return regex.replace(string, regExp, replace, true, false);
 	}

--- a/core/src/main/java/lucee/runtime/functions/string/REReplaceNoCase.java
+++ b/core/src/main/java/lucee/runtime/functions/string/REReplaceNoCase.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 /**
  * Implements the CFML Function rereplacenocase
@@ -23,7 +23,6 @@ package lucee.runtime.functions.string;
 
 import lucee.runtime.PageContext;
 import lucee.runtime.PageContextImpl;
-import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.FunctionException;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.ext.function.BIF;
@@ -36,12 +35,12 @@ public final class REReplaceNoCase extends BIF implements Function {
 	private static final long serialVersionUID = 3261493342788819694L;
 
 	public static String call(PageContext pc, String string, String regExp, String replace) throws PageException {
-		Regex regex = ((PageContextImpl) ThreadLocalPageContext.get()).getRegex();
+		Regex regex = ((PageContextImpl) pc).getRegex();
 		return regex.replace(string, regExp, replace, false, false);
 	}
 
 	public static String call(PageContext pc, String string, String regExp, String replace, String scope) throws PageException {
-		Regex regex = ((PageContextImpl) ThreadLocalPageContext.get()).getRegex();
+		Regex regex = ((PageContextImpl) pc).getRegex();
 		if (scope.equalsIgnoreCase("all")) return regex.replaceAll(string, regExp, replace, false, false);
 		return regex.replace(string, regExp, replace, false, false);
 	}


### PR DESCRIPTION
	modified:   core/src/main/java/lucee/runtime/functions/string/REReplace.java
	modified:   core/src/main/java/lucee/runtime/functions/string/REReplaceNoCase.java

removed use of ThreadLocalPageContext.get() and replace with passed in pc note: PageContext pc was already being passed but not used.

This fixes a null pointer issue I was having locally.