### PR TITLE
LDEV-5382 GetHTTPTimeString is wrongly using hyphens in its datetime mask

### DIFF
--- a/core/src/main/java/lucee/commons/date/DateTimeUtil.java
+++ b/core/src/main/java/lucee/commons/date/DateTimeUtil.java
@@ -34,6 +34,7 @@ import lucee.runtime.type.dt.DateTimeImpl;
 
 public abstract class DateTimeUtil {
 
+	private final static FormatterWrapper HTTP_TIME_STRING_FORMAT_OLD = FormatUtil.getDateTimeFormatter(Locale.ENGLISH, "EE, dd MMM yyyy HH:mm:ss zz");
 	private final static FormatterWrapper HTTP_TIME_STRING_FORMAT = FormatUtil.getDateTimeFormatter(Locale.ENGLISH, "EE, dd-MMM-yyyy HH:mm:ss zz");
 
 	private static final double DAY_MILLIS = 86400000D;
@@ -266,7 +267,7 @@ public abstract class DateTimeUtil {
 	 */
 	public static String toHTTPTimeString(Date date, boolean oldFormat) {
 		if (oldFormat) {
-			return StringUtil.replace(FormatUtil.format(HTTP_TIME_STRING_FORMAT.formatter, date, TimeZoneConstants.GMT), "+00:00", "", true);
+			return StringUtil.replace(FormatUtil.format(HTTP_TIME_STRING_FORMAT_OLD.formatter, date, TimeZoneConstants.GMT), "+00:00", "", true);
 		}
 		return StringUtil.replace(FormatUtil.format(HTTP_TIME_STRING_FORMAT.formatter, date, TimeZoneConstants.UTC), "+00:00", "", true);
 	}


### PR DESCRIPTION
GetHTTPTimeString uses "EE, dd MMM yyyy HH:mm:ss zz" on both Lucee 6.0 and Adobe CF.
As part of [this date refactor commit](https://github.com/lucee/Lucee/commit/94e0d4af9fcd6085be65fbdc26c93fd95e0f61e3#diff-e5dc03e1198ceaaa9659942fde54e3d8da668d23396646fd65b208462e15094eR273) the mask was accidentally changed to "EE, dd-MMM-yyyy HH:mm:ss zz", making it not match Adobe's behaviour anymore, on Lucee 6.2.

This PR reverts it to the old behaviour, so oldFormat behaves as documented:
https://github.com/lucee/Lucee/blob/2f849ff1eb58f3c9b302dea98d0f2dba635e0789/core/src/main/java/lucee/commons/date/DateTimeUtil.java#L262-L265