### PR TITLE
LDEV-6278 parse maven version ranges with metadata-driven resolution

### DIFF
--- a/core/src/main/java/lucee/runtime/mvn/MavenMetadataReader.java
+++ b/core/src/main/java/lucee/runtime/mvn/MavenMetadataReader.java
@@ -1,0 +1,271 @@
+/*
+ * Fetches and parses maven-metadata.xml for the runtime maven resolver.
+ *
+ * Intentionally separate from lucee.runtime.config.maven.MetadataReader —
+ * same XML format, same URL convention, but different ownership and
+ * different caching story:
+ *
+ *   - config.maven.MetadataReader is for the EXTENSION UPDATE provider:
+ *     it asks "which versions of lucee.jira:s3-extension exist?" so the
+ *     admin UI can offer updates. It's tied to MavenUpdateProvider's
+ *     Repository type (separate class) and its own cacheDirectory layout.
+ *
+ *   - This class (lucee.runtime.mvn.MavenMetadataReader) is for the
+ *     POM RESOLVER: when a transitive POM declares a version RANGE like
+ *     [2.2,3), we need to enumerate available versions of that coord to
+ *     pick the highest in range. It uses this package's own Repository
+ *     type and the standard mvn/{groupId}/{artifactId}/ cache layout,
+ *     with a .lastUpdated marker that matches how POMs/JARs are cached.
+ *
+ * Deliberate duplication — ~80 LOC here is worth keeping the extension
+ * update path and the dep resolver path decoupled.
+ */
+package lucee.runtime.mvn;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+import lucee.commons.io.IOUtil;
+import lucee.commons.io.SystemUtil;
+import lucee.commons.io.log.Log;
+import lucee.commons.io.res.Resource;
+import lucee.commons.net.http.HTTPDownloader;
+import lucee.runtime.text.xml.XMLUtil;
+
+/**
+ * Reads available versions of a given {@code groupId:artifactId} from
+ * the configured maven repositories' {@code maven-metadata.xml} files.
+ *
+ * Results are cached under {@code {mvnDir}/{group}/{artifact}/
+ * maven-metadata.xml} with a sibling {@code .lastUpdated} marker.
+ * Two TTLs apply:
+ *
+ * <ul>
+ * <li>Cache file present and marker fresh (within
+ * {@link MavenUtil#METADATA_CACHE_DURATION}, default 24h) → local parse
+ * returned.</li>
+ * <li>Cache file absent but marker fresh (within
+ * {@link MavenUtil#ARTIFACT_UNAVAILABLE_CACHE_DURATION}, default 15min)
+ * → negative hit, empty list returned (previous fetch failed; don't
+ * re-hammer the repos).</li>
+ * <li>Marker stale or absent → fetch each repo in order, write cache
+ * on success, write marker-only on failure.</li>
+ * <li>All repos fail but a stale cache exists → parse stale and reset
+ * the marker (yesterday's version list beats a hard failure).</li>
+ * </ul>
+ *
+ * <h3>Known limitation: first-successful-repo-wins</h3>
+ *
+ * The repo loop returns on the first parseable {@code maven-metadata.xml}.
+ * For releases on Central this is correct (Central is authoritative).
+ * For a coord served as a release by one repo and as a newer snapshot by
+ * another (e.g. Sonatype snapshots), the snapshot is invisible because
+ * the first repo's metadata is returned unmerged. A proper fix would
+ * union version lists across repos and let {@link MavenVersionRange#pickHighest}
+ * pick from the merged set; tracked under the snapshot work in the
+ * maven-lite epic.
+ */
+public final class MavenMetadataReader {
+
+	/** Connect + read timeouts for the metadata fetch. */
+	private static final int CONNECTION_TIMEOUT = POM.CONNECTION_TIMEOUT;
+	private static final int READ_TIMEOUT = POM.READ_TIMEOUT_GET;
+
+	private static final String METADATA_FILENAME = "maven-metadata.xml";
+	private static final String LAST_UPDATED_SUFFIX = ".lastUpdated";
+
+	private MavenMetadataReader() {
+		// static-only
+	}
+
+	/**
+	 * Lists versions present under {@code {mvnDir}/{group}/{artifact}/}
+	 * as subdirectories — each represents a version that has been
+	 * successfully installed at some point (the directory only exists
+	 * after a successful download). Used as a zero-HTTP candidate source
+	 * by {@link MavenUtil#resolveVersionRange(Resource, String, String, String, Collection, Log)}:
+	 * if a locally-cached version already satisfies the range, no metadata
+	 * fetch is needed and resolution works offline.
+	 *
+	 * @return version strings (directory names) — may be empty, never null.
+	 */
+	public static List<String> listLocalVersions(Resource mvnDir, String groupId, String artifactId) {
+		Resource artifactDir = mvnDir.getRealResource(groupId.replace('.', '/') + '/' + artifactId);
+		List<String> versions = new ArrayList<>();
+		if (!artifactDir.isDirectory()) return versions;
+		Resource[] children = artifactDir.listResources();
+		if (children == null) return versions;
+		for (Resource child: children) {
+			if (child.isDirectory()) versions.add(child.getName());
+		}
+		return versions;
+	}
+
+	/**
+	 * Returns the available versions of {@code groupId:artifactId}, using
+	 * a local {@code maven-metadata.xml} cache when fresh and falling
+	 * through to HTTP when not.
+	 *
+	 * @param mvnDir {@code mvn/} root where cache files live
+	 * @return list of version strings in document order, or an empty list
+	 *         if no repository returned a parseable metadata file.
+	 */
+	public static List<String> fetchAvailableVersions(Resource mvnDir, String groupId, String artifactId, Collection<Repository> repositories, Log log) throws IOException {
+		Resource artifactDir = mvnDir.getRealResource(groupId.replace('.', '/') + '/' + artifactId);
+		Resource cache = artifactDir.getRealResource(METADATA_FILENAME);
+		Resource marker = artifactDir.getRealResource(METADATA_FILENAME + LAST_UPDATED_SUFFIX);
+
+		if (marker.isFile()) {
+			long age = System.currentTimeMillis() - marker.lastModified();
+			if (cache.isFile()) {
+				// positive cache — metadata churn is slow, use the longer TTL
+				if (age < MavenUtil.METADATA_CACHE_DURATION) {
+					try {
+						return parse(cache);
+					}
+					catch (Exception e) {
+						if (log != null) log.debug("maven", "local maven-metadata.xml unreadable for " + groupId + ":" + artifactId + ", refetching: " + e.getMessage());
+						// fall through to HTTP
+					}
+				}
+			}
+			else if (age < MavenUtil.ARTIFACT_UNAVAILABLE_CACHE_DURATION) {
+				// negative cache hit — recent fetch failed for all repos, don't retry yet
+				return new ArrayList<>();
+			}
+		}
+
+		MavenUtil.assertDownloadAllowed("maven-metadata.xml for " + groupId + ":" + artifactId);
+
+		String path = groupId.replace('.', '/') + '/' + artifactId + "/" + METADATA_FILENAME;
+		for (Repository repo: repositories) {
+			try {
+				URL url = new URL(joinUrl(repo.getUrl(), path));
+				downloadToCache(url, cache, log);
+				touchMarker(marker);
+				return parse(cache);
+			}
+			catch (Exception e) {
+				if (log != null) log.debug("maven", "metadata fetch failed for " + groupId + ":" + artifactId + " at " + repo.getUrl() + ": " + e.getMessage());
+			}
+		}
+
+		// All repos failed. Prefer a stale-but-present cache over nothing:
+		// yesterday's version list beats "cannot resolve" for an install
+		// that just needs *a* satisfying version. Reset the marker so we
+		// don't hammer the repos again for the duration of the TTL.
+		if (cache.isFile()) {
+			try {
+				List<String> stale = parse(cache);
+				if (log != null) log.info("maven", "all repos failed for " + groupId + ":" + artifactId + ", using stale local cache (" + stale.size() + " versions)");
+				touchMarker(marker);
+				return stale;
+			}
+			catch (Exception e) {
+				if (log != null) log.debug("maven", "stale cache unreadable for " + groupId + ":" + artifactId + ": " + e.getMessage());
+			}
+		}
+
+		// No cache, no network — negative cache so we don't retry for TTL.
+		touchMarker(marker);
+		return new ArrayList<>();
+	}
+
+	private static void touchMarker(Resource marker) {
+		try {
+			Resource parent = marker.getParentResource();
+			if (!parent.isDirectory()) parent.createDirectory(true);
+			IOUtil.write(marker, String.valueOf(System.currentTimeMillis()), lucee.commons.io.CharsetUtil.UTF8, false);
+		}
+		catch (IOException ignore) {
+			// best effort — next call will simply refetch
+		}
+	}
+
+	private static void downloadToCache(URL url, Resource cache, Log log) throws IOException, java.security.GeneralSecurityException {
+		InputStream is = null;
+		Resource tmp = SystemUtil.getTempFile("xml", false);
+		try {
+			is = HTTPDownloader.get(url, null, null, CONNECTION_TIMEOUT, READ_TIMEOUT, null, log == null ? Log.LEVEL_INFO : Log.LEVEL_TRACE);
+			IOUtil.copy(is, tmp, false);
+			Resource parent = cache.getParentResource();
+			if (!parent.isDirectory()) parent.createDirectory(true);
+			if (cache.isFile()) cache.remove(true);
+			tmp.moveTo(cache);
+		}
+		finally {
+			IOUtil.closeEL(is);
+		}
+	}
+
+	private static List<String> parse(Resource cache) throws IOException, SAXException {
+		Reader r = null;
+		try {
+			r = IOUtil.getReader(cache.getInputStream(), (Charset) null);
+			Handler h = new Handler();
+			XMLReader xr = XMLUtil.createXMLReader();
+			xr.setContentHandler(h);
+			xr.setErrorHandler(h);
+			xr.parse(new InputSource(r));
+			return h.versions;
+		}
+		finally {
+			IOUtil.closeEL(r);
+		}
+	}
+
+	private static String joinUrl(String base, String path) {
+		if (base.endsWith("/")) return base + path;
+		return base + "/" + path;
+	}
+
+	/**
+	 * SAX handler extracting {@code /metadata/versioning/versions/version} text.
+	 */
+	private static final class Handler extends DefaultHandler {
+		private final List<String> versions = new ArrayList<>();
+		private final StringBuilder content = new StringBuilder();
+		private int depth = 0;
+		private boolean insideVersions = false;
+		private boolean insideVersion = false;
+
+		@Override
+		public void startElement(String uri, String name, String qName, Attributes atts) {
+			depth++;
+			// path: metadata(1) > versioning(2) > versions(3) > version(4)
+			if (depth == 3 && "versions".equalsIgnoreCase(qName)) insideVersions = true;
+			else if (depth == 4 && insideVersions && "version".equalsIgnoreCase(qName)) {
+				insideVersion = true;
+				content.setLength(0);
+			}
+		}
+
+		@Override
+		public void endElement(String uri, String name, String qName) {
+			if (insideVersion && depth == 4 && "version".equalsIgnoreCase(qName)) {
+				String v = content.toString().trim();
+				if (!v.isEmpty()) versions.add(v);
+				insideVersion = false;
+			}
+			else if (depth == 3 && "versions".equalsIgnoreCase(qName)) insideVersions = false;
+			depth--;
+		}
+
+		@Override
+		public void characters(char[] ch, int start, int length) {
+			if (insideVersion) content.append(ch, start, length);
+		}
+	}
+}

--- a/core/src/main/java/lucee/runtime/mvn/MavenUtil.java
+++ b/core/src/main/java/lucee/runtime/mvn/MavenUtil.java
@@ -65,6 +65,13 @@ public final class MavenUtil {
 	public static final int READ_TIMEOUT_HEAD = 5000;
 	public static final int READ_TIMEOUT_GET = 5000;
 	public static final long ARTIFACT_UNAVAILABLE_CACHE_DURATION = Caster.toLongValue(SystemUtil.getSystemPropOrEnvVar("lucee.maven.negative.cache.duration", null), 60000L * 15L);
+	/**
+	 * TTL for positive {@code maven-metadata.xml} caching in the runtime
+	 * resolver. Default 24h matches maven's own {@code updatePolicy=daily}
+	 * convention — metadata churn is slow, stale-for-a-day is cheap, and
+	 * admins can tune via {@code lucee.maven.metadata.cache.duration}.
+	 */
+	public static final long METADATA_CACHE_DURATION = Caster.toLongValue(SystemUtil.getSystemPropOrEnvVar("lucee.maven.metadata.cache.duration", null), 60000L * 60L * 24L);
 
 	private static final DateTimeFormatter MAVEN_DATE_FORMATTER = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH);
 
@@ -226,10 +233,7 @@ public final class MavenUtil {
 			}
 		}
 
-		// PATCH TODO better solution for this
-		if (v != null && v.startsWith("[")) {
-			v = v.substring(1, v.indexOf(','));
-		}
+		v = resolveVersionRange(localDirectory, g, a, v, current.getRepositories(), log);
 
 		// optional
 		String o = rd.optional;
@@ -575,23 +579,10 @@ public final class MavenUtil {
 						//////// if (log != null) log.info("maven", "download [" + url + "]");
 						URL url;
 						CloseableHttpClient httpClient;
-						int policy = CFMLEngineImpl.getActiveDownloadPolicy();
+						assertDownloadAllowed("artifact [" + pom.getGroupId() + ":" + pom.getArtifactId() + ":" + pom.getVersion() + "] (type: " + type + ")");
 						for (Repository r: sort(repositories)) {
 							url = null;
 							httpClient = null;
-							if (policy == CFMLEngineImpl.MAVEN_DOWNLOAD_POLICY_ERROR) {
-								throw new IOException("Lucee is unable to resolve the Maven artifact [" + pom.getGroupId() + ":" + pom.getArtifactId() + ":" + pom.getVersion()
-										+ "] " + "(type: " + type + ") because Maven downloads are blocked by policy. "
-										+ "To allow downloads, set the system property or environment variable " + "'lucee.maven.download.policy' to 'warn' or 'ignore'. ");
-							}
-							else if (policy == CFMLEngineImpl.MAVEN_DOWNLOAD_POLICY_WARN) {
-								LogUtil.log(CFMLEngineImpl.MAVEN_DOWNLOAD_POLICY_LOG_LEVEL, "maven",
-										"Downloading Maven artifact [" + pom.getGroupId() + ":" + pom.getArtifactId() + ":" + pom.getVersion() + "] " + "(type: " + type
-												+ "). Maven download policy is set to 'warn'. "
-												+ "Set the system property or environment variable 'lucee.maven.download.policy' to "
-												+ "'error' to block downloads or 'ignore' to suppress this warning.");
-							}
-
 							try {
 								url = new URL(r.getUrl() + scriptName);
 								httpClient = HttpClients.createDefault();
@@ -665,6 +656,30 @@ public final class MavenUtil {
 			}
 		}
 		return res;
+	}
+
+	/**
+	 * Enforces the maven download policy. Throws {@link IOException} when
+	 * the active policy is {@link CFMLEngineImpl#MAVEN_DOWNLOAD_POLICY_ERROR},
+	 * logs a warning when {@link CFMLEngineImpl#MAVEN_DOWNLOAD_POLICY_WARN},
+	 * silent on {@code IGNORE}. Check once before entering a per-repo loop.
+	 *
+	 * @param what short identifier of what is being downloaded — interpolated
+	 *             into both the exception and warn messages, e.g.
+	 *             {@code "artifact [g:a:v] (type: jar)"} or
+	 *             {@code "maven-metadata.xml for g:a"}.
+	 */
+	static void assertDownloadAllowed(String what) throws IOException {
+		int policy = CFMLEngineImpl.getActiveDownloadPolicy();
+		if (policy == CFMLEngineImpl.MAVEN_DOWNLOAD_POLICY_ERROR) {
+			throw new IOException("Maven download for " + what + " is blocked by policy. "
+					+ "To allow downloads, set the system property or environment variable 'lucee.maven.download.policy' to 'warn' or 'ignore'.");
+		}
+		if (policy == CFMLEngineImpl.MAVEN_DOWNLOAD_POLICY_WARN) {
+			LogUtil.log(CFMLEngineImpl.MAVEN_DOWNLOAD_POLICY_LOG_LEVEL, "maven",
+					"Downloading " + what + ". Maven download policy is set to 'warn'. "
+							+ "Set 'lucee.maven.download.policy' to 'error' to block downloads or 'ignore' to suppress this warning.");
+		}
 	}
 
 	private static StringBuilder createInfo() {
@@ -753,6 +768,102 @@ public final class MavenUtil {
 		if (rtn > 0) return rtn;
 
 		return defaultValue;
+	}
+
+	/**
+	 * Resolves a maven version spec to a concrete version string.
+	 *
+	 * Uses {@link MavenVersionRange} to parse the spec properly. Without
+	 * access to {@code maven-metadata.xml} we can only return a single
+	 * version for bare/pinned specs and for bracketed ranges with an
+	 * inclusive lower bound — see {@link MavenVersionRange#bestEffortSingleVersion()}.
+	 *
+	 * Ranges with exclusive lower bounds, open lowers, wildcards, or
+	 * unions fall back to the raw spec string (same as the previous hack)
+	 * and will fail at download time. That fallback goes away once the
+	 * resolver fetches {@code maven-metadata.xml} and we can call
+	 * {@link MavenVersionRange#pickHighest(java.util.List)}.
+	 */
+	public static String resolveVersionRange(String v) {
+		if (v == null || v.isEmpty()) return v;
+		try {
+			MavenVersionRange range = new MavenVersionRange(v);
+			String best = range.bestEffortSingleVersion();
+			if (best != null) return best;
+		}
+		catch (IllegalArgumentException iae) {
+			// unparseable — fall through to raw spec, caller will fail loudly downstream
+		}
+		return v;
+	}
+
+	/**
+	 * Full-context range resolution. When the spec can't be answered from
+	 * the parse alone (bracketed ranges with exclusive bounds, wildcards,
+	 * unions), fetch {@code maven-metadata.xml} for the given coordinate
+	 * (or load it from {@code localDirectory} if a fresh cached copy
+	 * exists — see {@link MavenMetadataReader}) and call
+	 * {@link MavenVersionRange#pickHighest(java.util.List)} to return the
+	 * highest available version that satisfies the range.
+	 *
+	 * Throws {@link IOException} if the spec demands metadata and either
+	 * no repository returns a parseable metadata file, or none of the
+	 * returned versions satisfy the range. Falling through to the raw
+	 * spec at this point would produce a download URL containing the
+	 * literal range (e.g. {@code .../jaxb-api/[2.2,3)/jaxb-api-[2.2,3).jar})
+	 * which 404s with no trace of the real cause.
+	 *
+	 * Unparseable specs still fall through to the raw string — the 1-arg
+	 * form behaves the same and this matches legacy behaviour for malformed
+	 * input.
+	 */
+	public static String resolveVersionRange(Resource localDirectory, String groupId, String artifactId, String v, Collection<Repository> repositories, Log log) throws IOException {
+		if (v == null || v.isEmpty()) return v;
+		MavenVersionRange range;
+		try {
+			range = new MavenVersionRange(v);
+		}
+		catch (IllegalArgumentException iae) {
+			return v;
+		}
+		String best = range.bestEffortSingleVersion();
+		if (best != null) return best;
+
+		// Local-first: previously-installed versions already on disk are
+		// the cheapest candidate source — no HTTP, works offline.
+		List<String> local = MavenMetadataReader.listLocalVersions(localDirectory, groupId, artifactId);
+		MavenVersion picked = range.pickHighest(local);
+		if (picked != null) {
+			if (log != null) log.debug("maven", "resolved range [" + v + "] to " + picked + " from local versions for " + groupId + ":" + artifactId);
+			return picked.asString();
+		}
+
+		// Nothing local satisfies the range — fetch metadata (or load from
+		// cached xml) and pick from the published list.
+		List<String> available = MavenMetadataReader.fetchAvailableVersions(localDirectory, groupId, artifactId, repositories, log);
+		if (available.isEmpty()) {
+			throw new IOException("cannot resolve version range [" + v + "] for " + groupId + ":" + artifactId
+					+ " — no maven-metadata.xml available from repositories " + repoUrls(repositories));
+		}
+		picked = range.pickHighest(available);
+		if (picked == null) {
+			throw new IOException("cannot resolve version range [" + v + "] for " + groupId + ":" + artifactId
+					+ " — no available version matches (candidates=" + available + ")");
+		}
+		if (log != null) log.debug("maven", "resolved range [" + v + "] to " + picked + " for " + groupId + ":" + artifactId);
+		return picked.asString();
+	}
+
+	private static String repoUrls(Collection<Repository> repositories) {
+		if (repositories == null || repositories.isEmpty()) return "[]";
+		StringBuilder sb = new StringBuilder("[");
+		boolean first = true;
+		for (Repository r: repositories) {
+			if (!first) sb.append(", ");
+			sb.append(r.getUrl());
+			first = false;
+		}
+		return sb.append(']').toString();
 	}
 
 	public static int toScope(String scope, int defaultValue) {

--- a/core/src/main/java/lucee/runtime/mvn/MavenVersion.java
+++ b/core/src/main/java/lucee/runtime/mvn/MavenVersion.java
@@ -1,0 +1,361 @@
+/*
+ * Maven version parsing and comparison for Lucee.
+ *
+ * The tokenisation + comparison algorithm here is ported from Apache
+ * Maven Resolver's GenericVersion (maven-resolver-util 2.0.16), which
+ * is licensed under the Apache License, Version 2.0:
+ *
+ *   https://github.com/apache/maven-resolver/blob/maven-resolver-2.0.16/
+ *     maven-resolver-util/src/main/java/org/eclipse/aether/util/version/
+ *     GenericVersion.java
+ *
+ * Maven version semantics are subtle enough that this is effectively
+ * the only correct implementation — we port it rather than reinvent.
+ * See test/general/MavenVersionParsing.cfc for the validation corpus.
+ */
+package lucee.runtime.mvn;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * A maven version, tokenised into comparable segments.
+ *
+ * Parses any input string using the canonical maven rules:
+ * delimiters <code>.</code>/<code>-</code>/<code>_</code> separate
+ * segments; digit/letter transitions also separate; leading zeros
+ * stripped from numbers; well-known qualifier names
+ * (alpha, beta, milestone, rc, cr, snapshot, ga, final, release, sp)
+ * get fixed ranks; <code>min</code>/<code>max</code> at end-of-string
+ * are sentinels below/above everything.
+ */
+public final class MavenVersion implements Comparable<MavenVersion> {
+
+	private final String version;
+	private final List<Item> items;
+
+	public MavenVersion(String version) {
+		if (version == null) throw new IllegalArgumentException("version cannot be null");
+		this.version = version;
+		List<Item> list = new ArrayList<>();
+		for (Tokenizer t = new Tokenizer(version); t.next();) {
+			list.add(t.toItem());
+		}
+		trimPadding(list);
+		this.items = Collections.unmodifiableList(list);
+	}
+
+	public String asString() {
+		return version;
+	}
+
+	public List<Item> asItems() {
+		return items;
+	}
+
+	/**
+	 * True if any segment is a pre-release qualifier (alpha, beta,
+	 * milestone, rc/cr, snapshot). Used by range resolution to exclude
+	 * pre-releases from {@link MavenVersionRange#pickHighest(List)} unless
+	 * the range spec itself names a pre-release bound.
+	 */
+	public boolean isPreRelease() {
+		for (Item it: items) {
+			if (it.kind == Item.KIND_QUALIFIER && ((Integer) it.value).intValue() < 0) return true;
+		}
+		return false;
+	}
+
+	// -------------------------------------------------------------------
+	// Padding trim (visible for testing)
+	// -------------------------------------------------------------------
+
+	static void trimPadding(List<Item> items) {
+		Boolean number = null;
+		int end = items.size() - 1;
+		for (int i = end; i > 0; i--) {
+			Item item = items.get(i);
+			if (!Boolean.valueOf(item.isNumber()).equals(number)) {
+				end = i;
+				number = item.isNumber();
+			}
+			if (end == i && (i == items.size() - 1 || items.get(i - 1).isNumber() == item.isNumber()) && item.compareTo(null) == 0) {
+				items.remove(i);
+				end--;
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// Comparison
+	// -------------------------------------------------------------------
+
+	@Override
+	public int compareTo(MavenVersion obj) {
+		final List<Item> these = items;
+		final List<Item> those = obj.items;
+		boolean number = true;
+
+		for (int index = 0;; index++) {
+			if (index >= these.size() && index >= those.size()) return 0;
+			if (index >= these.size()) return -comparePadding(those, index, null);
+			if (index >= those.size()) return comparePadding(these, index, null);
+
+			Item thisItem = these.get(index);
+			Item thatItem = those.get(index);
+
+			if (thisItem.isNumber() != thatItem.isNumber()) {
+				if (index == 0) return thisItem.compareTo(thatItem);
+				if (number == thisItem.isNumber()) return comparePadding(these, index, number);
+				return -comparePadding(those, index, number);
+			}
+			int rel = thisItem.compareTo(thatItem);
+			if (rel != 0) return rel;
+			number = thisItem.isNumber();
+		}
+	}
+
+	private static int comparePadding(List<Item> items, int index, Boolean number) {
+		int rel = 0;
+		for (int i = index; i < items.size(); i++) {
+			Item item = items.get(i);
+			if (number != null && number != item.isNumber()) continue;
+			rel = item.compareTo(null);
+			if (rel != 0) break;
+		}
+		return rel;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return o instanceof MavenVersion && compareTo((MavenVersion) o) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return items.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return version;
+	}
+
+	// -------------------------------------------------------------------
+	// Tokenizer — state machine over the version string
+	// -------------------------------------------------------------------
+
+	static final class Tokenizer {
+
+		private static final Integer QUALIFIER_ALPHA = Integer.valueOf(-5);
+		private static final Integer QUALIFIER_BETA = Integer.valueOf(-4);
+		private static final Integer QUALIFIER_MILESTONE = Integer.valueOf(-3);
+
+		private static final Map<String, Integer> QUALIFIERS = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		static {
+			QUALIFIERS.put("alpha", QUALIFIER_ALPHA);
+			QUALIFIERS.put("beta", QUALIFIER_BETA);
+			QUALIFIERS.put("milestone", QUALIFIER_MILESTONE);
+			QUALIFIERS.put("cr", Integer.valueOf(-2));
+			QUALIFIERS.put("rc", Integer.valueOf(-2));
+			QUALIFIERS.put("snapshot", Integer.valueOf(-1));
+			QUALIFIERS.put("ga", Integer.valueOf(0));
+			QUALIFIERS.put("final", Integer.valueOf(0));
+			QUALIFIERS.put("release", Integer.valueOf(0));
+			QUALIFIERS.put("", Integer.valueOf(0));
+			QUALIFIERS.put("sp", Integer.valueOf(1));
+		}
+
+		private final String version;
+		private final int versionLength;
+		private int index;
+		private String token;
+		private boolean number;
+		private boolean terminatedByNumber;
+
+		Tokenizer(String version) {
+			this.version = version.isEmpty() ? "0" : version;
+			this.versionLength = this.version.length();
+		}
+
+		public boolean next() {
+			if (index >= versionLength) return false;
+
+			int state = -2;
+			int start = index;
+			int end = versionLength;
+			terminatedByNumber = false;
+
+			for (; index < versionLength; index++) {
+				char c = version.charAt(index);
+
+				if (c == '.' || c == '-' || c == '_') {
+					end = index;
+					index++;
+					break;
+				}
+				if (c >= '0' && c <= '9') {
+					int digit = c - '0';
+					if (state == -1) {
+						end = index;
+						terminatedByNumber = true;
+						break;
+					}
+					if (state == 0) {
+						// strip leading zeros
+						start++;
+					}
+					state = (state > 0 || digit > 0) ? 1 : 0;
+				}
+				else {
+					if (state >= 0) {
+						end = index;
+						break;
+					}
+					state = -1;
+				}
+			}
+
+			if (end - start > 0) {
+				token = version.substring(start, end);
+				number = state >= 0;
+			}
+			else {
+				token = "0";
+				number = true;
+			}
+			return true;
+		}
+
+		public Item toItem() {
+			if (number) {
+				try {
+					if (token.length() < 10) {
+						return new Item(Item.KIND_INT, Integer.valueOf(Integer.parseInt(token)));
+					}
+					return new Item(Item.KIND_BIGINT, new BigInteger(token));
+				}
+				catch (NumberFormatException e) {
+					throw new IllegalStateException(e);
+				}
+			}
+			if (index >= version.length()) {
+				if ("min".equalsIgnoreCase(token)) return Item.MIN;
+				if ("max".equalsIgnoreCase(token)) return Item.MAX;
+			}
+			if (terminatedByNumber && token.length() == 1) {
+				switch (token.charAt(0)) {
+				case 'a':
+				case 'A':
+					return new Item(Item.KIND_QUALIFIER, QUALIFIER_ALPHA);
+				case 'b':
+				case 'B':
+					return new Item(Item.KIND_QUALIFIER, QUALIFIER_BETA);
+				case 'm':
+				case 'M':
+					return new Item(Item.KIND_QUALIFIER, QUALIFIER_MILESTONE);
+				default:
+				}
+			}
+			Integer qualifier = QUALIFIERS.get(token);
+			if (qualifier != null) return new Item(Item.KIND_QUALIFIER, qualifier);
+			return new Item(Item.KIND_STRING, token.toLowerCase(Locale.ENGLISH));
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// Item — one segment of a parsed version
+	// -------------------------------------------------------------------
+
+	public static final class Item {
+
+		static final int KIND_MAX = 8;
+		static final int KIND_BIGINT = 5;
+		static final int KIND_INT = 4;
+		static final int KIND_STRING = 3;
+		static final int KIND_QUALIFIER = 2;
+		static final int KIND_MIN = 0;
+
+		static final Item MAX = new Item(KIND_MAX, "max");
+		static final Item MIN = new Item(KIND_MIN, "min");
+
+		private final int kind;
+		private final Object value;
+
+		Item(int kind, Object value) {
+			this.kind = kind;
+			this.value = value;
+		}
+
+		public boolean isNumber() {
+			// kind != STRING and != QUALIFIER → treated as numeric tier for padding purposes
+			return (kind & KIND_QUALIFIER) == 0;
+		}
+
+		public int compareTo(Item that) {
+			int rel;
+			if (that == null) {
+				// null denotes the "pad" item (0 or empty qualifier)
+				switch (kind) {
+				case KIND_MIN:
+					rel = -1;
+					break;
+				case KIND_MAX:
+				case KIND_BIGINT:
+				case KIND_STRING:
+					rel = 1;
+					break;
+				case KIND_INT:
+				case KIND_QUALIFIER:
+					rel = ((Integer) value).intValue();
+					break;
+				default:
+					throw new IllegalStateException("unknown version item kind " + kind);
+				}
+			}
+			else {
+				rel = kind - that.kind;
+				if (rel == 0) {
+					switch (kind) {
+					case KIND_MAX:
+					case KIND_MIN:
+						break;
+					case KIND_BIGINT:
+						rel = ((BigInteger) value).compareTo((BigInteger) that.value);
+						break;
+					case KIND_INT:
+					case KIND_QUALIFIER:
+						rel = ((Integer) value).compareTo((Integer) that.value);
+						break;
+					case KIND_STRING:
+						rel = ((String) value).compareToIgnoreCase((String) that.value);
+						break;
+					default:
+						throw new IllegalStateException("unknown version item kind " + kind);
+					}
+				}
+			}
+			return rel;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof Item && compareTo((Item) obj) == 0;
+		}
+
+		@Override
+		public int hashCode() {
+			return value.hashCode() + kind * 31;
+		}
+
+		@Override
+		public String toString() {
+			return String.valueOf(value);
+		}
+	}
+}

--- a/core/src/main/java/lucee/runtime/mvn/MavenVersionRange.java
+++ b/core/src/main/java/lucee/runtime/mvn/MavenVersionRange.java
@@ -1,0 +1,221 @@
+/*
+ * Maven version range parsing for Lucee.
+ *
+ * Based on Apache Maven Resolver's GenericVersionRange + UnionVersionRange
+ * (maven-resolver-util 2.0.16, Apache License 2.0). Extended to handle
+ * maven's union-of-ranges form ("[1.0,1.5],[2.0,)") which aether splits
+ * at a higher level.
+ */
+package lucee.runtime.mvn;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parses maven version range specifications and answers whether a given
+ * {@link MavenVersion} is contained.
+ *
+ * Supported forms:
+ * <ul>
+ * <li>Bare version <code>1.0</code> — soft pin, treated as <code>[1.0]</code></li>
+ * <li>Pinned <code>[1.0]</code></li>
+ * <li>Bracketed with inclusive/exclusive bounds: <code>[1.0,2.0)</code>, <code>(1.0,2.0]</code>, etc.</li>
+ * <li>Open bounds: <code>[1.0,)</code>, <code>(,1.0]</code></li>
+ * <li>Wildcard <code>[1.2.*]</code> — expanded to <code>[1.2.min, 1.2.max]</code></li>
+ * <li>Union: <code>[1.0,1.5],[2.0,)</code></li>
+ * </ul>
+ */
+public final class MavenVersionRange {
+
+	private final String spec;
+	private final List<SubRange> subs;
+
+	public MavenVersionRange(String spec) {
+		if (spec == null) throw new IllegalArgumentException("range spec cannot be null");
+		this.spec = spec.trim();
+		if (this.spec.isEmpty()) throw new IllegalArgumentException("empty range spec");
+		this.subs = Collections.unmodifiableList(parse(this.spec));
+	}
+
+	public boolean contains(MavenVersion v) {
+		for (SubRange s: subs) {
+			if (s.contains(v)) return true;
+		}
+		return false;
+	}
+
+	public boolean contains(String v) {
+		return contains(new MavenVersion(v));
+	}
+
+	/**
+	 * Fast path for specs that resolve to a single authoritative version
+	 * without consulting {@code maven-metadata.xml}:
+	 *
+	 * <ul>
+	 * <li>Bare <code>1.0</code> or pinned <code>[1.0]</code>: returns that version string.</li>
+	 * <li>Anything else (ranges with bounds, open bounds, wildcards, unions):
+	 * returns {@code null} — caller must fetch metadata. Returning the
+	 * lower bound of a range like <code>[2.2,3)</code> is wrong: the range
+	 * means "any version in [2.2, 3)", not "version 2.2 exists". Many
+	 * real-world artifacts (jaxb-runtime, etc.) declare such ranges
+	 * where the literal lower bound was never published.</li>
+	 * </ul>
+	 */
+	public String bestEffortSingleVersion() {
+		if (subs.size() != 1) return null;
+		SubRange s = subs.get(0);
+		if (s.isWildcardExpansion) return null;
+		if (s.lower != null && s.upper != null && s.lowerInclusive && s.upperInclusive && s.lower.compareTo(s.upper) == 0) {
+			return s.lower.asString();
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the highest version from the given candidates that is
+	 * contained in this range, or {@code null} if none match.
+	 *
+	 * Pre-release candidates (alpha, beta, milestone, rc/cr, snapshot)
+	 * are skipped unless the range spec itself names a pre-release on
+	 * either bound — matching maven's default behaviour of not pulling
+	 * milestones transitively. Without this, {@code [2.2, 3)} against a
+	 * candidate list containing {@code 3.0.0-M5} would pick the milestone
+	 * (which by maven compareTo is less than {@code 3.0.0} and therefore
+	 * in range) over real releases like {@code 2.3.9}.
+	 */
+	public MavenVersion pickHighest(List<String> candidates) {
+		boolean allowPreRelease = rangeNamesPreRelease();
+		MavenVersion best = null;
+		for (String cand: candidates) {
+			if (cand == null || cand.isEmpty()) continue;
+			MavenVersion mv;
+			try {
+				mv = new MavenVersion(cand);
+			}
+			catch (RuntimeException ignore) {
+				// candidate isn't a valid version string (e.g. a stray .tmp dir
+				// name fed in from listLocalVersions) — skip silently
+				continue;
+			}
+			if (!allowPreRelease && mv.isPreRelease()) continue;
+			if (contains(mv) && (best == null || mv.compareTo(best) > 0)) best = mv;
+		}
+		return best;
+	}
+
+	private boolean rangeNamesPreRelease() {
+		for (SubRange s: subs) {
+			if (s.lower != null && s.lower.isPreRelease()) return true;
+			if (s.upper != null && s.upper.isPreRelease()) return true;
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return spec;
+	}
+
+	// -------------------------------------------------------------------
+	// Parsing
+	// -------------------------------------------------------------------
+
+	private static List<SubRange> parse(String spec) {
+		List<SubRange> out = new ArrayList<>();
+
+		char first = spec.charAt(0);
+		if (first != '[' && first != '(') {
+			// bare version — pinned
+			out.add(SubRange.pinned(new MavenVersion(spec)));
+			return out;
+		}
+
+		int i = 0;
+		int n = spec.length();
+		while (i < n) {
+			char open = spec.charAt(i);
+			if (open != '[' && open != '(') throw new IllegalArgumentException("expected '[' or '(' at position " + i + " in [" + spec + "]");
+			int closeIdx = findNextClose(spec, i);
+			if (closeIdx < 0) throw new IllegalArgumentException("missing close bracket in [" + spec + "]");
+			char close = spec.charAt(closeIdx);
+			boolean lowerInclusive = open == '[';
+			boolean upperInclusive = close == ']';
+			String inner = spec.substring(i + 1, closeIdx);
+			out.add(parseInner(inner, lowerInclusive, upperInclusive, spec));
+			i = closeIdx + 1;
+			if (i < n) {
+				if (spec.charAt(i) != ',') throw new IllegalArgumentException("expected ',' between ranges at position " + i + " in [" + spec + "]");
+				i++;
+			}
+		}
+		return out;
+	}
+
+	private static int findNextClose(String spec, int from) {
+		for (int j = from; j < spec.length(); j++) {
+			char c = spec.charAt(j);
+			if (c == ']' || c == ')') return j;
+		}
+		return -1;
+	}
+
+	private static SubRange parseInner(String inner, boolean lowerInclusive, boolean upperInclusive, String fullSpec) {
+		int comma = inner.indexOf(',');
+		if (comma < 0) {
+			// [something] — either pinned [1.0] or wildcard [1.2.*]
+			if (!lowerInclusive || !upperInclusive) throw new IllegalArgumentException("single version must be surrounded by [] in [" + fullSpec + "]");
+			String v = inner.trim();
+			if (v.endsWith(".*")) {
+				String prefix = v.substring(0, v.length() - 1); // includes trailing "."
+				SubRange wild = new SubRange(new MavenVersion(prefix + "min"), true, new MavenVersion(prefix + "max"), true);
+				wild.isWildcardExpansion = true;
+				return wild;
+			}
+			MavenVersion mv = new MavenVersion(v);
+			return SubRange.pinned(mv);
+		}
+		String lower = inner.substring(0, comma).trim();
+		String upper = inner.substring(comma + 1).trim();
+		if (upper.indexOf(',') >= 0) throw new IllegalArgumentException("too many versions in range [" + fullSpec + "]");
+		MavenVersion lowerV = lower.isEmpty() ? null : new MavenVersion(lower);
+		MavenVersion upperV = upper.isEmpty() ? null : new MavenVersion(upper);
+		return new SubRange(lowerV, lowerInclusive, upperV, upperInclusive);
+	}
+
+	// -------------------------------------------------------------------
+	// SubRange
+	// -------------------------------------------------------------------
+
+	private static final class SubRange {
+		private final MavenVersion lower;
+		private final boolean lowerInclusive;
+		private final MavenVersion upper;
+		private final boolean upperInclusive;
+		private boolean isWildcardExpansion;
+
+		SubRange(MavenVersion lower, boolean lowerInclusive, MavenVersion upper, boolean upperInclusive) {
+			this.lower = lower;
+			this.lowerInclusive = lowerInclusive;
+			this.upper = upper;
+			this.upperInclusive = upperInclusive;
+		}
+
+		static SubRange pinned(MavenVersion v) {
+			return new SubRange(v, true, v, true);
+		}
+
+		boolean contains(MavenVersion v) {
+			if (lower != null) {
+				int c = v.compareTo(lower);
+				if (lowerInclusive ? c < 0 : c <= 0) return false;
+			}
+			if (upper != null) {
+				int c = v.compareTo(upper);
+				if (upperInclusive ? c > 0 : c >= 0) return false;
+			}
+			return true;
+		}
+	}
+}

--- a/test/general/MavenVersionParsing.cfc
+++ b/test/general/MavenVersionParsing.cfc
@@ -1,0 +1,628 @@
+/**
+ * Maven version parsing tests, using maven-resolver as the oracle.
+ *
+ * Many of the data cases below are ported from Apache Maven Resolver's own
+ * unit tests (maven-resolver-util 2.0.16, Apache License 2.0):
+ *
+ *   maven-resolver-util/src/test/java/org/eclipse/aether/util/version/
+ *     GenericVersionTest.java
+ *     GenericVersionRangeTest.java
+ *
+ * These cases represent the canonical expected behaviour of maven version
+ * comparison and range containment. We reuse them here as a ground-truth
+ * corpus so that when Lucee gains its own MavenVersion implementation, it
+ * can be validated against the exact same inputs that aether validates
+ * against. Huge thanks to the Maven Resolver team for the rigorous test
+ * coverage.
+ *
+ * Source: https://github.com/apache/maven-resolver/tree/maven-resolver-2.0.16
+ */
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="maven"
+	javasettings='{"maven":["org.apache.maven.resolver:maven-resolver-util:2.0.16"]}' {
+
+	function beforeAll() {
+		variables.scheme = new org.eclipse.aether.util.version.GenericVersionScheme();
+	}
+
+	function run( testResults, testBox ) {
+
+		describe( "maven-resolver (oracle): Version.compareTo — does maven-resolver's reference implementation return the expected sign?", function() {
+			for ( var c in comparisonCases() ) {
+				( function( c ) {
+					it( title = "compare( '#c[ 1 ]#', '#c[ 2 ]#' ) -> sign #c[ 3 ]#", body = function( currentSpec ) {
+						var left  = scheme.parseVersion( c[ 1 ] );
+						var right = scheme.parseVersion( c[ 2 ] );
+						var raw   = left.compareTo( right );
+						var sign  = raw > 0 ? 1 : ( raw < 0 ? -1 : 0 );
+						expect( sign ).toBe( c[ 3 ], "failed on #c.toJson()# (raw compareTo=#raw#)" );
+					} );
+				} )( c );
+			}
+		} );
+
+		describe( "maven-resolver (oracle): VersionRange.containsVersion — does maven-resolver's reference implementation agree on range membership?", function() {
+			for ( var c in rangeCases() ) {
+				( function( c ) {
+					it( title = "'#c[ 1 ]#' containsVersion '#c[ 2 ]#' -> #c[ 3 ]#", body = function( currentSpec ) {
+						var constraint = scheme.parseVersionConstraint( c[ 1 ] );
+						var version    = scheme.parseVersion( c[ 2 ] );
+						expect( constraint.containsVersion( version ) ).toBe( c[ 3 ], "failed on #c.toJson()#" );
+					} );
+				} )( c );
+			}
+		} );
+
+		// ---------------------------------------------------------------------
+		// Baseline: Lucee's current MavenUtil.resolveVersionRange — the existing
+		// "crappy" single-line substring hack. Locks in current behaviour so we
+		// can see exactly what breaks when the real parser lands. Expected
+		// values here are the CURRENT (often wrong) output.
+		// ---------------------------------------------------------------------
+		describe( "Lucee MavenUtil.resolveVersionRange (wired to MavenVersionRange, best-effort without maven-metadata.xml)", function() {
+			for ( var c in currentResolveCases() ) {
+				( function( c ) {
+					it( title = "resolveVersionRange( '#c.input#' ) -> #c.current# [#c.verdict#]", body = function( currentSpec ) {
+						var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+						expect( util.resolveVersionRange( c.input ) ).toBe( c.current, "failed on #c.toJson()#" );
+					} );
+				} )( c );
+			}
+		} );
+
+		// ---------------------------------------------------------------------
+		// Lucee OSGiUtil.compare — Lucee already has an OSGi-flavoured version
+		// comparator. Run maven's expected sign against it to expose exactly
+		// which qualifier/ordering rules differ from maven semantics. Many of
+		// these are expected to FAIL today; that's the point.
+		// ---------------------------------------------------------------------
+		xdescribe( "Lucee OSGiUtil.compare (OSGi semantics, not maven) — skipped: one-time proof that OSGi's comparator is NOT a drop-in for maven semantics. Kept for reference; unskip to re-run the divergence map.", function() {
+			variables.osgiUtil = createObject( "java", "lucee.runtime.osgi.OSGiUtil" );
+			variables.osgiVersion = createObject( "java", "org.osgi.framework.Version" );
+
+			for ( var c in comparisonCases() ) {
+				( function( c ) {
+					it( title = "OSGiUtil.compare( '#c[ 1 ]#', '#c[ 2 ]#' ) -> sign #c[ 3 ]#", body = function( currentSpec ) {
+						// org.osgi.framework.Version can't parse arbitrary maven strings; constructor
+						// throws on e.g. "1.0-alpha-1" because it expects major.minor.micro.qualifier.
+						var raw = "";
+						try {
+							var left  = osgiVersion.init( c[ 1 ] );
+							var right = osgiVersion.init( c[ 2 ] );
+							raw = osgiUtil.compare( left, right );
+						}
+						catch ( any e ) {
+							fail( "OSGi Version rejected input #c.toJson()#: #e.message#" );
+						}
+						var sign = raw > 0 ? 1 : ( raw < 0 ? -1 : 0 );
+						expect( sign ).toBe( c[ 3 ], "OSGi disagrees with maven on #c.toJson()# (OSGi sign=#sign#, maven expected=#c[ 3 ]#)" );
+					} );
+				} )( c );
+			}
+		} );
+
+		// ---------------------------------------------------------------------
+		// Lucee has NO maven-style VersionRange.containsVersion at all. The
+		// closest thing — resolveVersionRange — returns a single string, so we
+		// degenerate containsVersion to "does the resolved string equal the
+		// tested version". Expect this to fail on most non-trivial cases;
+		// that's the point.
+		// ---------------------------------------------------------------------
+		// ---------------------------------------------------------------------
+		// Lucee's hand-rolled MavenVersion — the new implementation. Runs the
+		// SAME 123 comparison cases through our parser + comparator. Failures
+		// here are real bugs in our implementation.
+		// ---------------------------------------------------------------------
+		describe( "Lucee MavenVersion.compareTo (new hand-rolled impl) — does Lucee's new parser match maven?", function() {
+			for ( var c in comparisonCases() ) {
+				( function( c ) {
+					it( title = "MavenVersion.compareTo( '#c[ 1 ]#', '#c[ 2 ]#' ) -> sign #c[ 3 ]#", body = function( currentSpec ) {
+						var left  = createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( c[ 1 ] );
+						var right = createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( c[ 2 ] );
+						var raw   = left.compareTo( right );
+						var sign  = raw > 0 ? 1 : ( raw < 0 ? -1 : 0 );
+						expect( sign ).toBe( c[ 3 ], "Lucee MavenVersion disagrees with maven on #c.toJson()# (Lucee sign=#sign#, maven expected=#c[ 3 ]#)" );
+					} );
+				} )( c );
+			}
+		} );
+
+		// ---------------------------------------------------------------------
+		// Lucee's hand-rolled MavenVersionRange — the new implementation. Runs
+		// the SAME 36 range cases through our parser + contains.
+		// ---------------------------------------------------------------------
+		describe( "Lucee MavenVersionRange.contains (new hand-rolled impl) — does Lucee's new range parser match maven?", function() {
+			for ( var c in rangeCases() ) {
+				( function( c ) {
+					it( title = "MavenVersionRange( '#c[ 1 ]#' ).contains( '#c[ 2 ]#' ) -> #c[ 3 ]#", body = function( currentSpec ) {
+						try {
+							var range = createObject( "java", "lucee.runtime.mvn.MavenVersionRange" ).init( c[ 1 ] );
+							expect( range.contains( c[ 2 ] ) ).toBe( c[ 3 ], "Lucee MavenVersionRange disagrees with maven on #c.toJson()#" );
+						}
+						catch ( any e ) {
+							fail( "Lucee MavenVersionRange threw on #c.toJson()#: #e.message#" );
+						}
+					} );
+				} )( c );
+			}
+		} );
+
+		// ---------------------------------------------------------------------
+		// Integrated corpus — drive pickHighest against realistic candidate
+		// lists. Closes the gap between parse-level assertions (contains) and
+		// the metadata-driven resolution path. Covers every range form plus
+		// the pre-release filter. Expected picks reflect what the 5-arg
+		// resolveVersionRange produces once metadata fetch returns the
+		// candidate list.
+		// ---------------------------------------------------------------------
+		describe( "Lucee MavenVersionRange.pickHighest — integrated range + candidate-list resolution", function() {
+			for ( var c in pickCases() ) {
+				( function( c ) {
+					var desc = "pickHighest( '#c.spec#', #c.candidates.toJson()# ) -> " & ( structKeyExists( c, "expected" ) ? "'#c.expected#'" : "null" );
+					it( title = desc, body = function( currentSpec ) {
+						var range = createObject( "java", "lucee.runtime.mvn.MavenVersionRange" ).init( c.spec );
+						var list  = createObject( "java", "java.util.ArrayList" ).init();
+						for ( var v in c.candidates ) list.add( v );
+						local.picked = range.pickHighest( list );
+						if ( structKeyExists( c, "expected" ) ) {
+							expect( isNull( local.picked ) ).toBeFalse( "expected pick '#c.expected#' but got null for #c.toJson()#" );
+							expect( local.picked.asString() ).toBe( c.expected, "failed on #c.toJson()#" );
+						}
+						else {
+							expect( isNull( local.picked ) ).toBeTrue( "expected null pick but got non-null for #c.toJson()#" );
+						}
+					} );
+				} )( c );
+			}
+		} );
+
+		xdescribe( "Lucee degenerate containsVersion shim — skipped: one-time proof that resolveVersionRange alone cannot answer containment. Kept for reference; unskip to re-run.", function() {
+			for ( var c in rangeCases() ) {
+				( function( c ) {
+					it( title = "'#c[ 1 ]#' containsVersion '#c[ 2 ]#' -> #c[ 3 ]#", body = function( currentSpec ) {
+						var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+						var shimResult = false;
+						try {
+							shimResult = ( util.resolveVersionRange( c[ 1 ] ) == c[ 2 ] );
+						}
+						catch ( any e ) {
+							// resolveVersionRange threw — treat as "not contained" for the shim
+							shimResult = false;
+						}
+						expect( shimResult ).toBe( c[ 3 ], "Lucee disagrees with maven on #c.toJson()# (shim=#shimResult#, maven expected=#c[ 3 ]#)" );
+					} );
+				} )( c );
+			}
+		} );
+	}
+
+	// ---------------------------------------------------------------------
+	// Test data — kept in private helpers so additional describe blocks
+	// (e.g. for Lucee's own hand-rolled implementation) can reuse them.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Version comparison cases.
+	 * Row: [ left, right, expected sign of left.compareTo(right) ]
+	 *   -1 : left < right
+	 *    0 : left == right
+	 *    1 : left > right
+	 */
+	private array function comparisonCases() {
+		return [
+			// -------------------------------------------------------------
+			// Lucee-local smoke cases
+			// -------------------------------------------------------------
+			[ "1.0",         "1.0",           0 ],
+			[ "1.0",         "1.0.0",         0 ],
+			[ "1.0",         "1.1",          -1 ],
+			[ "1.1",         "1.0",           1 ],
+			[ "1.2.3",       "1.2.4",        -1 ],
+
+			// -------------------------------------------------------------
+			// ported from aether GenericVersionTest#testEmptyVersion
+			// -------------------------------------------------------------
+			[ "0",           "",              0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testEdgeCase_1_2 / 2_1 / 2_3 / 2_4
+			// -------------------------------------------------------------
+			[ "ga.ga.foo",     "foo",             -1 ],
+			[ "0.foo.1.2.3",   "foo.1.2.3",        1 ],
+			[ "0.foo",         "foo",              1 ],
+			[ "1.0.0-foo",     "1-foo",            0 ],
+			[ "1.0.0-ga-foo",  "1-foo",           -1 ],
+			[ "1.0.0-ga-foo",  "1-ga-foo",         0 ],
+			[ "1.0.0.final-foo","1-foo",          -1 ],
+			[ "1.0.0.final-foo","1-final-foo",     0 ],
+			[ "1.ga",          "1.0",              0 ],
+			[ "ga.1",          "0.1",             -1 ],
+			[ "1.ga.1",        "1.0.1",           -1 ],
+			[ "1.0.final.1",   "1.0.1.final",    -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testQualifier
+			// -------------------------------------------------------------
+			[ "1.0.0.a1",      "1.0.0.b1",        -1 ],
+			[ "1.0.0.b1",      "1.0.0.m1",        -1 ],
+			[ "1.0.0.m1",      "1.0.0.rc",        -1 ],
+			[ "1.0.0.rc",      "1.0.0-SNAPSHOT",  -1 ],
+			[ "1.0.0-SNAPSHOT","1.0.0",           -1 ],
+			[ "1.0.0.ga",      "1.0.0.final",      0 ],
+			[ "1.0.0.final",   "1.0.0.release",    0 ],
+			[ "1.0.0.final",   "1.0.0.sp",        -1 ],
+			[ "1.0.0",         "1.0.0.sp",        -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testNumericOrdering
+			// -------------------------------------------------------------
+			[ "2",             "10",              -1 ],
+			[ "1.2",           "1.10",            -1 ],
+			[ "1.0.2",         "1.0.10",          -1 ],
+			[ "1.0.0.2",       "1.0.0.10",        -1 ],
+			[ "1.0.20101206.111434.1", "1.0.20101206.111435.1", -1 ],
+			[ "1.0.20101206.111434.2", "1.0.20101206.111434.10", -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testDelimiters
+			// -------------------------------------------------------------
+			[ "1.0",           "1-0",              0 ],
+			[ "1.0",           "1_0",              0 ],
+			[ "1.a",           "1a",               0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testLeadingZerosAreSemanticallyIrrelevant
+			// -------------------------------------------------------------
+			[ "1",             "01",               0 ],
+			[ "1.2",           "1.002",            0 ],
+			[ "1.2.3",         "1.2.0003",         0 ],
+			[ "1.2.3.4",       "1.2.3.00004",      0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testTrailingZerosAreSemanticallyIrrelevant
+			// -------------------------------------------------------------
+			[ "1",             "1.0.0.0.0.0.0.0.0.0.0.0.0.0", 0 ],
+			[ "1",             "1-0-0-0-0-0-0-0-0-0-0-0-0-0", 0 ],
+			[ "1",             "1.0000000000000",   0 ],
+			[ "1.0",           "1.0.0",             0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testTrailingZerosBeforeQualifierAreSemanticallyIrrelevant
+			// -------------------------------------------------------------
+			[ "1.0_ga",        "1.0.0_ga",          0 ],
+			[ "1.0-ga",        "1.0.0-ga",          0 ],
+			[ "1.0.ga",        "1.0.0.ga",          0 ],
+			[ "1.0ga",         "1.0.0ga",           0 ],
+			[ "1.0-alpha",     "1.0.0-alpha",       0 ],
+			[ "1.0.alpha",     "1.0.0.alpha",       0 ],
+			[ "1.0alpha",      "1.0.0alpha",        0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testInitialDelimiters / testConsecutiveDelimiters
+			// -------------------------------------------------------------
+			[ "0.1",           ".1",                0 ],
+			[ "0.0.1",         "..1",               0 ],
+			[ "0.1",           "-1",                0 ],
+			[ "1.0.1",         "1..1",              0 ],
+			[ "1.0.0.1",       "1...1",             0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testUnlimitedNumberOfVersionComponents
+			//        / testUnlimitedNumberOfDigitsInNumericComponent
+			// -------------------------------------------------------------
+			[ "1.0.1.2.3.4.5.6.7.8.9.0.1.2.10", "1.0.1.2.3.4.5.6.7.8.9.0.1.2.3", 1 ],
+			[ "1.1234567890123456789012345678901", "1.123456789012345678901234567891", 1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testTransitionFromDigitToLetterAndViceVersaIsEquivalentToDelimiter
+			// -------------------------------------------------------------
+			[ "1alpha10",      "1.alpha.10",        0 ],
+			[ "1alpha10",      "1-alpha-10",        0 ],
+			[ "1.alpha10",     "1.alpha2",          1 ],
+			[ "10alpha",       "1alpha",            1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testWellKnownQualifierOrdering
+			// -------------------------------------------------------------
+			[ "1-alpha1",      "1-a1",              0 ],
+			[ "1-alpha",       "1-beta",           -1 ],
+			[ "1-beta1",       "1-b1",              0 ],
+			[ "1-beta",        "1-milestone",      -1 ],
+			[ "1-milestone1",  "1-m1",              0 ],
+			[ "1-milestone",   "1-rc",             -1 ],
+			[ "1-rc",          "1-cr",              0 ],
+			[ "1-rc",          "1-snapshot",       -1 ],
+			[ "1-snapshot",    "1",                -1 ],
+			[ "1",             "1-ga",              0 ],
+			[ "1",             "1.ga.0.ga",         0 ],
+			[ "1.0",           "1-ga",              0 ],
+			[ "1",             "1-ga.ga",           0 ],
+			[ "1",             "1-ga-ga",           0 ],
+			[ "1",             "1-final",           0 ],
+			[ "1",             "1-release",         0 ],
+			[ "1",             "1-sp",             -1 ],
+			[ "A.rc.1",        "A.ga.1",           -1 ],
+			[ "A.sp.1",        "A.ga.1",            1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testWellKnownQualifierVersusUnknownQualifierOrdering
+			// -------------------------------------------------------------
+			[ "1-abc",         "1-alpha",           1 ],
+			[ "1-abc",         "1-beta",            1 ],
+			[ "1-abc",         "1-milestone",       1 ],
+			[ "1-abc",         "1-rc",              1 ],
+			[ "1-abc",         "1-snapshot",        1 ],
+			[ "1-abc",         "1",                 1 ],
+			[ "1-abc",         "1-sp",              1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testWellKnownSingleCharQualifiersOnlyRecognizedIfImmediatelyFollowedByNumber
+			// -------------------------------------------------------------
+			[ "1.0a",          "1.0",               1 ],
+			[ "1.0-a",         "1.0",               1 ],
+			[ "1.0.a",         "1.0",               1 ],
+			[ "1.0a1",         "1.0",              -1 ],
+			[ "1.0-a1",        "1.0",              -1 ],
+			[ "1.0.a1",        "1.0",              -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testUnknownQualifierOrdering
+			// -------------------------------------------------------------
+			[ "1-abc",         "1-abcd",           -1 ],
+			[ "1-abc",         "1-bcd",            -1 ],
+			[ "1-abc",         "1-aac",             1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testCaseInsensitiveOrderingOfQualifiers
+			// -------------------------------------------------------------
+			[ "1.alpha",       "1.ALPHA",           0 ],
+			[ "1.beta",        "1.BETA",            0 ],
+			[ "1.milestone",   "1.MILESTONE",       0 ],
+			[ "1.rc",          "1.RC",              0 ],
+			[ "1.cr",          "1.CR",              0 ],
+			[ "1.snapshot",    "1.SNAPSHOT",        0 ],
+			[ "1.ga",          "1.GA",              0 ],
+			[ "1.final",       "1.FINAL",           0 ],
+			[ "1.release",     "1.RELEASE",         0 ],
+			[ "1.sp",          "1.SP",              0 ],
+			[ "1.unknown",     "1.UNKNOWN",         0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testHypenBeforeUnderscoreDotOrder
+			// -------------------------------------------------------------
+			[ "1.0.0-1",       "1.0.0_1",           0 ],
+			[ "1.0.0-1",       "1.0.0.1",           0 ],
+			[ "1.0.0_1",       "1.0.0.1",           0 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testQualifierVersusNumberOrdering
+			// -------------------------------------------------------------
+			[ "1-ga",          "1-1",              -1 ],
+			[ "1.ga",          "1.1",              -1 ],
+			[ "1-ga",          "1.0",               0 ],
+			[ "1.ga",          "1.0",               0 ],
+			[ "1.sp",          "1.0",               1 ],
+			[ "1.sp",          "1.1",              -1 ],
+			[ "1-abc",         "1-1",              -1 ],
+			[ "1.abc",         "1.1",              -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testVersionEvolution — pairwise adjacent
+			// -------------------------------------------------------------
+			[ "0.9.9-SNAPSHOT",    "0.9.9",              -1 ],
+			[ "0.9.9",             "0.9.10-SNAPSHOT",    -1 ],
+			[ "0.9.10-SNAPSHOT",   "0.9.10",             -1 ],
+			[ "0.9.10",            "1.0-alpha-2-SNAPSHOT",-1 ],
+			[ "1.0-alpha-2-SNAPSHOT","1.0-alpha-2",      -1 ],
+			[ "1.0-alpha-2",       "1.0-alpha-10-SNAPSHOT",-1 ],
+			[ "1.0-alpha-10-SNAPSHOT","1.0-alpha-10",    -1 ],
+			[ "1.0-alpha-10",      "1.0-beta-1-SNAPSHOT",-1 ],
+			[ "1.0-beta-1-SNAPSHOT","1.0-beta-1",        -1 ],
+			[ "1.0-beta-1",        "1.0-rc-1-SNAPSHOT",  -1 ],
+			[ "1.0-rc-1-SNAPSHOT", "1.0-rc-1",           -1 ],
+			[ "1.0-rc-1",          "1.0-SNAPSHOT",       -1 ],
+			[ "1.0-SNAPSHOT",      "1.0",                -1 ],
+			[ "1.0",               "1.0-sp-1-SNAPSHOT",  -1 ],
+			[ "1.0-sp-1-SNAPSHOT", "1.0-sp-1",           -1 ],
+			[ "1.0-sp-1",          "1.0.1-alpha-1-SNAPSHOT",-1 ],
+			[ "1.0.1",             "1.1-SNAPSHOT",       -1 ],
+			[ "1.1-SNAPSHOT",      "1.1",                -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testMinimumSegment / testMaximumSegment
+			// -------------------------------------------------------------
+			[ "1.min",             "1.0-alpha-1",        -1 ],
+			[ "1.min",             "1.0-SNAPSHOT",       -1 ],
+			[ "1.min",             "1.0",                -1 ],
+			[ "1.min",             "1.MIN",               0 ],
+			[ "1.min",             "0.99999",             1 ],
+			[ "1.min",             "0.max",               1 ],
+			[ "1.max",             "1.0-alpha-1",         1 ],
+			[ "1.max",             "1.0-SNAPSHOT",        1 ],
+			[ "1.max",             "1.0",                 1 ],
+			[ "1.max",             "1.MAX",               0 ],
+			[ "1.max",             "2.0-alpha-1",        -1 ],
+			[ "1.max",             "2.min",              -1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testCompareLettersToNumbers / testCompareDigitToLetter
+			// -------------------------------------------------------------
+			[ "1.7",               "J",                   1 ],
+			[ "7",                 "J",                   1 ],
+			[ "7",                 "c",                   1 ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionTest#testLexicographicOrder
+			// -------------------------------------------------------------
+			[ "zebra",             "aardvark",            1 ]
+		];
+	}
+
+	/**
+	 * Baseline cases for Lucee's current MavenUtil.resolveVersionRange.
+	 *
+	 * Each row is a struct with:
+	 *   input    — the version/range spec handed to resolveVersionRange
+	 *   current  — what the current (broken) impl returns, or "ERROR" if it throws
+	 *   verdict  — one of:
+	 *                "OK"                  — current impl is correct
+	 *                "WRONG-lower-bound"   — returns the bracketed lower bound literally
+	 *                "WRONG-passthrough"   — doesn't start with [, returned unchanged
+	 *                "WRONG-throws"        — crashes with StringIndexOutOfBoundsException
+	 *                "WRONG-union-first"   — picks lower bound of first range in a union
+	 *   correct  — the value a maven-correct resolver should return. For ranges
+	 *              that genuinely need an available-versions list to answer
+	 *              (e.g. [2.2,3)), use "NEEDS_LIST" as a sentinel.
+	 */
+	private array function currentResolveCases() {
+		return [
+			// plain versions — pass through unchanged
+			{ input: "1.0",               current: "1.0",               verdict: "OK",                 correct: "1.0"        },
+			{ input: "1.0-SNAPSHOT",      current: "1.0-SNAPSHOT",      verdict: "OK",                 correct: "1.0-SNAPSHOT" },
+			{ input: "2.3.9",             current: "2.3.9",             verdict: "OK",                 correct: "2.3.9"      },
+
+			// bracket forms with bounds — single-arg form can't answer without a version list,
+			// so falls through to raw spec. `[2.2,3)` does NOT mean "2.2 exists"; many real
+			// artifacts (jaxb-runtime et al) declare ranges where the literal lower bound
+			// was never published. Correct resolution requires metadata — use the 5-arg form.
+			{ input: "[2.2,3)",           current: "[2.2,3)",           verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+			{ input: "[1.0,2.0)",         current: "[1.0,2.0)",         verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+			{ input: "[1.0,)",            current: "[1.0,)",            verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+
+			// pinned — no longer throws; new impl returns the pinned version correctly
+			{ input: "[1.0]",             current: "1.0",               verdict: "OK",                 correct: "1.0"        },
+			// wildcard — expanded to [min,max] under the hood; bestEffort returns null, falls through raw
+			{ input: "[1.2.*]",           current: "[1.2.*]",           verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+
+			// paren forms — exclusive lower bound, bestEffort returns null, falls through raw
+			{ input: "(1.0,2.0]",         current: "(1.0,2.0]",         verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+			{ input: "(,1.0]",            current: "(,1.0]",            verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+			{ input: "(1.0,3.0)",         current: "(1.0,3.0)",         verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" },
+
+			// unions — multiple subranges, bestEffort returns null, falls through raw
+			{ input: "[1.0,1.5],[2.0,)",  current: "[1.0,1.5],[2.0,)",  verdict: "FALLTHROUGH-NEEDS-LIST", correct: "NEEDS_LIST" }
+		];
+	}
+
+	/**
+	 * pickHighest cases — exercises the metadata-driven resolution path.
+	 *
+	 * Each row:
+	 *   spec       — the range/version spec
+	 *   candidates — array of version strings as a metadata.xml would return
+	 *   expected   — version string pickHighest should select
+	 *                (omit the key entirely for cases that should return null)
+	 */
+	private array function pickCases() {
+		return [
+			// --- pinned --------------------------------------------------
+			{ spec: "[1.0]",             candidates: [ "1.0", "1.0.1", "2.0" ],                 expected: "1.0" },
+			{ spec: "[1.0]",             candidates: [ "0.9", "1.1", "2.0" ]                                   },  // pinned absent -> null
+			{ spec: "1.0",               candidates: [ "1.0", "1.0.1" ],                         expected: "1.0" },
+
+			// --- inclusive/exclusive bounds -----------------------------
+			{ spec: "[1.0,2.0]",         candidates: [ "0.9", "1.0", "1.5", "2.0", "2.1" ],     expected: "2.0" },
+			{ spec: "[1.0,2.0)",         candidates: [ "1.0", "1.5", "1.99", "2.0", "2.1" ],    expected: "1.99" },
+			{ spec: "(1.0,2.0]",         candidates: [ "1.0", "1.0.1", "2.0", "2.1" ],          expected: "2.0" },
+			{ spec: "(1.0,2.0)",         candidates: [ "1.0", "1.5", "2.0" ],                   expected: "1.5" },
+
+			// --- open bounds --------------------------------------------
+			{ spec: "[1.0,)",            candidates: [ "0.9", "1.0", "2.5", "99.0" ],           expected: "99.0" },
+			{ spec: "(,1.0]",            candidates: [ "0.1", "0.9", "1.0", "1.1" ],            expected: "1.0" },
+
+			// --- wildcard -----------------------------------------------
+			{ spec: "[1.2.*]",           candidates: [ "1.1.9", "1.2.0", "1.2.7", "1.3.0" ],    expected: "1.2.7" },
+
+			// --- union --------------------------------------------------
+			{ spec: "[1.0,1.5],[2.0,)",  candidates: [ "0.9", "1.0", "1.5", "1.7", "2.5" ],     expected: "2.5" },
+			{ spec: "[1.0,1.5],[2.0,)",  candidates: [ "1.6", "1.7", "1.9" ]                                    },  // gap -> null
+
+			// --- pre-release filter active ------------------------------
+			// jaxb-runtime real-world: [2.2,3) must not pick 3.0.0-M5 even though
+			// per maven compareTo M5 < 3.0.0 < 3 and is technically in range.
+			{ spec: "[2.2,3)",           candidates: [ "2.2.11", "2.3.9", "3.0.0-M5", "3.0.0-beta-1" ], expected: "2.3.9" },
+			{ spec: "[1.0,2.0)",         candidates: [ "1.5-M1", "1.5-beta", "1.5-SNAPSHOT" ]                    },  // all pre-release -> null
+			{ spec: "[1.0,2.0)",         candidates: [ "1.0-alpha", "1.5", "1.5-beta" ],        expected: "1.5" },
+
+			// --- pre-release filter off when bound names pre-release ---
+			{ spec: "[3.0.0-M1,3.0.0)",  candidates: [ "3.0.0-M1", "3.0.0-M3", "3.0.0-M5" ],    expected: "3.0.0-M5" },
+			{ spec: "[1.0-beta,2.0)",    candidates: [ "1.0-beta", "1.0-beta-2", "1.5" ],       expected: "1.5" },
+
+			// --- empty / no match ---------------------------------------
+			{ spec: "[1.0,2.0)",         candidates: [ ]                                                       },
+			{ spec: "[10.0,)",           candidates: [ "1.0", "2.0", "5.0" ]                                    }
+		];
+	}
+
+	/**
+	 * Range containment cases.
+	 * Row: [ rangeSpec, version, expectedContained ]
+	 */
+	private array function rangeCases() {
+		return [
+			// -------------------------------------------------------------
+			// Lucee-local smoke cases — pinned / incl / excl / open / unions
+			// -------------------------------------------------------------
+			[ "[1.0]",             "1.0",     true  ],
+			[ "[1.0]",             "1.1",     false ],
+			[ "[1.0,2.0)",         "1.0",     true  ],
+			[ "[1.0,2.0)",         "1.5",     true  ],
+			[ "[1.0,2.0)",         "2.0",     false ],
+			[ "(1.0,2.0]",         "1.0",     false ],
+			[ "(1.0,2.0]",         "2.0",     true  ],
+			[ "[1.0,)",            "99.0",    true  ],
+			[ "[1.0,)",            "0.9",     false ],
+			[ "(,1.0]",            "0.5",     true  ],
+			[ "(,1.0]",            "1.5",     false ],
+			[ "[1.0,1.5],[2.0,)",  "1.2",     true  ],
+			[ "[1.0,1.5],[2.0,)",  "1.7",     false ],  // gap
+			[ "[1.0,1.5],[2.0,)",  "2.5",     true  ],
+
+			// Real-world: ehcache 3.10.8's jaxb-runtime range
+			[ "[2.2,3)",           "2.2",     true  ],
+			[ "[2.2,3)",           "2.2.11",  true  ],
+			[ "[2.2,3)",           "2.3.9",   true  ],
+			[ "[2.2,3)",           "3.0",     false ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionRangeTest#testLowerBoundInclusiveUpperBoundInclusive
+			// -------------------------------------------------------------
+			[ "[1,2]",             "1",             true  ],
+			[ "[1,2]",             "1.1-SNAPSHOT",  true  ],
+			[ "[1,2]",             "2",             true  ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionRangeTest#testLowerBoundInclusiveUpperBoundExclusive
+			// -------------------------------------------------------------
+			[ "[1.2.3.4.5,1.2.3.4.6)", "1.2.3.4.5", true  ],
+			[ "[1.2.3.4.5,1.2.3.4.6)", "1.2.3.4.6", false ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionRangeTest#testLowerBoundExclusiveUpperBoundInclusive
+			// -------------------------------------------------------------
+			[ "(1a,1b]",           "1a",            false ],
+			[ "(1a,1b]",           "1b",            true  ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionRangeTest#testLowerBoundExclusiveUpperBoundExclusive
+			// -------------------------------------------------------------
+			[ "(1,3)",             "1",             false ],
+			[ "(1,3)",             "2-SNAPSHOT",    true  ],
+			[ "(1,3)",             "3",             false ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionRangeTest#testSingleVersion
+			// -------------------------------------------------------------
+			[ "[1]",               "1",             true  ],
+			[ "[1,1]",             "1",             true  ],
+
+			// -------------------------------------------------------------
+			// aether GenericVersionRangeTest#testSingleWildcardVersion
+			// -------------------------------------------------------------
+			[ "[1.2.*]",           "1.2-alpha-1",   true  ],
+			[ "[1.2.*]",           "1.2-SNAPSHOT",  true  ],
+			[ "[1.2.*]",           "1.2",           true  ],
+			[ "[1.2.*]",           "1.2.9999999",   true  ],
+			[ "[1.2.*]",           "1.3-rc-1",      false ]
+		];
+	}
+}

--- a/test/tickets/LDEV6278.cfc
+++ b/test/tickets/LDEV6278.cfc
@@ -1,0 +1,253 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="LDEV-6278,maven" {
+
+	function run( testResults, testBox ) {
+
+		describe( "LDEV-6278 — runtime resolver supports maven version range specs", function() {
+
+			// ---------------------------------------------------------------------
+			// Acceptance criteria — unit tests (no network required).
+			// Calls MavenUtil.resolveVersionRange directly to prove each spec-form
+			// lands on the right code path.
+			// ---------------------------------------------------------------------
+
+			describe( "resolveVersionRange — parse + best-effort resolution (no metadata fetch)", function() {
+
+				it( "pinned [1.0] returns '1.0' and does not throw", function() {
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					expect( util.resolveVersionRange( "[1.0]" ) ).toBe( "1.0" );
+				});
+
+				it( "bare version passes through unchanged (soft pin)", function() {
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					expect( util.resolveVersionRange( "1.0" ) ).toBe( "1.0" );
+					expect( util.resolveVersionRange( "1.0-SNAPSHOT" ) ).toBe( "1.0-SNAPSHOT" );
+					expect( util.resolveVersionRange( "2.3.9" ) ).toBe( "2.3.9" );
+				});
+
+				it( "any bracketed range with bounds falls through to the raw spec on the single-arg path", function() {
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					// The single-arg form has no metadata context and MUST NOT guess
+					// that the lower bound of a range is a real version. `[2.2,3)` means
+					// "any version in [2.2, 3)", not "2.2 exists" — many artifacts
+					// (jaxb-runtime, etc.) declare such ranges where the literal lower
+					// bound was never published. Caller must use the 5-arg form for
+					// metadata-driven resolution; otherwise the raw spec bubbles up
+					// and the download fails loudly.
+					expect( util.resolveVersionRange( "[2.2,3)" ) ).toBe( "[2.2,3)" );
+					expect( util.resolveVersionRange( "[1.0,)" ) ).toBe( "[1.0,)" );
+					expect( util.resolveVersionRange( "(1.0,2.0]" ) ).toBe( "(1.0,2.0]" );
+					expect( util.resolveVersionRange( "(,1.0]" ) ).toBe( "(,1.0]" );
+					expect( util.resolveVersionRange( "[1.0,1.5],[2.0,)" ) ).toBe( "[1.0,1.5],[2.0,)" );
+					expect( util.resolveVersionRange( "[1.2.*]" ) ).toBe( "[1.2.*]" );
+				});
+
+				it( "malformed specs fall through gracefully (no stack trace at parse time)", function() {
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					expect( util.resolveVersionRange( "[garbage" ) ).toBe( "[garbage" );
+					expect( util.resolveVersionRange( "" ) ).toBe( "" );
+				});
+			});
+
+			// ---------------------------------------------------------------------
+			// MavenVersion.isPreRelease — used by pickHighest to filter transitive
+			// milestone/alpha/beta/rc/snapshot candidates that a bare-release range
+			// shouldn't pull in.
+			// ---------------------------------------------------------------------
+			describe( "MavenVersion.isPreRelease — qualifier detection", function() {
+
+				it( "returns false for plain release versions", function() {
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0" ).isPreRelease() ).toBeFalse();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "2.3.9" ).isPreRelease() ).toBeFalse();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-ga" ).isPreRelease() ).toBeFalse();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-final" ).isPreRelease() ).toBeFalse();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-sp1" ).isPreRelease() ).toBeFalse();
+				});
+
+				it( "returns true for alpha/beta/milestone/rc/cr/snapshot qualifiers", function() {
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-alpha-1" ).isPreRelease() ).toBeTrue();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-beta" ).isPreRelease() ).toBeTrue();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "3.0.0-M5" ).isPreRelease() ).toBeTrue();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-rc1" ).isPreRelease() ).toBeTrue();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-cr1" ).isPreRelease() ).toBeTrue();
+					expect( createObject( "java", "lucee.runtime.mvn.MavenVersion" ).init( "1.0-SNAPSHOT" ).isPreRelease() ).toBeTrue();
+				});
+			});
+
+			// ---------------------------------------------------------------------
+			// MavenVersionRange.pickHighest — critical piece of metadata-driven
+			// resolution. Pre-releases must be filtered unless the range spec
+			// itself names a pre-release bound (otherwise transitive [2.2,3)
+			// pulls in 3.0.0-M5 over 2.3.9, which is nobody's expectation).
+			// ---------------------------------------------------------------------
+			describe( "MavenVersionRange.pickHighest — pre-release filtering", function() {
+
+				it( "skips milestones/alphas/betas when range is release-bounded", function() {
+					var range = createObject( "java", "lucee.runtime.mvn.MavenVersionRange" ).init( "[2.2,3)" );
+					var list  = createObject( "java", "java.util.ArrayList" ).init();
+					list.add( "2.2.11" );
+					list.add( "2.3.9" );
+					list.add( "3.0.0-M5" );
+					list.add( "3.0.0-beta-1" );
+					local.picked = range.pickHighest( list );
+					expect( isNull( local.picked ) ).toBeFalse();
+					expect( local.picked.asString() ).toBe( "2.3.9",
+						"expected 2.3.9 (highest stable release in [2.2,3)), got #local.picked.asString()#" );
+				});
+
+				it( "allows pre-releases when the range bound is itself a pre-release", function() {
+					var range = createObject( "java", "lucee.runtime.mvn.MavenVersionRange" ).init( "[3.0.0-M1,3.0.0)" );
+					var list  = createObject( "java", "java.util.ArrayList" ).init();
+					list.add( "3.0.0-M1" );
+					list.add( "3.0.0-M3" );
+					list.add( "3.0.0-M5" );
+					local.picked = range.pickHighest( list );
+					expect( isNull( local.picked ) ).toBeFalse();
+					expect( local.picked.asString() ).toBe( "3.0.0-M5" );
+				});
+
+				it( "returns null when only pre-releases are available in a release-bounded range", function() {
+					var range = createObject( "java", "lucee.runtime.mvn.MavenVersionRange" ).init( "[1.0,2.0)" );
+					var list  = createObject( "java", "java.util.ArrayList" ).init();
+					list.add( "1.5-M1" );
+					list.add( "1.5-beta" );
+					list.add( "1.5-SNAPSHOT" );
+					expect( isNull( range.pickHighest( list ) ) ).toBeTrue();
+				});
+
+				it( "picks a real release when range is pinned and candidate list has extras", function() {
+					var range = createObject( "java", "lucee.runtime.mvn.MavenVersionRange" ).init( "[1.0]" );
+					var list  = createObject( "java", "java.util.ArrayList" ).init();
+					list.add( "1.0" );
+					list.add( "1.0-SNAPSHOT" );
+					list.add( "1.0.1" );
+					local.picked = range.pickHighest( list );
+					expect( isNull( local.picked ) ).toBeFalse();
+					expect( local.picked.asString() ).toBe( "1.0" );
+				});
+			});
+
+			// ---------------------------------------------------------------------
+			// Integrated resolver path — 6-arg resolveVersionRange against a
+			// pre-seeded local mvnDir. Exercises the full parse → local-scan →
+			// cache → pickHighest chain without any real HTTP. Catches any
+			// mismatch between unit-level behaviour and the end-to-end path.
+			// ---------------------------------------------------------------------
+			describe( "MavenUtil.resolveVersionRange (6-arg) — end-to-end with seeded mvnDir", function() {
+
+				it( "picks highest locally-installed version in range (no cache, no HTTP)", function() {
+					var mvnDir = seedMvnDir();
+					// Simulate prior installs: version subdirs exist on disk
+					createVersionDir( mvnDir, "org.glassfish.jaxb", "jaxb-runtime", "2.2.11" );
+					createVersionDir( mvnDir, "org.glassfish.jaxb", "jaxb-runtime", "2.3.9" );
+					createVersionDir( mvnDir, "org.glassfish.jaxb", "jaxb-runtime", "2.3.5" );
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					var result = util.resolveVersionRange( mvnDir, "org.glassfish.jaxb", "jaxb-runtime",
+						"[2.2,3)", createObject( "java", "java.util.ArrayList" ).init(), javaCast( "null", "" ) );
+					expect( result ).toBe( "2.3.9" );
+				});
+
+				it( "picks highest in-range from seeded metadata cache when no local version", function() {
+					var mvnDir = seedMvnDir();
+					seedMetadataCache( mvnDir, "org.glassfish.jaxb", "jaxb-runtime",
+						[ "2.2.11", "2.3.5", "2.3.9", "3.0.0-M5" ] );
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					var result = util.resolveVersionRange( mvnDir, "org.glassfish.jaxb", "jaxb-runtime",
+						"[2.2,3)", createObject( "java", "java.util.ArrayList" ).init(), javaCast( "null", "" ) );
+					// 3.0.0-M5 excluded by pre-release filter; 2.3.9 is highest stable in range
+					expect( result ).toBe( "2.3.9" );
+				});
+
+				it( "throws IOException when range unsatisfiable by seeded metadata", function() {
+					var mvnDir = seedMvnDir();
+					seedMetadataCache( mvnDir, "org.example", "nothing",
+						[ "1.0", "1.1", "1.2" ] );
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					expect( function() {
+						util.resolveVersionRange( mvnDir, "org.example", "nothing",
+							"[5.0,6.0)", createObject( "java", "java.util.ArrayList" ).init(), javaCast( "null", "" ) );
+					} ).toThrow();
+				});
+
+				it( "local version wins even if metadata cache has newer", function() {
+					var mvnDir = seedMvnDir();
+					createVersionDir( mvnDir, "org.example", "lib", "2.0.0" );
+					seedMetadataCache( mvnDir, "org.example", "lib",
+						[ "1.0", "2.0.0", "2.5.0", "2.9.0" ] );
+					var util = createObject( "java", "lucee.runtime.mvn.MavenUtil" );
+					var result = util.resolveVersionRange( mvnDir, "org.example", "lib",
+						"[2.0,3.0)", createObject( "java", "java.util.ArrayList" ).init(), javaCast( "null", "" ) );
+					// local-first: 2.0.0 is on disk, so we don't consult the cache
+					expect( result ).toBe( "2.0.0" );
+				});
+			});
+
+			// ---------------------------------------------------------------------
+			// End-to-end integration — exercises the full install pipeline through
+			// the user-facing mavenLoad() BIF. Only runs transitive range resolution
+			// because mavenLoad takes a concrete top-level GAV, but the transitive
+			// graph is where the range bug bites in real extensions.
+			// ---------------------------------------------------------------------
+			describe( "mavenLoad() — end-to-end install with transitive ranges (hits Central)", function() {
+
+				it( "ehcache 3.10.8 loads cleanly (transitively pulls jaxb-runtime:[2.2,3))", function() {
+					// Before the fix: walker hit jaxb-runtime:[2.2,3), resolved to literal "2.2",
+					// tried to fetch jaxb-runtime-2.2.pom → 404 → missing dep.
+					// After: metadata fetch picks an actual 2.x release → resolves cleanly.
+					var jars = mavenLoad( {
+						"groupId":    "org.ehcache",
+						"artifactId": "ehcache",
+						"version":    "3.10.8"
+					} );
+					expect( isArray( jars ) ).toBeTrue();
+					expect( arrayLen( jars ) ).toBeGT( 0, "expected ehcache to resolve to at least one jar" );
+					// jaxb-runtime should be in the resolved set at a real 2.x version,
+					// not at the non-existent bare "2.2"
+					var hasRealJaxb = false;
+					for ( var p in jars ) {
+						if ( findNoCase( "jaxb-runtime-2.", p ) && !findNoCase( "jaxb-runtime-2.2.jar", p ) ) {
+							hasRealJaxb = true;
+							break;
+						}
+					}
+					expect( hasRealJaxb ).toBeTrue( "expected jaxb-runtime at a real 2.x version, not bare 2.2" );
+				});
+			});
+		});
+	}
+
+	// ---------------------------------------------------------------------
+	// Helpers for the seeded-mvnDir block. Each call produces a unique tmp
+	// root so tests stay isolated. Per test-hygiene convention we clean up
+	// *before* each test, not after, leaving artifacts for inspection.
+	// ---------------------------------------------------------------------
+
+	private any function seedMvnDir() {
+		var path = getTempDirectory() & "/ldev6278-mvn-" & createUUID() & "/";
+		directoryCreate( path, true, true );
+		return createObject( "java", "lucee.commons.io.res.util.ResourceUtil" )
+			.toResourceNotExisting( getPageContext(), path );
+	}
+
+	private void function createVersionDir( required any mvnDir, required string groupId, required string artifactId, required string version ) {
+		var rel = replace( arguments.groupId, ".", "/", "all" ) & "/" & arguments.artifactId & "/" & arguments.version & "/";
+		directoryCreate( arguments.mvnDir.getAbsolutePath() & "/" & rel, true, true );
+	}
+
+	private void function seedMetadataCache( required any mvnDir, required string groupId, required string artifactId, required array versions ) {
+		var rel = replace( arguments.groupId, ".", "/", "all" ) & "/" & arguments.artifactId & "/";
+		var dir = arguments.mvnDir.getAbsolutePath() & "/" & rel;
+		directoryCreate( dir, true, true );
+		var xml = '<?xml version="1.0" encoding="UTF-8"?>' & chr(10)
+			& '<metadata>' & chr(10)
+			& '  <groupId>' & arguments.groupId & '</groupId>' & chr(10)
+			& '  <artifactId>' & arguments.artifactId & '</artifactId>' & chr(10)
+			& '  <versioning>' & chr(10)
+			& '    <versions>' & chr(10);
+		for ( var v in arguments.versions ) {
+			xml &= '      <version>' & v & '</version>' & chr(10);
+		}
+		xml &= '    </versions>' & chr(10) & '  </versioning>' & chr(10) & '</metadata>' & chr(10);
+		fileWrite( dir & "maven-metadata.xml", xml );
+		fileWrite( dir & "maven-metadata.xml.lastUpdated", toString( getTickCount() ) );
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces the legacy substring hack in `MavenUtil.resolveVersionRange` (`v = v.substring(1, v.indexOf(','))`) with proper maven range parsing. `MavenVersion` + `MavenVersionRange` are source-ported from Apache Maven Resolver 2.0.16 (`GenericVersion`, `GenericVersionRange`) with the Apache-2.0 header preserved — no new runtime dep.
- Adds `MavenMetadataReader` for metadata-driven range resolution with file-backed cache (24h positive / 15min negative TTL, both sysprop-tunable), local-version-dir scan before HTTP, and stale-cache fallback on all-repos-fail.
- Pre-release filter in `pickHighest`: `[2.2,3)` picks the highest stable 2.x release, not `3.0.0-M5` (which is technically in range per maven compareTo but never what a transitive range is asking for).
- Loud `IOException` on unresolvable ranges naming coord + range + repo list, replacing the silent wrong-version behaviour that produced 404s on URLs like `.../jaxb-runtime/[2.2,3)/jaxb-runtime-[2.2,3).jar`.
- Shared `MavenUtil.assertDownloadAllowed(...)` helper so `lucee.maven.download.policy=error` blocks metadata fetches the same way it blocks artifact fetches.

Jira: https://luceeserver.atlassian.net/browse/LDEV-6278

## Test plan

- [x] Full suite `mvn test` — 0 failures, 0 errors
- [x] `test/tickets/LDEV6278.cfc` — 15/15 (unit + `isPreRelease` + `pickHighest` + seeded-mvnDir end-to-end + mavenLoad integration)
- [x] `test/general/MavenVersionParsing.cfc` — 123 comparison + 36 containment cases differential against aether 2.0.16, plus 20+ integrated `pickHighest` rows
- [ ] Backport audit — 6.1, 6.2 LTS, 7.0 stable, 7.2. Same substring hack on all branches; new files are self-contained; expected clean cherry-pick