### PR TITLE
LDEV-6274 debugger: fix breakpoints and stack frames for cfinclude from UDF

### DIFF
--- a/core/src/main/java/lucee/runtime/PageContextImpl.java
+++ b/core/src/main/java/lucee/runtime/PageContextImpl.java
@@ -1090,6 +1090,9 @@ public final class PageContextImpl extends PageContext {
 			DebugEntryTemplate debugEntry = debugger.getEntry(this, currentPage.getPageSource());
 			try {
 				addPageSource(currentPage.getPageSource(), true);
+				if (ConfigImpl.DEBUGGER) {
+					debuggerFrames.add(new DebuggerFrame(getTopmostDebuggerFrame(), currentPage.getPageSource()));
+				}
 				debugEntry.updateFileLoadTime((System.nanoTime() - time));
 				exeTime = System.nanoTime();
 				currentPage.call(this);
@@ -1113,6 +1116,9 @@ public final class PageContextImpl extends PageContext {
 				long diff = ((System.nanoTime() - exeTime) - (executionTime - currTime));
 				executionTime += (System.nanoTime() - time);
 				debugEntry.updateExeTime(diff);
+				if (ConfigImpl.DEBUGGER && !debuggerFrames.isEmpty()) {
+					debuggerFrames.removeLast();
+				}
 				removeLastPageSource(true);
 			}
 		}
@@ -1122,6 +1128,9 @@ public final class PageContextImpl extends PageContext {
 			if (runOnce && includeOnce.contains(currentPage.getPageSource())) return;
 			try {
 				addPageSource(currentPage.getPageSource(), true);
+				if (ConfigImpl.DEBUGGER) {
+					debuggerFrames.add(new DebuggerFrame(getTopmostDebuggerFrame(), currentPage.getPageSource()));
+				}
 				currentPage.call(this);
 			}
 			catch (Throwable t) {
@@ -1137,6 +1146,9 @@ public final class PageContextImpl extends PageContext {
 			}
 			finally {
 				includeOnce.add(currentPage.getPageSource());
+				if (ConfigImpl.DEBUGGER && !debuggerFrames.isEmpty()) {
+					debuggerFrames.removeLast();
+				}
 				removeLastPageSource(true);
 			}
 		}
@@ -3524,6 +3536,9 @@ public final class PageContextImpl extends PageContext {
 	 * inspect variables in any frame, not just the current one.
 	 */
 	public static final class DebuggerFrame {
+		public enum Kind { UDF, INCLUDE }
+
+		public final Kind kind;
 		public final Local local;
 		public final Argument arguments;
 		public final Variables variables;
@@ -3532,6 +3547,7 @@ public final class PageContextImpl extends PageContext {
 		private volatile int line;
 
 		DebuggerFrame(Local local, Argument arguments, Variables variables, PageSource pageSource, String functionName) {
+			this.kind = Kind.UDF;
 			this.local = local;
 			this.arguments = arguments;
 			this.variables = variables;
@@ -3540,6 +3556,17 @@ public final class PageContextImpl extends PageContext {
 			this.line = 0;
 		}
 
+		DebuggerFrame(DebuggerFrame enclosing, PageSource pageSource) {
+			this.kind = Kind.INCLUDE;
+			this.local = enclosing != null ? enclosing.local : null;
+			this.arguments = enclosing != null ? enclosing.arguments : null;
+			this.variables = enclosing != null ? enclosing.variables : null;
+			this.pageSource = pageSource;
+			this.functionName = null;
+			this.line = 0;
+		}
+
+		public Kind getKind() { return kind; }
 		public int getLine() { return line; }
 		public void setLine(int line) { this.line = line; }
 		public String getFile() { return pageSource != null ? pageSource.getDisplayPath() : null; }

--- a/core/src/main/java/lucee/runtime/engine/DebuggerExecutionLog.java
+++ b/core/src/main/java/lucee/runtime/engine/DebuggerExecutionLog.java
@@ -2,7 +2,6 @@ package lucee.runtime.engine;
 
 import java.util.Map;
 
-import lucee.commons.io.res.Resource;
 import lucee.runtime.PageContext;
 import lucee.runtime.PageContextImpl;
 import lucee.runtime.PageSource;
@@ -61,23 +60,19 @@ public final class DebuggerExecutionLog implements ExecutionLogPro {
 		DebuggerListener listener = DebuggerRegistry.getListener();
 		if (listener == null || !listener.isClientConnected()) return;
 
-		// Get file from debugger frame if available, otherwise from current page source
+		// Always resolve file from pathList - it correctly tracks cfinclude boundaries.
+		// Frames only supply defining file, which goes stale when a UDF cfincludes a template.
+		// getDisplayPath() is cached on PageSourceImpl and matches the DebuggerListener contract.
 		String file = null;
+		PageSource ps = pci.getCurrentPageSource(null);
+		if (ps != null) file = ps.getDisplayPath();
+
 		PageContextImpl.DebuggerFrame frame = pci.getTopmostDebuggerFrame();
 		if (frame != null) {
 			frame.setLine(line);
-			file = frame.getFile();
 		}
 		else {
-			// Top-level code (outside functions) - get file from page source
-			PageSource ps = pci.getCurrentPageSource(null);
-			if (ps != null) {
-				Resource res = ps.getPhyscalFile();
-				if (res != null) {
-					file = res.getAbsolutePath();
-				}
-			}
-			// Store in thread-local for breakpoint() to use
+			// Top-level code (outside functions) - store in thread-local for breakpoint() to use
 			currentTopLevelFile.set(file);
 			int[] lineHolder = currentTopLevelLine.get();
 			if (lineHolder == null) {


### PR DESCRIPTION
[LDEV-6274](https://luceeserver.atlassian.net/browse/LDEV-6274)

Two bugs in the 7.1 native debugger path, same reproduction (front-controller apps that `cfinclude` from `onRequest` / `onError` / util UDFs):

1. Breakpoints set inside the included file never fire — `DebuggerExecutionLog` matched against the UDF's *defining* file, not the currently-executing one. Resolved by reading the current file from `pci.getCurrentPageSource(null)` (pathList) instead of `frame.getFile()`.
2. Stack frame `source.path` pointed at the UDF's defining file instead of the included file — `cfinclude` didn't push its own debugger frame. Introduced `DebuggerFrame.Kind { UDF, INCLUDE }` and a push/pop in `PageContextImpl._doInclude` (both debug and no-debug branches). INCLUDE frames borrow scope references from the enclosing UDF, since included code runs in the caller's scope.

Affects every `_doInclude` path from inside a UDF: `cfinclude`, `cfmodule`, custom tags.

Hot-path gated with `if (ConfigImpl.DEBUGGER)` so the disabled branch is JIT-elided — zero overhead when the debugger flag is off.

## Test plan

- [x] `ant fast` clean
- [x] Extension CI (luceedebug) run `24626790364` green on agent 6.2, 7.0, and native 7.1
- [x] Breakpoints fire inside included files for onRequest / onRequestStart / onError / plain UDF cfinclude scenarios
- [x] Stack top reports the included file for cfinclude, cfmodule, and nested (depth 2) includes
- [x] Regression guard: breakpoint on the `include template=` line inside a UDF body still reports the UDF file as top frame
- [x] Step-over across a cfinclude boundary stays in the included file

## Companion extension work

Extension-side `NativeDebugFrame` reads `DebuggerFrame.kind` via reflection and renders INCLUDE frames with the included file's basename. Lands on `lucee/extension-debugger`; `luceeCoreVersion` pom bump pending the next 7.1 snapshot.

https://github.com/lucee/extension-debugger/pull/3

[LDEV-6274]: https://luceeserver.atlassian.net/browse/LDEV-6274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ