### PR TITLE
LDEV-5518 Fix preserveCaseForQueryColumn in remote method json serialization

### DIFF
--- a/core/src/main/java/lucee/runtime/ComponentPageImpl.java
+++ b/core/src/main/java/lucee/runtime/ComponentPageImpl.java
@@ -77,6 +77,7 @@ import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.FunctionArgument;
 import lucee.runtime.type.KeyImpl;
+import lucee.runtime.type.QueryImpl;
 import lucee.runtime.type.Struct;
 import lucee.runtime.type.StructImpl;
 import lucee.runtime.type.UDF;
@@ -938,7 +939,14 @@ public abstract class ComponentPageImpl extends ComponentPage implements PagePro
 				prefix = pc.getApplicationContext().getSecureJsonPrefix();
 				if (prefix == null) prefix = "";
 			}
-			pc.forceWrite(prefix + converter.serialize(pc, rtn, qf, true));
+
+			// If rtn is a query or struct, set preserveCase to null to allow SerializationSettings
+			// to determine case preservation in JSONConverter. Otherwise set preserveCase to true.
+			Boolean preserveCase = (rtn instanceof QueryImpl || rtn instanceof StructImpl) ? null : true;
+			if (rtn instanceof QueryImpl || rtn instanceof StructImpl) {
+				preserveCase = null;
+			}
+			pc.forceWrite(prefix + converter.serialize(pc, rtn, qf, preserveCase));
 		}
 		// CFML
 		else if (UDF.RETURN_FORMAT_SERIALIZE == props.format) {

--- a/core/src/main/java/lucee/runtime/listener/ModernApplicationContext.java
+++ b/core/src/main/java/lucee/runtime/listener/ModernApplicationContext.java
@@ -1003,6 +1003,9 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 	public SerializationSettings getSerializationSettings() {
 		if (!initSerializationSettings) {
 			Struct sct = Caster.toStruct(get(component, KeyConstants._serialization, null), null);
+			if (sct == null) {
+				sct = Caster.toStruct(get(component, KeyConstants._serializationSettings, null), null);
+			}
 			if (sct != null) {
 				serializationSettings = SerializationSettings.toSerializationSettings(sct);
 			}

--- a/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
+++ b/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
@@ -970,6 +970,7 @@ public class KeyConstants {
 	public static final Key _mailServers = KeyImpl._const("mailServers");
 	public static final Key _smtpServerSettings = KeyImpl._const("smtpServerSettings");
 	public static final Key _serialization = KeyImpl._const("serialization");
+	public static final Key _serializationSettings = KeyImpl._const("serializationSettings");
 	public static final Key _preserveCaseForStructKey = KeyImpl._const("preserveCaseForStructKey");
 	public static final Key _preserveCaseForQueryColumn = KeyImpl._const("preserveCaseForQueryColumn");
 	public static final Key _serializeQueryAs = KeyImpl._const("serializeQueryAs");

--- a/core/src/main/java/resource/tld/core-base.tld
+++ b/core/src/main/java/resource/tld/core-base.tld
@@ -8730,10 +8730,18 @@ Specifies how Lucee stores session variables:
 		<attribute>
 			<type>struct</type>
 			<name>SerializationSettings</name>
-			<alias>SerializationSetting</alias>
+			<alias>Serialization</alias>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description></description>
+			<description>
+				```
+				{
+					preserveCaseForStructKey: boolean,
+					preserveCaseForQueryColumn: boolean,
+					serializeQueryAs: "column|struct|row"
+				}
+				```
+		</description>
 		</attribute>
 		<attribute>
 			<type>struct</type>

--- a/test/general/SerializeJSON.cfc
+++ b/test/general/SerializeJSON.cfc
@@ -59,6 +59,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( mystruct );
 				expect(find("Name", jsonObject)).toBeGT(0);
 				expect(find("id", jsonObject)).toBeGT(0);
+				expect(find("NAME", jsonObject)).toBe(0);
+				expect(find("ID", jsonObject)).toBe(0);
 			});
 
 			it(title="Checking serializeJSON() with preserve case for structkey(preservecaseforstructkey) Eq to false", body=function(){
@@ -87,6 +89,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( data );
 				expect(find("DateJoined", jsonObject)).toBeGT(0);
 				expect(find("ID", jsonObject)).toBeGT(0);
+				expect(find("DATEJOINED", jsonObject)).toBe(0);
 			});
 
 			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
@@ -97,6 +100,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( data );
 				expect(find("DATEJOINED", jsonObject)).toBeGT(0);
 				expect(find("ID", jsonObject)).toBeGT(0);
+				expect(find("DateJoined", jsonObject)).toBe(0);
 			});
 			// if we serializeQueryAs struct with preserveCaseForQueryColumn true lucee fails to maintain preserveCase for query column
 			xit(title="Checking serializeJSON() with preserveCaseForQueryColumn is true & serializeQueryAs struct", body=function(){
@@ -109,6 +113,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( data );
 				expect(find("DateJoined", jsonObject)).toBeGT(0);
 				expect(find("ID", jsonObject)).toBeGT(0);
+				expect(find("DATEJOINED", jsonObject)).toBe(0);
 			});
 		});
 
@@ -126,6 +131,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var json = res.filecontent;
 				expect(find("DateJoined", json)).toBeGT( 0 );
 				expect(find("Id", json)).toBeGT( 0 );
+				expect(find("DATEJOINED", json)).toBe( 0 );
+				expect(find("ID", json)).toBe( 0 );
 			});
 
 			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
@@ -139,6 +146,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				);
 				expect(isJson(res.filecontent)).toBeTrue();
 				var json = res.filecontent;
+				expect(find("DATEJOINED", json)).toBeGT( 0 );
+				expect(find("ID", json)).toBeGT( 0 );
 				expect(find("DateJoined", json)).toBe( 0 );
 				expect(find("Id", json)).toBe( 0 );
 			});
@@ -160,9 +169,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				debug(json);
 				expect(find("Name", json)).toBeGT( 0 );
 				expect(find("Id", json)).toBeGT( 0 );
+				expect(find("NAME", json)).toBe( 0 );
+				expect(find("ID", json)).toBe( 0 );
 			});
 
-			xit(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
+			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
 				var uri=createURI("serializeJson/remoteQuery.cfc");
 				var res=_InternalRequest(
 					template:uri,
@@ -175,6 +186,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				expect(isJson(res.filecontent)).toBeTrue();
 				var json = res.filecontent;
 				debug(json);
+				expect(find("NAME", json)).toBeGT( 0 );
+				expect(find("ID", json)).toBeGT( 0 );
 				expect(find("Name", json)).toBe( 0 );
 				expect(find("Id", json)).toBe( 0 );
 			});
@@ -194,6 +207,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var json = res.filecontent;
 				expect(find("DateJoined", json)).toBeGT( 0 );
 				expect(find("Id", json)).toBeGT( 0 );
+				expect(find("DATEJOINED", json)).toBe( 0 );
+				expect(find("ID", json)).toBe( 0 );
 			});
 
 			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
@@ -207,6 +222,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				);
 				expect(isJson(res.filecontent)).toBeTrue();
 				var json = res.filecontent;
+				expect(find("DATEJOINED", json)).toBeGT( 0 );
+				expect(find("ID", json)).toBeGT( 0 );
 				expect(find("DateJoined", json)).toBe( 0 );
 				expect(find("Id", json)).toBe( 0 );
 			});

--- a/test/general/SerializeJSON.cfc
+++ b/test/general/SerializeJSON.cfc
@@ -144,6 +144,42 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 			});
 		});
 
+		describe( "test suite for this.serialization via application.cfc, remote cfc", function() {
+			it (title="Checking serializeJSON() with preserveCaseForQueryColumn is true", body=function(){
+				var uri=createURI("serializeJson/remoteQuery.cfc");
+				var res=_InternalRequest(
+					template:uri,
+					url: {
+						preserveCaseForQueryColumn: true,
+						prop: "serialization",
+						method: "test"
+					}
+				);
+				expect(isJson(res.filecontent)).toBeTrue();
+				var json = res.filecontent;
+				debug(json);
+				expect(find("Name", json)).toBeGT( 0 );
+				expect(find("Id", json)).toBeGT( 0 );
+			});
+
+			xit(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
+				var uri=createURI("serializeJson/remoteQuery.cfc");
+				var res=_InternalRequest(
+					template:uri,
+					url:{
+						preserveCaseForQueryColumn: false,
+						prop: "serialization",
+						method: "test"
+					}
+				);
+				expect(isJson(res.filecontent)).toBeTrue();
+				var json = res.filecontent;
+				debug(json);
+				expect(find("Name", json)).toBe( 0 );
+				expect(find("Id", json)).toBe( 0 );
+			});
+		});
+
 		describe( "test suite for this.serializationSettings via application.cfc", function() {
 			it (title="Checking serializeJSON() with preserveCaseForQueryColumn is true", body=function(){
 				var uri=createURI("serializeJson/preserveCaseForQueryColumn.cfm");

--- a/test/general/SerializeJSON.cfc
+++ b/test/general/SerializeJSON.cfc
@@ -43,13 +43,13 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				expect(local.tmpData).toBeTypeOf("Array");
 				expect(arrayLen(local.tmpData)).toBe("3");
 			});
-			
+
 
 			it(title="Checking serializeJSON() with preserve case for structkey(preservecaseforstructkey) Eq to TRUE", body=function(){
 				var serSettings =  getApplicationSettings().serialization;
 				serSettings.preserveCaseForStructKey = true;
 				application action="update" SerializationSettings=serSettings;
-				
+
 				var myStruct = {
 					 "id"          : 1
 					,"Name"        : "POTHYS"
@@ -65,7 +65,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var serSettings =  getApplicationSettings().serialization;
 				serSettings.preserveCaseForStructKey = false;
 				application action="update" SerializationSettings=serSettings;
-				
+
 				var myStruct = {
 					 "id"          : 1
 					,"Name"        : "POTHYS"
@@ -111,5 +111,76 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				expect(find("ID", jsonObject)).toBeGT(0);
 			});
 		});
+
+		describe( "test suite for this.serialization via application.cfc", function() {
+			it (title="Checking serializeJSON() with preserveCaseForQueryColumn is true", body=function(){
+				var uri=createURI("serializeJson/preserveCaseForQueryColumn.cfm");
+				var res=_InternalRequest(
+					template:uri,
+					url: {
+						preserveCaseForQueryColumn: true,
+						prop: "serialization"
+					}
+				);
+				expect(isJson(res.filecontent)).toBeTrue();
+				var json = res.filecontent;
+				expect(find("DateJoined", json)).toBeGT( 0 );
+				expect(find("Id", json)).toBeGT( 0 );
+			});
+
+			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
+				var uri=createURI("serializeJson/preserveCaseForQueryColumn.cfm");
+				var res=_InternalRequest(
+					template:uri,
+					url:{
+						preserveCaseForQueryColumn: false,
+						prop: "serialization"
+					}
+				);
+				expect(isJson(res.filecontent)).toBeTrue();
+				var json = res.filecontent;
+				expect(find("DateJoined", json)).toBe( 0 );
+				expect(find("Id", json)).toBe( 0 );
+			});
+		});
+
+		describe( "test suite for this.serializationSettings via application.cfc", function() {
+			it (title="Checking serializeJSON() with preserveCaseForQueryColumn is true", body=function(){
+				var uri=createURI("serializeJson/preserveCaseForQueryColumn.cfm");
+				var res=_InternalRequest(
+					template:uri,
+					url: {
+						preserveCaseForQueryColumn: true,
+						prop: "serializationSettings"
+					}
+				);
+				expect(isJson(res.filecontent)).toBeTrue();
+				var json = res.filecontent;
+				expect(find("DateJoined", json)).toBeGT( 0 );
+				expect(find("Id", json)).toBeGT( 0 );
+			});
+
+			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
+				var uri=createURI("serializeJson/preserveCaseForQueryColumn.cfm");
+				var res=_InternalRequest(
+					template:uri,
+					url:{
+						preserveCaseForQueryColumn: false,
+						prop: "serializationSettings"
+					}
+				);
+				expect(isJson(res.filecontent)).toBeTrue();
+				var json = res.filecontent;
+				expect(find("DateJoined", json)).toBe( 0 );
+				expect(find("Id", json)).toBe( 0 );
+			});
+		});
 	}
+
+	private string function createURI(string calledName){
+		var baseURI="/test/#listLast(getDirectoryFromPath(getCurrenttemplatepath()),"\/")#/";
+		return baseURI&""&calledName;
+	}
+
+
 }

--- a/test/general/serializeJson/Application.cfc
+++ b/test/general/serializeJson/Application.cfc
@@ -1,0 +1,6 @@
+component {
+	this.name="serializeJson";
+	this[ url.prop ] = {
+		preserveCaseForQueryColumn = url.preserveCaseForQueryColumn
+	}
+} 

--- a/test/general/serializeJson/preserveCaseForQueryColumn.cfm
+++ b/test/general/serializeJson/preserveCaseForQueryColumn.cfm
@@ -1,0 +1,8 @@
+<cfscript>
+	data = queryNew("Id, DateJoined", "INTEGER, TIMESTAMP", [
+		{ID=1, DateJoined="2017-01-03 10:57:54"},
+		{ID=2, DateJoined="2017-01-03 10:57:54"},
+		{ID=3, DateJoined="2017-01-03 10:57:54"}
+	]);
+	echo(serializeJSON( data ));
+</cfscript>

--- a/test/general/serializeJson/remoteQuery.cfc
+++ b/test/general/serializeJson/remoteQuery.cfc
@@ -1,0 +1,15 @@
+<cfcomponent output="false">
+	<cffunction name="test" access="remote" output="false" returntype="query" returnformat="json">
+		<cfscript>
+			//systemOutput(getApplicationSettings().serialization, true);
+			return queryNew(
+				"Id,Name",
+				"numeric,varchar",
+				{
+					id: [1,2,3],
+					name: ['Neo','Trinity','Morpheus']
+				}
+				);
+		</cfscript>
+	</cffunction>
+</cfcomponent>


### PR DESCRIPTION
Fixes remote method query json encoding to respect `SerializationSettings. preserveCaseForQueryColumn`. Also restores alias `serializationSettings` in Application settings

https://luceeserver.atlassian.net/browse/LDEV-5518

