### PR TITLE
LDEV-6155 prevent StopThread from poisoning recycled PageContexts

### DIFF
--- a/core/src/main/java/lucee/commons/io/SystemUtil.java
+++ b/core/src/main/java/lucee/commons/io/SystemUtil.java
@@ -1875,15 +1875,26 @@ class Ref {
 class StopThread extends Thread {
 
 	private final PageContext pc;
-	// private final Log log;
+	private final Thread target;
+	private final int requestId;
 
 	public StopThread(PageContext pc) {
 		this.pc = pc;
+		this.target = pc.getThread();
+		this.requestId = ((PageContextImpl) pc).getRequestId();
 	}
 
 	@Override
 	public void run() {
-		SystemUtil.stop(pc, pc.getThread());
+		// LDEV-6155: if the PageContext has been recycled for a new request, bail out.
+		// Without this check, we'd poison the new request by setting timeoutStackTrace
+		// and interrupting its thread.
+		if (((PageContextImpl) pc).getRequestId() != requestId) {
+			Log log = ThreadLocalPageContext.getLog(pc, "requesttimeout");
+			if (log != null) log.info("StopThread", "skipping stop, PageContext was recycled (original request " + requestId + " already completed)");
+			return;
+		}
+		SystemUtil.stop(pc, target);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix race condition in `StopThread` where a delayed `run()` could poison a recycled `PageContext`, causing spurious `RequestTimeoutException` on a brand-new request
- Capture thread reference and `requestId` at construction time; bail out if the `PageContext` has been recycled

https://luceeserver.atlassian.net/browse/LDEV-6155