### PR TITLE
LDEV-6226 fix cross-classloader method resolution

### DIFF
--- a/core/src/main/java/lucee/runtime/reflection/Reflector.java
+++ b/core/src/main/java/lucee/runtime/reflection/Reflector.java
@@ -294,7 +294,8 @@ public final class Reflector {
 	 */
 	public static boolean like(Class src, Class trg) {
 		if (src == trg) return true;
-		return isInstaneOf(src, trg, true);
+		if (trg.isAssignableFrom(src)) return true;
+		return isInstaneOf(src, trg, false);
 	}
 
 	public static Object convert(Object src, Class trgClass, RefInteger rating, Object defaultValue) {

--- a/core/src/main/java/lucee/transformer/dynamic/meta/Clazz.java
+++ b/core/src/main/java/lucee/transformer/dynamic/meta/Clazz.java
@@ -267,7 +267,9 @@ public abstract class Clazz implements Serializable {
 			if ((args.length == fm.getArgumentCount()) && clazz.getName().equals(fm.getDeclaringClassName())) {
 				parameterTypes = fm.getArgumentClasses();
 				for (int y = 0; y < parameterTypes.length; y++) {
-					if (!Reflector.toReferenceClass(parameterTypes[y]).isAssignableFrom(args[y] == null ? Object.class : args[y].getClass())) continue outer;
+					Class argClass = args[y] == null ? Object.class : args[y].getClass();
+					Class paramClass = Reflector.toReferenceClass(parameterTypes[y]);
+					if (!paramClass.isAssignableFrom(argClass) && !Reflector.isInstaneOf(argClass, paramClass, false)) continue outer;
 				}
 				return fm;
 			}
@@ -326,8 +328,10 @@ public abstract class Clazz implements Serializable {
 					if (args[y] == null) {
 						if (parameterTypes[y].isPrimitive()) continue outer;
 					}
-					else if (!Reflector.toReferenceClass(parameterTypes[y]).isAssignableFrom(args[y].getClass())) {
-						continue outer;
+					else {
+						Class argClass = args[y].getClass();
+						Class paramClass = Reflector.toReferenceClass(parameterTypes[y]);
+						if (!paramClass.isAssignableFrom(argClass) && !Reflector.isInstaneOf(argClass, paramClass, false)) continue outer;
 					}
 				}
 				return fm;

--- a/test/tickets/LDEV6226.cfc
+++ b/test/tickets/LDEV6226.cfc
@@ -1,0 +1,105 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" {
+
+	function beforeAll() {
+		variables.tempDir = getTempDirectory() & "LDEV6226/";
+		if ( directoryExists( variables.tempDir ) ) directoryDelete( variables.tempDir, true );
+		directoryCreate( variables.tempDir );
+		directoryCreate( variables.tempDir & "src/" );
+		directoryCreate( variables.tempDir & "classes1/" );
+		directoryCreate( variables.tempDir & "classes2/" );
+
+		var javaSource = 'public class LDEV6226Helper {
+	private String value;
+	public LDEV6226Helper() { this.value = "default"; }
+	public LDEV6226Helper( String value ) { this.value = value; }
+	public String getValue() { return this.value; }
+	public String extractFrom( LDEV6226Helper other ) { return other.getValue(); }
+}';
+
+		fileWrite( variables.tempDir & "src/LDEV6226Helper.java", javaSource );
+
+		var javac = createObject( "java", "javax.tools.ToolProvider" ).getSystemJavaCompiler();
+		if ( isNull( javac ) )
+			throw( message="JDK required - javac not available", type="application" );
+
+		javac.run(
+			javaCast( "null", "" ), javaCast( "null", "" ), javaCast( "null", "" ),
+			[ "-d", variables.tempDir & "classes1", variables.tempDir & "src/LDEV6226Helper.java" ]
+		);
+		fileCopy(
+			variables.tempDir & "classes1/LDEV6226Helper.class",
+			variables.tempDir & "classes2/LDEV6226Helper.class"
+		);
+	}
+
+	private function createFileClassLoader( required string classDir ) {
+		var file = createObject( "java", "java.io.File" ).init( arguments.classDir );
+		var urlArray = createObject( "java", "java.lang.reflect.Array" )
+			.newInstance( createObject( "java", "java.net.URL" ).getClass(), 1 );
+		urlArray[ 1 ] = file.toURI().toURL();
+		return createObject( "java", "java.net.URLClassLoader" )
+			.init( urlArray, javaCast( "null", "" ) );
+	}
+
+	function run( testResults, testBox ) {
+		describe( "LDEV-6226 - Java method resolution fails with cross-classloader arguments", function() {
+
+			it( "isAssignableFrom fails across classloaders but name-based matching works", function() {
+				var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
+				var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
+
+				try {
+					var class1 = cl1.loadClass( "LDEV6226Helper" );
+					var class2 = cl2.loadClass( "LDEV6226Helper" );
+
+					// same name, different classloaders
+					expect( class1.getName() ).toBe( class2.getName() );
+					expect( class1.getClassLoader().toString() )
+						.notToBe( class2.getClassLoader().toString() );
+
+					// strict identity check fails - root cause of the bug
+					expect( class1.isAssignableFrom( class2 ) ).toBeFalse();
+
+					// name-based check works
+					var Reflector = createObject( "java", "lucee.runtime.reflection.Reflector" );
+					expect( Reflector.isInstaneOf( class2, class1, false ) ).toBeTrue();
+				}
+				finally {
+					cl1.close();
+					cl2.close();
+				}
+			});
+
+			it( "Clazz.getMethod should find methods with cross-classloader arguments", function() {
+				// simulates the real scenario: receiver persisted from old classloader,
+				// argument created from new classloader after bundle refresh
+				var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
+				var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
+
+				try {
+					var class1 = cl1.loadClass( "LDEV6226Helper" );
+					var class2 = cl2.loadClass( "LDEV6226Helper" );
+
+					// create an argument from cl2 (fresh classloader, like after bundle refresh)
+					var ctor = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ]);
+					var foreignArg = ctor.newInstance([ "test-value" ]);
+
+					// resolve method on class1 (old classloader, like persisted receiver)
+					// this failed before the fix with: "No matching method for
+					// LDEV6226Helper.extractFrom(LDEV6226Helper) found."
+					var di = createObject( "java", "lucee.transformer.dynamic.DynamicInvoker" ).getExistingInstance();
+					var clazzz = di.toClazz( class1 );
+					var method = clazzz.getMethod( "extractFrom", [ foreignArg ], true, true, true );
+					expect( method ).notToBeNull();
+					expect( method.getName() ).toBe( "extractFrom" );
+				}
+				finally {
+					cl1.close();
+					cl2.close();
+				}
+			});
+
+		});
+	}
+
+}

--- a/test/tickets/LDEV6226.cfc
+++ b/test/tickets/LDEV6226.cfc
@@ -12,6 +12,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 	private String value;
 	public LDEV6226Helper() { this.value = "default"; }
 	public LDEV6226Helper( String value ) { this.value = value; }
+	public LDEV6226Helper( LDEV6226Helper other ) { this.value = other.getValue(); }
 	public String getValue() { return this.value; }
 	public String extractFrom( LDEV6226Helper other ) { return other.getValue(); }
 }';
@@ -22,10 +23,12 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 		if ( isNull( javac ) )
 			throw( message="JDK required - javac not available", type="application" );
 
-		javac.run(
+		var result = javac.run(
 			javaCast( "null", "" ), javaCast( "null", "" ), javaCast( "null", "" ),
 			[ "-d", variables.tempDir & "classes1", variables.tempDir & "src/LDEV6226Helper.java" ]
 		);
+		if ( result != 0 )
+			throw( message="javac compilation failed with exit code #result#", type="application" );
 		fileCopy(
 			variables.tempDir & "classes1/LDEV6226Helper.class",
 			variables.tempDir & "classes2/LDEV6226Helper.class"
@@ -37,8 +40,17 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 		var urlArray = createObject( "java", "java.lang.reflect.Array" )
 			.newInstance( createObject( "java", "java.net.URL" ).getClass(), 1 );
 		urlArray[ 1 ] = file.toURI().toURL();
+		// null parent classloader forces each instance to load its own copy of the class,
+		// giving us two Class objects with the same FQN but different identity (simulates OSGi bundle refresh)
 		return createObject( "java", "java.net.URLClassLoader" )
 			.init( urlArray, javaCast( "null", "" ) );
+	}
+
+	private function getDynamicInvokerClazz( required clazz ) {
+		var di = createObject( "java", "lucee.transformer.dynamic.DynamicInvoker" ).getExistingInstance();
+		if ( isNull( di ) )
+			throw( message="DynamicInvoker not initialised in this context", type="application" );
+		return di.toClazz( arguments.clazz );
 	}
 
 	function run( testResults, testBox ) {
@@ -87,11 +99,33 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 					// resolve method on class1 (old classloader, like persisted receiver)
 					// this failed before the fix with: "No matching method for
 					// LDEV6226Helper.extractFrom(LDEV6226Helper) found."
-					var di = createObject( "java", "lucee.transformer.dynamic.DynamicInvoker" ).getExistingInstance();
-					var clazzz = di.toClazz( class1 );
+					var clazzz = getDynamicInvokerClazz( class1 );
 					var method = clazzz.getMethod( "extractFrom", [ foreignArg ], true, true, true );
 					expect( method ).notToBeNull();
 					expect( method.getName() ).toBe( "extractFrom" );
+				}
+				finally {
+					cl1.close();
+					cl2.close();
+				}
+			});
+
+			it( "Clazz.getConstructor should resolve with cross-classloader arguments", function() {
+				var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
+				var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
+
+				try {
+					var class1 = cl1.loadClass( "LDEV6226Helper" );
+					var class2 = cl2.loadClass( "LDEV6226Helper" );
+
+					// create an instance from cl2 to use as a constructor arg
+					var foreignArg = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ])
+						.newInstance([ "ctor-test" ]);
+
+					// resolve constructor on class1 with a cross-classloader argument
+					var clazzz = getDynamicInvokerClazz( class1 );
+					var ctor = clazzz.getConstructor( [ foreignArg ], true, true, javaCast( "null", "" ) );
+					expect( ctor ).notToBeNull();
 				}
 				finally {
 					cl1.close();

--- a/test/tickets/LDEV6226.cfc
+++ b/test/tickets/LDEV6226.cfc
@@ -15,6 +15,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 	public LDEV6226Helper( LDEV6226Helper other ) { this.value = other.getValue(); }
 	public String getValue() { return this.value; }
 	public String extractFrom( LDEV6226Helper other ) { return other.getValue(); }
+	public String extractFrom( Object other ) { return "object:" + other.toString(); }
 }';
 
 		fileWrite( variables.tempDir & "src/LDEV6226Helper.java", javaSource );
@@ -53,17 +54,26 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 		return di.toClazz( arguments.clazz );
 	}
 
+	// helper: loads the class from both classloaders, runs the callback, closes classloaders
+	private function withCrossClassLoaders( required function callback ) {
+		var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
+		var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
+		try {
+			var class1 = cl1.loadClass( "LDEV6226Helper" );
+			var class2 = cl2.loadClass( "LDEV6226Helper" );
+			arguments.callback( class1, class2 );
+		}
+		finally {
+			cl1.close();
+			cl2.close();
+		}
+	}
+
 	function run( testResults, testBox ) {
-		describe( "LDEV-6226 - Java method resolution fails with cross-classloader arguments", function() {
+		describe( "LDEV-6226 - cross-classloader identity mismatch", function() {
 
 			it( "isAssignableFrom fails across classloaders but name-based matching works", function() {
-				var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
-				var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
-
-				try {
-					var class1 = cl1.loadClass( "LDEV6226Helper" );
-					var class2 = cl2.loadClass( "LDEV6226Helper" );
-
+				withCrossClassLoaders( function( class1, class2 ) {
 					// same name, different classloaders
 					expect( class1.getName() ).toBe( class2.getName() );
 					expect( class1.getClassLoader().toString() )
@@ -75,62 +85,70 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="java,classloader" 
 					// name-based check works
 					var Reflector = createObject( "java", "lucee.runtime.reflection.Reflector" );
 					expect( Reflector.isInstaneOf( class2, class1, false ) ).toBeTrue();
-				}
-				finally {
-					cl1.close();
-					cl2.close();
-				}
+				});
 			});
 
-			it( "Clazz.getMethod should find methods with cross-classloader arguments", function() {
-				// simulates the real scenario: receiver persisted from old classloader,
-				// argument created from new classloader after bundle refresh
-				var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
-				var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
+			it( "Clazz.getMethod resolves with cross-classloader arguments", function() {
+				withCrossClassLoaders( function( class1, class2 ) {
+					var foreignArg = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ])
+						.newInstance([ "test-value" ]);
 
-				try {
-					var class1 = cl1.loadClass( "LDEV6226Helper" );
-					var class2 = cl2.loadClass( "LDEV6226Helper" );
-
-					// create an argument from cl2 (fresh classloader, like after bundle refresh)
-					var ctor = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ]);
-					var foreignArg = ctor.newInstance([ "test-value" ]);
-
-					// resolve method on class1 (old classloader, like persisted receiver)
-					// this failed before the fix with: "No matching method for
-					// LDEV6226Helper.extractFrom(LDEV6226Helper) found."
+					// resolve method on class1 (old classloader) with arg from class2 (new classloader)
 					var clazzz = getDynamicInvokerClazz( class1 );
 					var method = clazzz.getMethod( "extractFrom", [ foreignArg ], true, true, true );
 					expect( method ).notToBeNull();
 					expect( method.getName() ).toBe( "extractFrom" );
-				}
-				finally {
-					cl1.close();
-					cl2.close();
-				}
+				});
 			});
 
-			it( "Clazz.getConstructor should resolve with cross-classloader arguments", function() {
-				var cl1 = createFileClassLoader( variables.tempDir & "classes1/" );
-				var cl2 = createFileClassLoader( variables.tempDir & "classes2/" );
+			it( "Clazz.getMethod picks the typed overload over Object for cross-classloader args", function() {
+				withCrossClassLoaders( function( class1, class2 ) {
+					var foreignArg = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ])
+						.newInstance([ "overload-test" ]);
 
-				try {
-					var class1 = cl1.loadClass( "LDEV6226Helper" );
-					var class2 = cl2.loadClass( "LDEV6226Helper" );
+					// with overloaded extractFrom(LDEV6226Helper) and extractFrom(Object),
+					// should resolve the more specific typed overload, not fall back to Object
+					var clazzz = getDynamicInvokerClazz( class1 );
+					var method = clazzz.getMethod( "extractFrom", [ foreignArg ], true, true, true );
+					expect( method ).notToBeNull();
 
-					// create an instance from cl2 to use as a constructor arg
+					// verify it picked the typed overload by checking param type
+					var paramTypes = method.getArgumentClasses();
+					expect( paramTypes[ 1 ].getName() ).toBe( "LDEV6226Helper",
+						"should pick extractFrom(LDEV6226Helper) not extractFrom(Object)" );
+				});
+			});
+
+			it( "Clazz.getConstructor resolves with cross-classloader arguments", function() {
+				withCrossClassLoaders( function( class1, class2 ) {
 					var foreignArg = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ])
 						.newInstance([ "ctor-test" ]);
 
-					// resolve constructor on class1 with a cross-classloader argument
 					var clazzz = getDynamicInvokerClazz( class1 );
 					var ctor = clazzz.getConstructor( [ foreignArg ], true, true, javaCast( "null", "" ) );
 					expect( ctor ).notToBeNull();
-				}
-				finally {
-					cl1.close();
-					cl2.close();
-				}
+				});
+			});
+
+			it( "Reflector.like matches cross-classloader types", function() {
+				withCrossClassLoaders( function( class1, class2 ) {
+					var Reflector = createObject( "java", "lucee.runtime.reflection.Reflector" );
+					expect( Reflector.like( class2, class1 ) ).toBeTrue(
+						"Reflector.like() should match same class from different classloaders"
+					);
+				});
+			});
+
+			it( "Reflector.convert handles cross-classloader types", function() {
+				withCrossClassLoaders( function( class1, class2 ) {
+					var obj = class2.getConstructor([ createObject( "java", "java.lang.String" ).getClass() ])
+						.newInstance([ "convert-test" ]);
+
+					// convert() should recognise obj as compatible with class1's type
+					var Reflector = createObject( "java", "lucee.runtime.reflection.Reflector" );
+					var result = Reflector.convert( obj, class1, javaCast( "null", "" ) );
+					expect( result ).notToBeNull();
+				});
 			});
 
 		});


### PR DESCRIPTION
## Summary

Fixes intermittent `NoSuchMethodException` when calling Java methods from CFML after OSGi bundle refresh.

- https://luceeserver.atlassian.net/browse/LDEV-6226
- https://dev.lucee.org/t/lucee-6-2-6-19-rc-available-for-testing/17178/6

## Root Cause

`Clazz.getMethod()` and `Clazz.getConstructor()` Phase 1 matching uses `Class.isAssignableFrom()` which does strict class identity comparison. When a Java object is persisted in a long-lived scope (e.g. `variables.sfnClient`) and an OSGi bundle refreshes overnight, the persisted object's class is from the old classloader while newly created arguments are from the new classloader. Same class name, different classloader = `isAssignableFrom` returns false = method not found.

`ClazzDynamic` caches by `Class` object (not name), so a new classloader gets a fresh cache entry — the cache itself is not the problem. The issue is purely in the type comparison during method resolution.

## Fix

In `Clazz.java`, both `getMethod()` and `getConstructor()` Phase 1: try `isAssignableFrom` first (zero cost for the common same-classloader case), fall back to `Reflector.isInstaneOf(argClass, paramClass, false)` which does name-based comparison with superclass/interface hierarchy walking. This method already exists and is used elsewhere in Lucee.

## Known Limitation

Method **resolution** is fixed, but the **invocation** path still has issues for this scenario:

1. ASM-generated wrapper emits `CHECKCAST` using old classloader types → `ClassCastException`
2. `MethodInstance` catches this and falls back to `Method.invoke()`, which also rejects cross-classloader args → `IllegalArgumentException`
3. This is a hard JVM constraint — class identity is enforced at every invocation level

User-level mitigation: don't persist Java objects across bundle refreshes (recreate clients periodically or on error).

## Test plan

- [x] `LDEV6226.cfc` — compiles a Java class to two separate dirs, loads each from an isolated URLClassLoader, verifies:
  - `isAssignableFrom` fails across classloaders but `Reflector.isInstaneOf` with `exactMatch=false` works
  - `Clazz.getMethod()` finds methods despite cross-classloader argument types