### PR TITLE
LDEV-5566 - Fixed date string millisecond parsing

### DIFF
--- a/core/src/main/java/lucee/runtime/op/date/DateCaster.java
+++ b/core/src/main/java/lucee/runtime/op/date/DateCaster.java
@@ -781,11 +781,23 @@ public final class DateCaster {
 			ds.removeWhitespace();
 			if (msSeconds == -1) return defaultValue;
 
-			double divisor = 1;
-			while (msSeconds / divisor >= 1) {
-				divisor *= 10;
-			}
-			msSeconds = (int) ((msSeconds / divisor) * 1000);
+			/*
+			 * In order to correct parse millisecond strings, we need to know the length
+			 * of the original digits. Once we know the length, we can generate a divisor
+			 * to make sure our millisecond string is correctly converted into an int.
+			 * 
+			 * This handles numeric strings as follows:
+			 * 
+			 * 001 = 1ms
+			 * 01 = 10ms
+			 * 1 = 100ms
+			 * 0001 = 0ms
+			 * 0005 = 1ms
+			 * 0009412 = 1ms
+			 */
+			double divisor = Math.pow(10, ds.getLastDigitLength());
+			// we use round, so that nanosecond inputs round to the nearest millisecond
+			msSeconds = (int) Math.round((msSeconds / divisor) * 1000);
 		}
 
 		if (ds.isAfterLast()) {

--- a/core/src/main/java/lucee/runtime/op/date/DateString.java
+++ b/core/src/main/java/lucee/runtime/op/date/DateString.java
@@ -34,6 +34,7 @@ public final class DateString {
 
 	private String str;
 	private int pos;
+	private int lastDigitLength = -1;
 
 	private static Map months = new HashMap();
 	static {
@@ -226,18 +227,30 @@ public final class DateString {
 	 * 
 	 * @return value from the digits
 	 */
+	public int getLastDigitLength() {
+		return lastDigitLength;
+	}
+
+	/**
+	 * read in the next digits from current position
+	 * 
+	 * @return value from the digits
+	 */
 	public int readDigits() {
 		int value = 0;
+		lastDigitLength = 0;
 		char c;
 		if (isValidIndex() && isDigit(c = str.charAt(pos))) {
 			value = ints[0][c - 48];
 			pos++;
+			lastDigitLength++;
 		}
 		else return -1;
 		while (isValidIndex() && isDigit(c = str.charAt(pos))) {
 			value *= 10;
 			value += ints[0][c - 48];
 			pos++;
+			lastDigitLength++;
 		}
 		return value;
 	}
@@ -343,6 +356,7 @@ public final class DateString {
 
 	public void reset() {
 		pos = 0;
+		lastDigitLength = -1;
 	}
 
 }

--- a/test/tickets/LDEV5566.cfc
+++ b/test/tickets/LDEV5566.cfc
@@ -1,0 +1,45 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" {
+	/* 
+		To run only this test, add the following command line argument:
+
+		mvn test -DtestFilter='LDEV5566'
+
+		or
+
+		mvn test -DtestFilter='LDEV5566' -DtestDebugger='true' -DtestDebug='true'
+	*/
+
+	function run( testResults , testBox ) {
+
+		describe( title="[LDEV-5566] Incorrect parsing of milliseconds in string date", body=function() {
+
+			it( title="ISO-8601 dates as string should correct parse milliseconds with leading zeros", body=function( currentSpec ) {
+				expect(dateTimeFormat("2010-04-30T22:26:00.003", "yyyy-mm-dd HH:nn:ss.lll")).toBe("2010-04-30 22:26:00.003");
+				expect(dateTimeFormat("2010-04-30T22:26:00.083", "yyyy-mm-dd HH:nn:ss.lll")).toBe("2010-04-30 22:26:00.083");
+				expect(dateTimeFormat("2010-04-30T22:26:00.983", "yyyy-mm-dd HH:nn:ss.lll")).toBe("2010-04-30 22:26:00.983");
+			});
+
+			it( title="ISO-8601-like dates as string should correct parse milliseconds with leading zeros", body=function( currentSpec ) {
+				expect(dateTimeFormat("2010-04-30 22:26:00.003", "yyyy-mm-dd HH:nn:ss.lll")).toBe("2010-04-30 22:26:00.003");
+				expect(dateTimeFormat("2010-04-30 22:26:00.083", "yyyy-mm-dd HH:nn:ss.lll")).toBe("2010-04-30 22:26:00.083");
+				expect(dateTimeFormat("2010-04-30 22:26:00.983", "yyyy-mm-dd HH:nn:ss.lll")).toBe("2010-04-30 22:26:00.983");
+			});
+
+			it( title='test nanoseconds', body=function( currentSpec ) {
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.0002")) ).toBe(000);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.0005")) ).toBe(001);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.00002")) ).toBe(000);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.000002")) ).toBe(000);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.0000002")) ).toBe(000);
+			});
+
+			it( title='From LDEV-4825: test millisecond fraction', body=function( currentSpec ) {
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.6")) ).toBe(600);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.60")) ).toBe(600);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.600")) ).toBe(600);
+				expect( millisecond(parseDateTime("2024-04-04 00:00:00.6000")) ).toBe(600);
+			});
+
+		});
+	}
+}


### PR DESCRIPTION
* Fixed millisecond parsing issues in DateCaster.parseTime()
* Updated DateString to return length of last digit string

https://luceeserver.atlassian.net/browse/LDEV-5568