### PR TITLE
LDEV-6144 - recover from stale Felix cache on startup (bundle name conflict)

### DIFF
--- a/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
+++ b/loader/src/main/java/lucee/loader/engine/CFMLEngineFactory.java
@@ -675,7 +675,19 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 				setEngine(engine);
 			}
 			else {
-				bundleCollection = BundleLoader.loadBundles(this, getFelixCacheDirectory(), getBundleDirectory(), lucee, bundleCollection);
+				try {
+					bundleCollection = BundleLoader.loadBundles(this, getFelixCacheDirectory(), getBundleDirectory(), lucee, bundleCollection);
+				}
+				catch (BundleException be) {
+					// LDEV-6144: stale felix cache (bundle registered at old path after rename, e.g. from LDEV-6145).
+					// Clear the cache and retry once with a fresh Felix instance.
+					if (be.getMessage() != null && be.getMessage().contains("not unique")) {
+						log(org.apache.felix.resolver.Logger.LOG_WARNING, "Felix cache is stale (bundle name conflict: " + be.getMessage() + "), clearing cache and retrying");
+						Util.deleteContent(getFelixCacheDirectory(), null);
+						bundleCollection = BundleLoader.loadBundles(this, getFelixCacheDirectory(), getBundleDirectory(), lucee, null);
+					}
+					else throw be;
+				}
 				// bundle=loadBundle(lucee);
 				log(org.apache.felix.resolver.Logger.LOG_DEBUG, "Loaded bundle: [" + bundleCollection.core.getSymbolicName() + "]");
 				setEngine(getEngine(bundleCollection));
@@ -823,9 +835,10 @@ public class CFMLEngineFactory extends CFMLEngineFactorySupport {
 			// this could be cause by an invalid felix cache, so we simply delete it and try again
 			if (!isNew && "Error creating bundle cache.".equals(be.getMessage())) {
 				Util.deleteContent(cacheRootDir, null);
-
+				felix = new Felix(config);
+				felix.start();
 			}
-
+			else throw be;
 		}
 
 		return felix;


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6144

## Summary

- When Felix starts and encounters "Bundle symbolic name and version are not unique" (caused by a stale cache, e.g. from LDEV-6145), Lucee would crash on startup with no recovery
- Also fixes an existing bug in `getFelix()` where "Error creating bundle cache" was caught and the cache cleared, but Felix was never restarted — returning an unstarted Felix instance causing an NPE
- Fix: catch the "not unique" `BundleException` from `BundleLoader.loadBundles()`, clear the stale Felix cache, and retry with a fresh Felix instance

## Why this is needed alongside LDEV-6145

LDEV-6145 prevents future corruption, but users who already have a corrupted Felix cache (from an older Lucee version) cannot start Lucee at all — core never loads, so the LDEV-6145 fix never runs. This loader-level fix recovers from the corrupted state automatically on next restart.