### PR TITLE
For LDEV-5425, Updated the test case for getSystemPropOrEnvVar() to cover the default value

### DIFF
--- a/test/functions/GetSystemPropOrEnvVar.cfc
+++ b/test/functions/GetSystemPropOrEnvVar.cfc
@@ -31,6 +31,15 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 					}
 				});
 			});
+			
+			//For LDEV-5425
+			xit( title = "should return the default value instead of an empty value for GetSystemPropOrEnvVar(prop)", body = function( currentSpec ) {
+                var props = GetSystemPropOrEnvVar();
+                ArrayEach( props, function( item ){
+                    var result = GetSystemPropOrEnvVar( item.sysProp );
+                    expect( len(result) ).toBeGT( 0 );
+                });
+            })
 
 		});
 	}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-5425