### PR TITLE
LDEV-3349 fix url encoding when a plus sign is present

### DIFF
--- a/core/src/main/java/lucee/commons/net/HTTPUtil.java
+++ b/core/src/main/java/lucee/commons/net/HTTPUtil.java
@@ -368,7 +368,7 @@ public final class HTTPUtil {
 	}
 
 	public static String escapeQSValue(String str, boolean encodeOnlyWhenNecessary) {
-		if (encodeOnlyWhenNecessary && !ReqRspUtil.needEncoding(str, false)) return str;
+		if (encodeOnlyWhenNecessary && !ReqRspUtil.needEncoding(str)) return str;
 		PageContextImpl pc = (PageContextImpl) ThreadLocalPageContext.get();
 		if (pc != null) {
 			try {

--- a/core/src/main/java/lucee/commons/net/http/httpclient/HTTPEngine4Impl.java
+++ b/core/src/main/java/lucee/commons/net/http/httpclient/HTTPEngine4Impl.java
@@ -505,8 +505,8 @@ public class HTTPEngine4Impl {
 	}
 
 	public static void addCookie(CookieStore cookieStore, String domain, String name, String value, String path, String charset) {
-		if (ReqRspUtil.needEncoding(name, false)) name = ReqRspUtil.encode(name, charset);
-		if (ReqRspUtil.needEncoding(value, false)) value = ReqRspUtil.encode(value, charset);
+		if (ReqRspUtil.needEncoding(name)) name = ReqRspUtil.encode(name, charset);
+		if (ReqRspUtil.needEncoding(value)) value = ReqRspUtil.encode(value, charset);
 		BasicClientCookie cookie = new BasicClientCookie(name, value);
 		if (!StringUtil.isEmpty(domain, true)) cookie.setDomain(domain);
 		if (!StringUtil.isEmpty(path, true)) cookie.setPath(path);

--- a/core/src/main/java/lucee/runtime/functions/other/URLEncode.java
+++ b/core/src/main/java/lucee/runtime/functions/other/URLEncode.java
@@ -45,7 +45,7 @@ public class URLEncode {
 
 	public static String invoke(String str, String encoding, boolean force) throws PageException {
 
-		if (!force && !ReqRspUtil.needEncoding(str, false)) return str;
+		if (!force && !ReqRspUtil.needEncoding(str)) return str;
 
 		try {
 

--- a/core/src/main/java/lucee/runtime/functions/other/URLEncodedFormat.java
+++ b/core/src/main/java/lucee/runtime/functions/other/URLEncodedFormat.java
@@ -49,7 +49,7 @@ public final class URLEncodedFormat implements Function {
 	}
 
 	public static String invoke(String str, String encoding, boolean force) throws PageException {
-		if (!force && !ReqRspUtil.needEncoding(str, false)) return str;
+		if (!force && !ReqRspUtil.needEncoding(str)) return str;
 
 		try {
 			String enc = lucee.commons.net.URLEncoder.encode(str, encoding);

--- a/core/src/main/java/lucee/runtime/functions/system/InternalRequest.java
+++ b/core/src/main/java/lucee/runtime/functions/system/InternalRequest.java
@@ -344,7 +344,7 @@ public class InternalRequest implements Function {
 
 	private static String urlenc(String str, Charset charset) throws PageException {
 		try {
-			if (!ReqRspUtil.needEncoding(str, false)) return str;
+			if (!ReqRspUtil.needEncoding(str)) return str;
 			return URLEncoder.encode(str, charset);
 		}
 		catch (UnsupportedEncodingException uee) {

--- a/core/src/main/java/lucee/runtime/net/http/HttpUtil.java
+++ b/core/src/main/java/lucee/runtime/net/http/HttpUtil.java
@@ -87,7 +87,7 @@ public class HttpUtil {
 		while (e.hasMoreElements()) {
 			name = (String) e.nextElement();
 			values = req instanceof HTTPServletRequestWrap ? ((HTTPServletRequestWrap) req).getParameterValues(pc, name) : req.getParameterValues(name);
-			if (values == null && ReqRspUtil.needEncoding(name, false)) values = req.getParameterValues(ReqRspUtil.encode(name, ReqRspUtil.getCharacterEncoding(null, req)));
+			if (values == null && ReqRspUtil.needEncoding(name)) values = req.getParameterValues(ReqRspUtil.encode(name, ReqRspUtil.getCharacterEncoding(null, req)));
 			if (values == null) {
 				if (pc != null && ReqRspUtil.identical(pc.getHttpServletRequest(), req)) {
 					values = HTTPServletRequestWrap.getParameterValues(pc, name);

--- a/core/src/main/java/lucee/runtime/net/http/ReqRspUtil.java
+++ b/core/src/main/java/lucee/runtime/net/http/ReqRspUtil.java
@@ -48,6 +48,7 @@ import org.xml.sax.InputSource;
 
 import lucee.commons.io.CharsetUtil;
 import lucee.commons.io.IOUtil;
+import lucee.commons.io.SystemUtil;
 import lucee.commons.lang.ExceptionUtil;
 import lucee.commons.lang.Pair;
 import lucee.commons.lang.StringUtil;
@@ -73,6 +74,12 @@ import lucee.runtime.type.UDF;
 import lucee.runtime.type.util.CollectionUtil;
 
 public final class ReqRspUtil {
+
+	private static boolean urlEncodeAllowPlus;
+
+	static {
+		urlEncodeAllowPlus = Caster.toBooleanValue(SystemUtil.getSystemPropOrEnvVar("lucee.url.encodeAllowPlus", "true"), true);
+	}
 
 	private static Map<String, String> rootPathes = new ReferenceMap<String, String>(HARD, SOFT);
 
@@ -290,6 +297,10 @@ public final class ReqRspUtil {
 		catch (UnsupportedEncodingException e) {
 			return str;
 		}
+	}
+
+	public static boolean needEncoding(String str) {
+		return needEncoding(str, urlEncodeAllowPlus);
 	}
 
 	public static boolean needEncoding(String str, boolean allowPlus) {

--- a/core/src/main/java/lucee/runtime/tag/Http.java
+++ b/core/src/main/java/lucee/runtime/tag/Http.java
@@ -1627,7 +1627,7 @@ public final class Http extends BodyTagImpl {
 	}
 
 	private static String urlenc(String str, String charset, boolean checkIfNeeded) throws UnsupportedEncodingException {
-		if (checkIfNeeded && !ReqRspUtil.needEncoding(str, false)) return str;
+		if (checkIfNeeded && !ReqRspUtil.needEncoding(str)) return str;
 		return URLEncoder.encode(str, CharsetUtil.toCharset(charset));
 	}
 

--- a/core/src/main/java/lucee/runtime/type/scope/CookieImpl.java
+++ b/core/src/main/java/lucee/runtime/type/scope/CookieImpl.java
@@ -402,7 +402,7 @@ public final class CookieImpl extends ScopeSupport implements Cookie, ScriptProt
 	}
 
 	public String enc(String str) {
-		if (ReqRspUtil.needEncoding(str, false)) return enc(str, true);
+		if (ReqRspUtil.needEncoding(str)) return enc(str, true);
 		return enc(str, false);
 	}
 

--- a/core/src/main/java/lucee/runtime/type/scope/util/ScopeUtil.java
+++ b/core/src/main/java/lucee/runtime/type/scope/util/ScopeUtil.java
@@ -77,7 +77,7 @@ public class ScopeUtil {
 		for (int x = 0; x < itemsArr.length; x++) {
 			items = itemsArr[x];
 			encoding = encodings[x];
-			if (ReqRspUtil.needEncoding(name, false)) encName = ReqRspUtil.encode(name, encoding);
+			if (ReqRspUtil.needEncoding(name)) encName = ReqRspUtil.encode(name, encoding);
 			else encName = null;
 			for (int i = 0; i < items.length; i++) {
 				n = items[i].getName();

--- a/core/src/main/java/resource/setting/sysprop-envvar.json
+++ b/core/src/main/java/resource/setting/sysprop-envvar.json
@@ -368,5 +368,10 @@
         "sysprop": "lucee.template.charset",
         "envvar": "LUCEE_TEMPLATE_CHARSET",
         "desc": ""
+    },
+    {
+        "sysprop": "lucee.url.encodeAllowPlus",
+        "envvar": "LUCEE_URL_ENCODEALLOWPLUS",
+        "desc": "Lucee before 6.2 would attempt to re-encode a url param which contained a space. If the url param was already encoded, it would trigger re-encoding the param again, breaking it. This was avoidable previously by using cfhttp encodeurl=false, set to false to enable previous behaviour"
     }
 ]

--- a/test/tickets/LDEV0973.cfc
+++ b/test/tickets/LDEV0973.cfc
@@ -25,7 +25,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="http"	{
 		http url="#variables.updateProvider#/rest/update/provider/echoGet?filtername=henk+patat" result="local.res";
 		expect( isJson( res.filecontent ) ).toBeTrue( res.filecontent );
 		res=deserializeJSON(res.filecontent);
-		assertEquals("henk+patat",res.url.filtername);
+		assertEquals("henk patat",res.url.filtername);
 	}
 
 	

--- a/test/tickets/LDEV3349.cfc
+++ b/test/tickets/LDEV3349.cfc
@@ -1,50 +1,82 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" skip=true {
+component extends="org.lucee.cfml.test.LuceeTestCase" {
 	function run( testResults, testBox ){
 
         describe( "checking query string encoding for spaces", function() {
-            variables.uri = createURI("LDEV3349/test.cfm");
+            variables.uri = createURI("LDEV3349/ldev3349.cfm");
 
             it( title="cfhttp with queryString %20", body=function( currentSpec ){
                 local.result = _internalRequest(
                     template: variables.uri,
                     url: "%20"
                 );
-                expect(result.filecontent).toBe("%20");
+                expect(result.filecontent).toBe(" =");
             });
             it( title="cfhttp with queryString space", body=function( currentSpec ){
                 local.result = _internalRequest(
                     template: variables.uri,
                     url: " "
                 );
-                expect(result.filecontent).toBe("%20");
+                expect(result.filecontent).toBe(" =");
             });
             it( title="cfhttp with queryString +", body=function( currentSpec ){
                 local.result = _internalRequest(
                     template: variables.uri,
                     url: "+"
                 );
-                expect(result.filecontent).toBe("%20");
+                expect(result.filecontent).toBe(" =");
             });
             it( title="cfhttp with queryString +%20", body=function( currentSpec ){
                 local.result = _internalRequest(
                     template: variables.uri,
                     url: "+%20"
                 );
-                expect(result.filecontent).toBe("%20%20");
+                expect(result.filecontent).toBe("  =");
             });
             it( title="cfhttp with queryString %2B+%2B", body=function( currentSpec ){
                 local.result = _internalRequest(
                     template: variables.uri,
                     url: "%2B+%2B"
                 );
-                expect(result.filecontent).toBe("%2B%20%2B");
+                expect(result.filecontent).toBe("+ +=");
             });
             it( title="cfhttp with queryString space1space", body=function( currentSpec ){
                 local.result = _internalRequest(
                     template: variables.uri,
                     url: " 1 "
                 );
-                expect(result.filecontent).toBe("%2B%20%2B");
+                expect(result.filecontent).toBe(" 1 =");
+            });
+
+            it( title="cfhttp with queryString a=?", body=function( currentSpec ){
+                local.result = _internalRequest(
+                    template: variables.uri,
+                    url: "a=?" // ? is a reserved character and will be converted to %3F encoding
+                );
+                expect(result.filecontent).toBe("a=?");
+            });
+
+            it( title="cfhttp with queryString a=?&b=+", body=function( currentSpec ){
+                local.result = _internalRequest(
+                    template: variables.uri,
+                    url: "a=?&b=+" // ? is a reserved character and will be converted to %3F encoding
+                );
+                expect(result.filecontent).toBe("a=?&b= ");
+            });
+
+            it( title="cfhttp with queryString a=%3F&b= ", body=function( currentSpec ){
+                local.result = _internalRequest(
+                    template: variables.uri,
+                    url: "a=%3F&b=+"
+                );
+                expect(result.filecontent).toBe("a=?&b= ");
+            });
+
+            it( title="LDEV-5172 azure blob url problem", body=function( currentSpec ){
+                local.result = _internalRequest(
+                    template: variables.uri,
+                    url: "rscd=attachment%3B+filename%3D%22results.zip%22"
+                );
+                expect( result.filecontent ).toBe( 'rscd=attachment; filename="results.zip"' );
             });
         });
     }

--- a/test/tickets/LDEV3349/ldev3349.cfm
+++ b/test/tickets/LDEV3349/ldev3349.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#urlDecode(getPageContext().getRequest().getQueryString())#</cfoutput>

--- a/test/tickets/LDEV3349/test.cfm
+++ b/test/tickets/LDEV3349/test.cfm
@@ -1,1 +1,0 @@
-<cfoutput>#getPageContext().getRequest().getQueryString()#</cfoutput>


### PR DESCRIPTION
When a plus sign is present, Lucee would re-encode an already escaped url param

Change the default behaviour to not encode these values

Adds a flag to re-enable to old flawed behaviour `lucee.url.encodeAllowPlus=false` 

https://luceeserver.atlassian.net/browse/LDEV-3349