### PR TITLE
LDEV-6145 - do not rename bundle JAR if Felix already has it registered

### DIFF
--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -1194,6 +1194,22 @@ public class OSGiUtil {
 
 		String preferedName = bf.getSymbolicName() + "-" + bf.getVersionAsString() + ".jar";
 		if (!preferedName.equals(f.getName())) {
+			// LDEV-6145: do not rename if Felix already has this bundle registered at the current path.
+			// Renaming without updating Felix leaves the cache pointing at the old (now missing) path,
+			// causing "Bundle symbolic name and version are not unique" on the next restart.
+			try {
+				BundleContext bc = CFMLEngineFactory.getInstance().getBundleContext();
+				if (bc != null) {
+					String location = f.getAbsolutePath();
+					for (Bundle b: bc.getBundles()) {
+						if (location.equals(b.getLocation())) return bf;
+					}
+				}
+			}
+			catch (Exception e) {
+				// engine not yet started; safe to rename
+			}
+
 			try {
 				File nf = new File(f.getParentFile(), preferedName);
 				if (f.renameTo(nf)) {


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6145

## Summary

- `OSGiUtil.improveFileName()` was renaming bundle JARs on disk (e.g. `commons.lang-2.6.jar` → `commons.lang-2.6.0.jar`) without updating the Felix OSGi cache
- Felix persists bundle locations across restarts, so on the next JVM restart it tries to install the bundle at the old (now missing) path alongside the renamed one, causing: `BundleException: Bundle symbolic name and version are not unique`
- Fix: before renaming, check if Felix already has the bundle registered at the current path — if yes, skip the rename

## Root cause

`Version.parseVersion("2.6").toString()` returns `"2.6.0"` (OSGi always outputs 3-part versions), so `improveFileName()` always tried to rename `2.6.jar` → `2.6.0.jar`. This rename is only safe before Felix starts (first boot). After Felix is running and has registered the bundle location, renaming corrupts the cache.

## Related

- LDEV-6144 (companion loader fix for recovery from already-corrupted caches)