### PR TITLE
LDEV-5094 onmissingfunction

### DIFF
--- a/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
+++ b/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package lucee.runtime.type.util;
 
@@ -750,6 +750,7 @@ public class KeyConstants {
 	public static final Key __toArray = KeyImpl._const("_toArray");
 	public static final Key __toQuery = KeyImpl._const("_toQuery");
 	public static final Key _onmissingmethod = KeyImpl._const("onmissingmethod");
+	public static final Key _onmissingfunction = KeyImpl._const("onmissingfunction");
 	public static final Key _functions = KeyImpl._const("functions");
 	public static final Key _fullname = KeyImpl._const("fullname");
 	public static final Key _skeleton = KeyImpl._const("skeleton");

--- a/test/tickets/LDEV5094.cfc
+++ b/test/tickets/LDEV5094.cfc
@@ -1,0 +1,34 @@
+component extends="org.lucee.cfml.test.LuceeTestCase"{
+	function run( testResults , testBox ) {
+		describe( title="LDEV-5094 onMissingFunction feature", body=function() {
+			it( title='should trigger onMissingFunction in Application.cfc when a nonexistent function is called with positional arguments',body=function( currentSpec ) {
+				var uri = createURI("LDEV5094");
+				local.result = _InternalRequest(
+					template:"#uri#/testPositionalArgs.cfm"
+				);
+				expect(local.result.filecontent.trim()).toBe('Function name: someTestFunction. Arguments: ["arg1",true]');
+			});
+
+			it( title='should trigger onMissingFunction in Application.cfc when a nonexistent function is called with named arguments',body=function( currentSpec ) {
+				var uri = createURI("LDEV5094");
+				local.result = _InternalRequest(
+					template:"#uri#/testNamedArgs.cfm"
+				);
+				expect(local.result.filecontent.trim()).toBe('Function name: anotherTestFunction. Arguments: {"test":true}');
+			});
+
+			it( title='should have lucee throw the usual missing function error when Application.cfc does not implement onMissingFunction',body=function( currentSpec ) {
+				var uri = createURI("LDEV5094/notimplemented");
+				local.result = _InternalRequest(
+					template:"#uri#/test.cfm"
+				);
+				expect(local.result.filecontent.trim()).toContain('No matching function [myMissingFunction] found');
+			});
+		});
+	}
+
+	private string function createURI(string calledName){
+		var baseURI="/test/#listLast(getDirectoryFromPath(getCurrenttemplatepath()),"\/")#/";
+		return baseURI&""&calledName;
+	}
+}

--- a/test/tickets/LDEV5094.cfc
+++ b/test/tickets/LDEV5094.cfc
@@ -6,7 +6,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				local.result = _InternalRequest(
 					template:"#uri#/testPositionalArgs.cfm"
 				);
-				expect(local.result.filecontent.trim()).toBe('[Function name: SOMETESTFUNCTION. Arguments: {"1":"arg1","2":true}]');
+				expect(local.result.filecontent.trim()).toBe('Function name: SOMETESTFUNCTION. Arguments: {"1":"arg1","2":true}');
 			});
 
 			it( title='should trigger onMissingFunction in Application.cfc when a nonexistent function is called with named arguments',body=function( currentSpec ) {

--- a/test/tickets/LDEV5094.cfc
+++ b/test/tickets/LDEV5094.cfc
@@ -6,7 +6,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				local.result = _InternalRequest(
 					template:"#uri#/testPositionalArgs.cfm"
 				);
-				expect(local.result.filecontent.trim()).toBe('Function name: someTestFunction. Arguments: ["arg1",true]');
+				expect(local.result.filecontent.trim()).toBe('[Function name: SOMETESTFUNCTION. Arguments: {"1":"arg1","2":true}]');
 			});
 
 			it( title='should trigger onMissingFunction in Application.cfc when a nonexistent function is called with named arguments',body=function( currentSpec ) {
@@ -14,7 +14,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				local.result = _InternalRequest(
 					template:"#uri#/testNamedArgs.cfm"
 				);
-				expect(local.result.filecontent.trim()).toBe('Function name: anotherTestFunction. Arguments: {"test":true}');
+				expect(local.result.filecontent.trim()).toBe('Function name: ANOTHERTESTFUNCTION. Arguments: {"test":true}');
 			});
 
 			it( title='should have lucee throw the usual missing function error when Application.cfc does not implement onMissingFunction',body=function( currentSpec ) {
@@ -22,7 +22,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				local.result = _InternalRequest(
 					template:"#uri#/test.cfm"
 				);
-				expect(local.result.filecontent.trim()).toContain('No matching function [myMissingFunction] found');
+				expect(local.result.filecontent.trim()).toBe('No matching function [myMissingFunction] found');
 			});
 		});
 	}

--- a/test/tickets/LDEV5094/Application.cfc
+++ b/test/tickets/LDEV5094/Application.cfc
@@ -1,0 +1,11 @@
+component {
+	this.name="LDEV5094";
+
+	public function onRequestStart() {
+		setting requesttimeout=10;
+	}
+
+	public function onMissingFunction( functionName, functionArguments ){
+		return "Function name: #arguments.functionName#. Arguments: #SerializeJson( arguments.functionArguments )#";
+	}
+}

--- a/test/tickets/LDEV5094/notimplemented/Application.cfc
+++ b/test/tickets/LDEV5094/notimplemented/Application.cfc
@@ -1,0 +1,8 @@
+component {
+	this.name="LDEV5094";
+
+	public function onRequestStart() {
+		setting requesttimeout=10;
+	}
+
+}

--- a/test/tickets/LDEV5094/notimplemented/test.cfm
+++ b/test/tickets/LDEV5094/notimplemented/test.cfm
@@ -1,0 +1,7 @@
+<cfscript>
+	try {
+		myMissingFunction( "test" );
+	} catch( any e ) {
+		echo( e.message );
+	}
+</cfscript>

--- a/test/tickets/LDEV5094/testNamedArgs.cfm
+++ b/test/tickets/LDEV5094/testNamedArgs.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#anotherTestFunction( test=true )#</cfoutput>

--- a/test/tickets/LDEV5094/testPositionalArgs.cfm
+++ b/test/tickets/LDEV5094/testPositionalArgs.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#someTestFunction( "arg1", true )#</cfoutput>


### PR DESCRIPTION
As per: https://luceeserver.atlassian.net/browse/LDEV-5094, this PR adds the ability for application developers to provide their own dynamic UDFs through an `Application.cfc$onMissingFunction()` lifecycle method. They may also choose to use this for other purposes, of course.