### PR TITLE
LDEV-5315 Fix: Modern debugging template - Expanding/collapsing not working in certain cases

### DIFF
--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -84,7 +84,7 @@ group("Execution Time","Execution times for templates, includes, modules, custom
 				queryAddColumn(queries, "hash",[]);
 			}
 			loop query=queries {
-				var h="h"&hash(queries.src&":"&queries.line, "quick");
+				var h="h"&hash(queries.src&":"&queries.line&":"&queries.currentrow, "quick");
 				arrayAppend(otherSections, h);
 				querySetCell(queries, "hash", h,queries.currentrow);
 			}

--- a/core/src/main/java/resource/context/admin/debug/Modern.cfc
+++ b/core/src/main/java/resource/context/admin/debug/Modern.cfc
@@ -914,20 +914,19 @@ if(structKeyExists(arguments.custom, "metrics_Charts")) {
 
 				<cfoutput>
 				  cookieName: 	"#variables.cookieName#"
-				, bitmaskAll: 	Math.pow( 2, 31 ) - 1
 				, allSections: 	#serializeJSON( this.allSections )#
 				</cfoutput>
 
 				, setFlag: 		function( name ) {
 
-					var value = __LUCEE.util.getCookie( __LUCEE.debug.cookieName, __LUCEE.debug.allSections.ALL ) | __LUCEE.debug.allSections[ name ];
+					var value = BigInt(__LUCEE.util.getCookie( __LUCEE.debug.cookieName, __LUCEE.debug.allSections.ALL )) | BigInt(__LUCEE.debug.allSections[ name ]);
 					__LUCEE.util.setCookie( __LUCEE.debug.cookieName, value );
 					return value;
 				}
 
 				, clearFlag: 	function( name ) {
 
-					var value = __LUCEE.util.getCookie( __LUCEE.debug.cookieName, 0 ) & ( __LUCEE.debug.bitmaskAll - __LUCEE.debug.allSections[ name ] );
+					var value = BigInt(__LUCEE.util.getCookie( __LUCEE.debug.cookieName, 0 )) & ~BigInt(__LUCEE.debug.allSections[ name ]);
 					__LUCEE.util.setCookie( __LUCEE.debug.cookieName, value );
 					return value;
 				}
@@ -936,7 +935,7 @@ if(structKeyExists(arguments.custom, "metrics_Charts")) {
 
 					var btn = __LUCEE.util.getDomObject( "-lucee-debugging-btn-" + name );
 					var obj = __LUCEE.util.getDomObject( "-lucee-debugging-" + name );
-					var isOpen = ( __LUCEE.util.getCookie( __LUCEE.debug.cookieName, 0 ) & __LUCEE.debug.allSections[ name ] ) > 0;
+					var isOpen = ( BigInt(__LUCEE.util.getCookie( __LUCEE.debug.cookieName, 0 )) & BigInt(__LUCEE.debug.allSections[ name ]) ) > 0;
 
 					if ( isOpen ) {
 


### PR DESCRIPTION
Fixes the below issues related to the modern debugging template:
* If multiple queries were ran with the same file and line number, none of them were expandable/collapsable because they all had the same HTML element IDs.
* If more than ~18 queries (31 sections, includes 13 hardcoded) were ran, expanding/collapsing any query from the 19th onwards wasn't working, due to the hardcoded bitmaskAll and due to the int32 limit being exceeded, requiring BigInt.

Example code to reproduce this (with your own datasource/table):
```
<cfloop index="i" from="1" to="50">
    <cfquery name="LOCAL.qryRows" datasource="testdatasource">
    SELECT 1 FROM exampletable
    </cfquery>
</cfloop>
```

I have tested and can confirm this works, refreshing the page persists selections, etc.
It loses compatibility with older browsers e.g. IE11 because of [BigInt](https://caniuse.com/bigint), but I'm hoping that's okay.

From testing, the max queries this is capable of handling is around 100, vs 18 before.
Any more than that and the cookie starts to get messed up, collapsing/expanding things incorrectly onload.

If we want to support more than that then I think our options are to handle it in chunks of 32 and split on | in the cookie or something OR remove the bitwise operations and use sessionStorage or localStorage instead.

Edit: I don't think this is the ideal fix, maybe chunks is better. Would rather no limit.