### PR TITLE
Allow dots in datasource names again

### DIFF
--- a/core/src/main/java/lucee/runtime/tag/Admin.java
+++ b/core/src/main/java/lucee/runtime/tag/Admin.java
@@ -2639,7 +2639,7 @@ public final class Admin extends TagImpl implements DynamicAttributes {
 		}
 
 		String tmp = getString("admin", action, "newName");
-		Pattern pattern = Pattern.compile("[a-zA-Z0-9_-]*");
+		Pattern pattern = Pattern.compile("[.a-zA-Z0-9_-]*");
 		Matcher matcher = pattern.matcher(tmp);
 
 		if (matcher.matches() == false) {


### PR DESCRIPTION
Adobe CFML and Lucee 5.x allowed this, and I'm not aware of any issues it would cause.