### PR TITLE
LDEV-5603 - ensure embeded error template have the style and javascript included

### DIFF
--- a/core/src/main/cfml/context/templates/error/error.cfm
+++ b/core/src/main/cfml/context/templates/error/error.cfm
@@ -1,3 +1,4 @@
+<cfsetting enablecfoutputonly="reset">
 <cfparam name="addClosingHTMLTags" default="#true#" type="boolean"><cfif addClosingHTMLTags></TD></TD></TD></TH></TH></TH></TR></TR></TR></TABLE></TABLE></TABLE></A></ABBREV></ACRONYM></ADDRESS></APPLET></AU></B></BANNER></BIG></BLINK></BLOCKQUOTE></BQ></CAPTION></CENTER></CITE></CODE></COMMENT></DEL></DFN></DIR></DIV></DL></EM></FIG></FN></FONT></FORM></FRAME></FRAMESET></H1></H2></H3></H4></H5></H6></HEAD></I></INS></KBD></LISTING></MAP></MARQUEE></MENU></MULTICOL></NOBR></NOFRAMES></NOSCRIPT></NOTE></OL></P></PARAM></PERSON></PLAINTEXT></PRE></Q></S></SAMP></SCRIPT></SELECT></SMALL></STRIKE></STRONG></SUB></SUP></TABLE></TD></TEXTAREA></TH></TITLE></TR></TT></U></UL></VAR></WBR></XMP>
 </cfif><style>
 	#-lucee-err			{ font-family: Verdana, Geneva, Arial, Helvetica, sans-serif; font-size: 11px; background-color:#930; border-collapse: collapse; }


### PR DESCRIPTION
Reset setting enablecfoutputonly to ensure the embeded style/js is always included

Anything up the stack could have changed the value of enablecfoutputonly multiple time. Make use of Lucee's enhanced function https://docs.lucee.org/guides/Various/lucee-enhanced-functions.html to ensure it always reset back to false. This is safe as we are at the top of the stack and end of the request lifecycle.