### PR TITLE
try fast bigDecimal parser via jackson-core (experiment)

### DIFF
--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -402,7 +402,6 @@
       includeantruntime="false"
       debug="true" 
       debuglevel="lines,vars,source">
-       <compilerarg arg="-XX:CompileCommand=inline,java/lang/String.charAt"/>
        <classpath refid="classpath" />
        <classpath path="${temp}/loader"/>
     </javac>

--- a/ant/build-core.xml
+++ b/ant/build-core.xml
@@ -402,6 +402,7 @@
       includeantruntime="false"
       debug="true" 
       debuglevel="lines,vars,source">
+       <compilerarg arg="-XX:CompileCommand=inline,java/lang/String.charAt"/>
        <classpath refid="classpath" />
        <classpath path="${temp}/loader"/>
     </javac>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -385,6 +385,11 @@
 <version>10.0.0</version>
 <scope>provided</scope>
 </dependency>
+<dependency>
+  <groupId>com.fasterxml.jackson.core</groupId>
+  <artifactId>jackson-core</artifactId>
+  <version>2.18.1</version>
+</dependency>
   </dependencies>
 
   <repositories>

--- a/core/src/main/java/META-INF/MANIFEST.MF
+++ b/core/src/main/java/META-INF/MANIFEST.MF
@@ -360,7 +360,8 @@ Require-Bundle: org.apache.commons.commons-codec;bundle-version=1.15.0,
  org.lucee.commonmark;bundle-version=0.22.0,
  com.github.f4b6a3.ulid;bundle-version=5.2.3,
  org.lucee.janino;bundle-version=3.1.9,
- org.lucee.janinocc;bundle-version=3.1.9
+ org.lucee.janinocc;bundle-version=3.1.9,
+ com.fasterxml.jackson.core.jackson-core;bundle-version=2.18.1
 Require-Extension: 7E673D15-D87C-41A6-8B5F1956528C605F;name=MySQL;label=MySQL;version=9.0.0,
  99A4EF8D-F2FD-40C8-8FB8C2E67A4EEEB6;name=MSSQL;label=MS SQL Server;version=12.6.3.jre11,
  671B01B8-B3B3-42B9-AC055A356BED5281;name=PostgreSQL;label=PostgreSQL;version=42.7.3,

--- a/core/src/main/java/META-INF/osgi-maven-mapping.ini
+++ b/core/src/main/java/META-INF/osgi-maven-mapping.ini
@@ -1432,3 +1432,7 @@ artifactId=argon2-jvm-nolibs
 [org.lucee.commonmark]
 groupId=org.lucee
 artifactId=commonmark
+
+[com.fasterxml.jackson.core.jackson-core]
+groupId=com.fasterxml.jackson.core
+artifactId=jackson-core

--- a/core/src/main/java/lucee/runtime/op/Caster.java
+++ b/core/src/main/java/lucee/runtime/op/Caster.java
@@ -161,6 +161,7 @@ public final class Caster {
 	}
 	// static Map calendarsMap=new ReferenceMap(ReferenceMap.SOFT,ReferenceMap.SOFT);
 
+	private static final boolean USE_FAST_PARSER = true;
 	private static final int NUMBERS_MIN = 0;
 	private static final int NUMBERS_MAX = 999;
 	private static final String[] NUMBERS = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23",
@@ -564,7 +565,7 @@ public final class Caster {
 			else if (curr > '9') {
 				if (curr == 'e' || curr == 'E') {
 					try {
-						return Double.parseDouble(str);
+						return NumberInput.parseDouble(str, USE_FAST_PARSER);
 					}
 					catch (NumberFormatException e) {
 						if (!alsoFromDate) throw new CasterException("cannot cast [" + str + "] string to a number value");
@@ -584,7 +585,7 @@ public final class Caster {
 				rtn += toDigit(curr);
 				if (hasDot) {
 					deep *= 10;
-					if (deep > 1000000000000000000000D) return Double.parseDouble(str); // patch for LDEV-2654
+					if (deep > 1000000000000000000000D) return NumberInput.parseDouble(str, USE_FAST_PARSER); // patch for LDEV-2654
 				}
 
 			}
@@ -703,7 +704,7 @@ public final class Caster {
 			else if (curr > '9') {
 				if (curr == 'e' || curr == 'E') {
 					try {
-						return Double.parseDouble(str);
+						return NumberInput.parseDouble(str, USE_FAST_PARSER);
 					}
 					catch (NumberFormatException e) {
 						if (!alsoFromDate) return defaultValue;
@@ -1580,7 +1581,7 @@ public final class Caster {
 		else if (o instanceof CharSequence) {
 			String str = o.toString();
 			try {
-				return Long.parseLong(str);
+				return NumberInput.parseLong(str);
 			}
 			catch (NumberFormatException nfe) {
 				return (long) toDoubleValue(str);
@@ -1603,7 +1604,7 @@ public final class Caster {
 	public static long toLongValue(String str) throws PageException {
 		BigInteger bi = null;
 		try {
-			bi = new BigInteger(str);
+			bi = NumberInput.parseBigInteger(str, USE_FAST_PARSER);
 
 		}
 		catch (Throwable t) {
@@ -1631,7 +1632,7 @@ public final class Caster {
 				return Caster.toBigDecimal(str);
 			}
 			// integer
-			BigInteger bi = new BigInteger(str);
+			BigInteger bi = NumberInput.parseBigInteger(str, USE_FAST_PARSER);
 			int l = bi.bitLength();
 			if (l < 32) return Integer.valueOf(bi.intValue());
 			if (l < 64) return Long.valueOf(bi.longValue());

--- a/core/src/main/java/lucee/runtime/op/Caster.java
+++ b/core/src/main/java/lucee/runtime/op/Caster.java
@@ -151,6 +151,8 @@ import lucee.runtime.type.wrap.MapAsStruct;
 import lucee.runtime.type.wrap.StructAsArray;
 import lucee.runtime.util.ForEachUtil;
 
+import com.fasterxml.jackson.core.io.NumberInput;
+
 /**
  * This class can cast object of one type to another by CFML rules
  */
@@ -5130,7 +5132,8 @@ public final class Caster {
 
 	public static BigDecimal toBigDecimal(String str) throws CasterException {
 		try {
-			return new BigDecimal(str.trim(), MathContext.DECIMAL128);
+			//return new BigDecimal(str.trim(), MathContext.DECIMAL128);
+			return NumberInput.parseBigDecimal(str.trim(), true);
 		}
 		catch (NumberFormatException nfe) {
 			if (Util.isEmpty(str, true)) throw new CasterException("cannot convert string[" + str + "] to a number, the string is empty");

--- a/core/src/main/java/lucee/runtime/op/Caster.java
+++ b/core/src/main/java/lucee/runtime/op/Caster.java
@@ -161,7 +161,7 @@ public final class Caster {
 	}
 	// static Map calendarsMap=new ReferenceMap(ReferenceMap.SOFT,ReferenceMap.SOFT);
 
-	private static final boolean USE_FAST_PARSER = false;
+	private static final boolean USE_FAST_PARSER = true;
 	private static final int NUMBERS_MIN = 0;
 	private static final int NUMBERS_MAX = 999;
 	private static final String[] NUMBERS = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23",

--- a/core/src/main/java/lucee/runtime/op/Caster.java
+++ b/core/src/main/java/lucee/runtime/op/Caster.java
@@ -161,7 +161,7 @@ public final class Caster {
 	}
 	// static Map calendarsMap=new ReferenceMap(ReferenceMap.SOFT,ReferenceMap.SOFT);
 
-	private static final boolean USE_FAST_PARSER = true;
+	private static final boolean USE_FAST_PARSER = false;
 	private static final int NUMBERS_MIN = 0;
 	private static final int NUMBERS_MAX = 999;
 	private static final String[] NUMBERS = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23",

--- a/core/src/main/java/lucee/runtime/op/Decision.java
+++ b/core/src/main/java/lucee/runtime/op/Decision.java
@@ -75,12 +75,15 @@ import lucee.runtime.type.Struct;
 import lucee.runtime.type.UDF;
 import lucee.runtime.type.dt.DateTime;
 
+import com.fasterxml.jackson.core.io.NumberInput;
+
 /**
  * Object to test if an Object is a specific type
  */
 public final class Decision {
 
 	private static final String STRING_DEFAULT_VALUE = "this is a unique string";
+	private static final boolean USE_FAST_PARSER = true;
 
 	private static Pattern ssnPattern;
 	private static Pattern phonePattern;
@@ -210,7 +213,7 @@ public final class Decision {
 		}
 		if (hasExp) {
 			try {
-				if (Double.isInfinite(Double.parseDouble(str))) return false;
+				if (Double.isInfinite(NumberInput.parseDouble(str, USE_FAST_PARSER))) return false;
 
 				return true;
 			}

--- a/core/src/main/java/lucee/runtime/op/Decision.java
+++ b/core/src/main/java/lucee/runtime/op/Decision.java
@@ -83,7 +83,7 @@ import com.fasterxml.jackson.core.io.NumberInput;
 public final class Decision {
 
 	private static final String STRING_DEFAULT_VALUE = "this is a unique string";
-	private static final boolean USE_FAST_PARSER = true;
+	private static final boolean USE_FAST_PARSER = false;
 
 	private static Pattern ssnPattern;
 	private static Pattern phonePattern;

--- a/core/src/main/java/lucee/runtime/op/Decision.java
+++ b/core/src/main/java/lucee/runtime/op/Decision.java
@@ -83,7 +83,7 @@ import com.fasterxml.jackson.core.io.NumberInput;
 public final class Decision {
 
 	private static final String STRING_DEFAULT_VALUE = "this is a unique string";
-	private static final boolean USE_FAST_PARSER = false;
+	private static final boolean USE_FAST_PARSER = true;
 
 	private static Pattern ssnPattern;
 	private static Pattern phonePattern;

--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -691,6 +691,11 @@
 <version>10.0.0</version>
 <scope>provided</scope>
 </dependency>
+<dependency>
+  <groupId>com.fasterxml.jackson.core</groupId>
+  <artifactId>jackson-core</artifactId>
+  <version>2.18.1</version>
+</dependency>
 </dependencies>
 
   <repositories>

--- a/loader/src/main/java/lucee/loader/engine/BundleProvider.java
+++ b/loader/src/main/java/lucee/loader/engine/BundleProvider.java
@@ -444,6 +444,7 @@ public final class BundleProvider {
 		put(mappings, "com.sun.xml.bind.jaxb-impl", new Info("org.glassfish.jaxb", "jaxb-runtime"));
 		put(mappings, "org.lucee.commonmark", new Info("org.lucee", "commonmark"));
 		put(mappings, "org.lucee.argon2-jvm-nolibs", new Info("org.lucee", "argon2-jvm-nolibs"));
+		put(mappings, "com.fasterxml.jackson.core.jackson-core", new Info("com.fasterxml.jackson.core", "jackson-core"));
 	}
 
 	private static void put(Map<String, Info[]> mappings, String name, Info... value) {


### PR DESCRIPTION
Just wanted to try the fasterDouble Parser out as per https://luceeserver.atlassian.net/browse/LDEV-3524

https://github.com/wrandelshofer/FastDoubleParser

That lib doesn't include OSGI metadata, but jackson-core does, so I thought I'd try it out

Usual process for adding a new java library to Lucee
- add to core and loader `pom.xml` files
- add to the core `MANIFEST.mf` file
- I also tried adding an entry to the `osgi-maven-mapping.ini` and the BundleProvider (but that's in the loader)

Then I imported the class into caster and swapped out the default method

Dropping the `.lco` into the deploy folder throws the following error

```
deploy.log ERROR 11:25:05, 31 Oct, 2024Thread-3222
"java.lang.NoSuchMethodException:No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.;java.lang.NoSuchMethodException:No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.;java.lang.NoSuchMethodException:No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.;No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.;lucee.runtime.exp.NativeException: java.lang.NoSuchMethodException:No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.
at lucee.commons.lang.ExceptionUtil.toIOException(ExceptionUtil.java:215)
at lucee.commons.lang.ExceptionUtil.toIOException(ExceptionUtil.java:213)
at lucee.transformer.dynamic.meta.dynamic.MethodDynamic.invoke(MethodDynamic.java:27)
at lucee.runtime.config.ConfigAdmin.restart(ConfigAdmin.java:3870)
at lucee.runtime.config.ConfigAdmin.updateCore(ConfigAdmin.java:4547)
at lucee.runtime.config.DeployHandler.deploy(DeployHandler.java:101)
at lucee.runtime.engine.Controler.control(Controler.java:209)
at lucee.runtime.engine.Controler$ControlerThread.run(Controler.java:118)
Caused by: java.io.IOException: java.lang.NoSuchMethodException:No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.
... 8 more
Caused by: java.lang.NoSuchMethodException: No matching method for lucee.loader.engine.CFMLEngineFactory._restart() found. there are no methods with this name.
at lucee.transformer.dynamic.meta.Clazz.getMethodMatch(Clazz.java:271)
at lucee.transformer.dynamic.DynamicInvoker.createInstance(DynamicInvoker.java:158)
at lucee.runtime.reflection.pairs.MethodInstance.getResult(MethodInstance.java:119)
at lucee.runtime.reflection.pairs.MethodInstance.invoke(MethodInstance.java:64)
at lucee.transformer.dynamic.meta.dynamic.MethodDynamic.invoke(MethodDynamic.java:24)
... 5 more
"
deploy.log INFO 11:25:05, 31 Oct, 2024Thread-3222
"Installing Lucee [6.2.0.144-SNAPSHOT] (previous version was [6.2.0.142-SNAPSHOT] )"
```

Which is probably due to Lucee not being able to dynamically download the new dependency, which I confirmed as stopping Tomcat and instead using the fat jar compiles off this branch, which works fine? 

I was using the 6.0.3.1 loader, also tried the 6.2.0.142 loader, same problem.

Did I miss a step?

I think previously we got a better exception / more logging prior to the move to maven?