### PR TITLE
LDEV-6298 share static infrastructure on Component.duplicate()

### DIFF
--- a/core/src/main/java/lucee/runtime/ComponentImpl.java
+++ b/core/src/main/java/lucee/runtime/ComponentImpl.java
@@ -446,6 +446,19 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 			for (Entry<Key, UDF> e: srcMap.entrySet()) {
 				udf = e.getValue();
 
+				// LDEV-6298: flyweight property accessors are stateless dispatchers (LDEV-3335) —
+				// dispatch reads/writes against the calling `this` scope, not the prototype.
+				// Safe to share across duplicates; mirrors the LDEV-6236 short-circuit in addUDFS.
+				// Compare via pageSource so chained duplicates (a → b → c) still match: the shared
+				// UDF's owner stays at the prototype, but the class identity is what matters.
+				if (udf instanceof UDFGSProperty) {
+					Component udfOwner = udf.getOwnerComponent();
+					if (udfOwner == null || udfOwner.getPageSource() == src.getPageSource()) {
+						trgMap.put(e.getKey(), udf);
+					}
+					continue;
+				}
+
 				if (udf.getOwnerComponent() == src) {
 					UDF clone = e.getValue().duplicate();
 					if (clone instanceof UDFPlus) {

--- a/core/src/main/java/lucee/runtime/ComponentImpl.java
+++ b/core/src/main/java/lucee/runtime/ComponentImpl.java
@@ -450,14 +450,9 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 			for (Entry<Key, UDF> e: srcMap.entrySet()) {
 				udf = e.getValue();
 
-				// LDEV-6298: flyweight property accessors are stateless dispatchers (LDEV-3335) —
-				// dispatch reads/writes against the calling `this` scope, not the prototype.
-				// Safe to share across duplicates; mirrors the LDEV-6236 short-circuit in addUDFS.
-				// Compare via pageSource so chained duplicates (a → b → c) still match: the shared
-				// UDF's owner stays at the prototype, but the class identity is what matters.
+				// pageSource compare so chained duplicates match
 				if (udf instanceof UDFGSProperty) {
-					Component udfOwner = udf.getOwnerComponent();
-					if (udfOwner == null || udfOwner.getPageSource() == src.getPageSource()) {
+					if (udf.getOwnerComponent().getPageSource() == src.getPageSource()) {
 						trgMap.put(e.getKey(), udf);
 					}
 					continue;

--- a/core/src/main/java/lucee/runtime/ComponentImpl.java
+++ b/core/src/main/java/lucee/runtime/ComponentImpl.java
@@ -316,7 +316,11 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 			trg.isExtended = isExtended;
 			trg.afterConstructor = afterConstructor;
 			trg.dataMemberDefaultAccess = dataMemberDefaultAccess;
-			trg.properties = properties.duplicate();
+			// LDEV-6298 follow-up: ComponentProperties is treated as immutable post-init
+			// (its only post-init mutator setInline() runs in ComponentLoader before any
+			// duplicate, and the inner property/meta maps are populated once during init).
+			// Share the wrapper rather than allocating a fresh one per duplicate.
+			trg.properties = properties;
 			trg.isInit = isInit;
 			trg.absFin = absFin;
 			trg.isRestEnabled = this.isRestEnabled;

--- a/core/src/main/java/lucee/runtime/ComponentProperties.java
+++ b/core/src/main/java/lucee/runtime/ComponentProperties.java
@@ -26,6 +26,10 @@ import lucee.runtime.type.Collection;
 import lucee.runtime.type.Struct;
 import lucee.runtime.type.util.KeyConstants;
 
+/**
+ * Shared across all duplicates of a prototype (LDEV-6298). Treat as immutable post-init.
+ * Any new post-init mutation will silently leak across every duplicate of the same prototype.
+ */
 public final class ComponentProperties implements Serializable {
 
 	private static final Collection.Key WSDL_FILE = KeyConstants._wsdlfile;

--- a/test/tickets/LDEV6298.cfc
+++ b/test/tickets/LDEV6298.cfc
@@ -1,0 +1,101 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" {
+
+	function run( testResults, testBox ){
+		describe( title="LDEV-6298 share flyweight property accessors across Component duplicates", body=function(){
+
+			describe( title="runtime mutation isolation", body=function(){
+				it( title="overriding accessor on duplicate doesn't leak to source", body=function( currentSpec ){
+					var orig = new LDEV3335.testPropertyTypes();
+					orig.setAge( 30 );
+					var copy = duplicate( orig );
+					copy.getAge = function() { return 999; };
+					expect( copy.getAge() ).toBe( 999 );
+					expect( orig.getAge() ).toBe( 30 );
+				});
+				it( title="overriding accessor on source doesn't leak to existing duplicate", body=function( currentSpec ){
+					var orig = new LDEV3335.testPropertyTypes();
+					var copy = duplicate( orig );
+					orig.getAge = function() { return 777; };
+					expect( orig.getAge() ).toBe( 777 );
+					// duplicate must still use real accessor
+					copy.setAge( 42 );
+					expect( copy.getAge() ).toBe( 42 );
+				});
+				it( title="injecting new method on duplicate doesn't leak to source", body=function( currentSpec ){
+					var orig = new LDEV3335.testWithAccessors();
+					var copy = duplicate( orig );
+					copy.customMethod = function() { return "from copy"; };
+					expect( copy.customMethod() ).toBe( "from copy" );
+					expect( function(){ orig.customMethod(); } ).toThrow();
+				});
+			});
+
+			describe( title="mass duplication (ORM hot path)", body=function(){
+				it( title="50 duplicates from one prototype — all isolated", body=function( currentSpec ){
+					var prototype = new LDEV3335.testPropertyTypes();
+					var entities = [];
+					for ( var i=1; i<=50; i++ ) {
+						var entity = duplicate( prototype );
+						entity.setAge( i );
+						entity.setName( "entity-" & i );
+						arrayAppend( entities, entity );
+					}
+					for ( var i=1; i<=50; i++ ) {
+						expect( entities[ i ].getAge() ).toBe( i );
+						expect( entities[ i ].getName() ).toBe( "entity-" & i );
+					}
+				});
+				it( title="duplicates remain isolated when prototype is mutated mid-flight", body=function( currentSpec ){
+					var prototype = new LDEV3335.testWithAccessors();
+					prototype.setA( "before" );
+					var early = duplicate( prototype );
+					prototype.setA( "after" );
+					var late = duplicate( prototype );
+					expect( early.getA() ).toBe( "before" );
+					expect( late.getA() ).toBe( "after" );
+				});
+			});
+
+			describe( title="duplicate of duplicate", body=function(){
+				it( title="three-level chain — each level isolated", body=function( currentSpec ){
+					var a = new LDEV3335.testWithAccessors();
+					a.setA( "level-a" );
+					var b = duplicate( a );
+					b.setA( "level-b" );
+					var c = duplicate( b );
+					c.setA( "level-c" );
+					expect( a.getA() ).toBe( "level-a" );
+					expect( b.getA() ).toBe( "level-b" );
+					expect( c.getA() ).toBe( "level-c" );
+				});
+			});
+
+			describe( title="reflection metadata still correct", body=function(){
+				it( title="getMetadata() on duplicate returns same property list as source", body=function( currentSpec ){
+					var orig = new LDEV3335.testPropertyTypes();
+					var copy = duplicate( orig );
+					var origMeta = getMetadata( orig );
+					var copyMeta = getMetadata( copy );
+					expect( copyMeta.name ).toBe( origMeta.name );
+					expect( arrayLen( copyMeta.properties ) ).toBe( arrayLen( origMeta.properties ) );
+				});
+			});
+
+			describe( title="inheritance preserved across duplicate", body=function(){
+				it( title="parent property accessor works on duplicated child", body=function( currentSpec ){
+					var child = new LDEV3335.testInheritChild();
+					var copy = duplicate( child );
+					expect( copy.getParentProp() ).toBe( "from parent" );
+					copy.setParentProp( "set on copy" );
+					expect( copy.getParentProp() ).toBe( "set on copy" );
+					expect( child.getParentProp() ).toBe( "from parent" );
+				});
+				it( title="child override of parent accessor preserved on duplicate", body=function( currentSpec ){
+					var orig = new LDEV3335.testInheritChildOverride();
+					var copy = duplicate( orig );
+					expect( copy.getParentProp() ).toBe( "CHILD OVERRIDE" );
+				});
+			});
+		});
+	}
+}

--- a/test/tickets/LDEV6298.cfc
+++ b/test/tickets/LDEV6298.cfc
@@ -56,7 +56,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 				});
 			});
 
-			describe( title="duplicate of duplicate", body=function(){
+			describe( title="chained duplicates (a → b → c)", body=function(){
 				it( title="three-level chain — each level isolated", body=function( currentSpec ){
 					var a = new LDEV3335.testWithAccessors();
 					a.setA( "level-a" );
@@ -67,6 +67,19 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 					expect( a.getA() ).toBe( "level-a" );
 					expect( b.getA() ).toBe( "level-b" );
 					expect( c.getA() ).toBe( "level-c" );
+				});
+				it( title="mixin at level B + mixin at level C — each mixin only visible at and below its level", body=function( currentSpec ){
+					var a = new LDEV3335.testWithAccessors();
+					var b = duplicate( a );
+					b.bMixin = function() { return "from b"; };
+					var c = duplicate( b );
+					c.cMixin = function() { return "from c"; };
+					expect( function(){ a.bMixin(); } ).toThrow();
+					expect( function(){ a.cMixin(); } ).toThrow();
+					expect( b.bMixin() ).toBe( "from b" );
+					expect( function(){ b.cMixin(); } ).toThrow();
+					expect( c.bMixin() ).toBe( "from b" );
+					expect( c.cMixin() ).toBe( "from c" );
 				});
 			});
 
@@ -94,6 +107,209 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 					var orig = new LDEV3335.testInheritChildOverride();
 					var copy = duplicate( orig );
 					expect( copy.getParentProp() ).toBe( "CHILD OVERRIDE" );
+				});
+			});
+
+			describe( title="mixin propagation: prototype → duplicate", body=function(){
+				it( title="closure mixed onto prototype is carried into the duplicate", body=function( currentSpec ){
+					var orig = new LDEV3335.testWithAccessors();
+					orig.customMethod = function() { return "mixed in"; };
+					var copy = duplicate( orig );
+					expect( copy.customMethod() ).toBe( "mixed in" );
+				});
+				it( title="mixin-overridden accessor survives duplicate, and re-override on copy is isolated", body=function( currentSpec ){
+					var orig = new LDEV3335.testPropertyTypes();
+					orig.getAge = function() { return 999; };
+					var copy = duplicate( orig );
+					expect( copy.getAge() ).toBe( 999 );
+					// re-override on copy must not bleed back to orig
+					copy.getAge = function() { return 111; };
+					expect( copy.getAge() ).toBe( 111 );
+					expect( orig.getAge() ).toBe( 999 );
+				});
+				it( title="structDelete of mixed-in method on duplicate doesn't remove it from source", body=function( currentSpec ){
+					var orig = new LDEV3335.testWithAccessors();
+					orig.shared = function() { return "original"; };
+					var copy = duplicate( orig );
+					structDelete( copy, "shared" );
+					expect( orig.shared() ).toBe( "original" );
+					expect( function(){ copy.shared(); } ).toThrow();
+				});
+				it( title="restoring real accessor after duplicate restores dispatch", body=function( currentSpec ){
+					var orig = new LDEV3335.testPropertyTypes();
+					orig.getAge = function() { return 999; };
+					var copy = duplicate( orig );
+					// orig still has the mixin
+					expect( orig.getAge() ).toBe( 999 );
+					// removing the mixin from copy should fall back to default (or property scope)
+					structDelete( copy, "getAge" );
+					copy.setAge( 42 );
+					expect( orig.getAge() ).toBe( 999 );
+					// note: copy.getAge() after structDelete depends on accessor regen — not asserting beyond isolation
+				});
+			});
+
+			describe( title="sibling duplicate isolation (dup1 vs dup2)", body=function(){
+				it( title="two sibling duplicates with different mixins — fooMixin on dup1, barMixin on dup2 — fully isolated", body=function( currentSpec ){
+					var proto = new LDEV3335.testWithAccessors();
+					var dup1 = duplicate( proto );
+					var dup2 = duplicate( proto );
+
+					dup1.fooMixin = function() { return "foo from dup1"; };
+					dup2.barMixin = function() { return "bar from dup2"; };
+
+					// dup1 has foo, not bar
+					expect( dup1.fooMixin() ).toBe( "foo from dup1" );
+					expect( function(){ dup1.barMixin(); } ).toThrow();
+
+					// dup2 has bar, not foo
+					expect( dup2.barMixin() ).toBe( "bar from dup2" );
+					expect( function(){ dup2.fooMixin(); } ).toThrow();
+
+					// proto has neither
+					expect( function(){ proto.fooMixin(); } ).toThrow();
+					expect( function(){ proto.barMixin(); } ).toThrow();
+
+					// accessors still dispatch independently against each instance's own scope
+					proto.setA( "proto-a" );
+					dup1.setA( "dup1-a" );
+					dup2.setA( "dup2-a" );
+					expect( proto.getA() ).toBe( "proto-a" );
+					expect( dup1.getA() ).toBe( "dup1-a" );
+					expect( dup2.getA() ).toBe( "dup2-a" );
+				});
+				it( title="two sibling duplicates override the same accessor with different closures — isolated", body=function( currentSpec ){
+					var proto = new LDEV3335.testWithAccessors();
+					var dup1 = duplicate( proto );
+					var dup2 = duplicate( proto );
+
+					dup1.getA = function() { return "from dup1"; };
+					dup2.getA = function() { return "from dup2"; };
+
+					expect( dup1.getA() ).toBe( "from dup1" );
+					expect( dup2.getA() ).toBe( "from dup2" );
+
+					// proto's real accessor still works against its own scope
+					proto.setA( "proto-real" );
+					expect( proto.getA() ).toBe( "proto-real" );
+				});
+				it( title="getMetadata stays structurally identical across dup1, dup2, proto even with divergent runtime mixins", body=function( currentSpec ){
+					// getMetadata is structural — it reads from the shared ComponentProperties wrapper
+					// and only surfaces declared cffunction/accessors, NOT runtime closure assignments
+					// (those land in _data, not _udfs). Sharing the wrapper means metadata MUST stay
+					// consistent across all duplicates of one prototype. Runtime mixins must not bleed
+					// into metadata structure on any of them.
+					var proto = new LDEV3335.testWithAccessors();
+					var dup1 = duplicate( proto );
+					var dup2 = duplicate( proto );
+
+					// runtime mixins on each duplicate
+					dup1.fooMixin = function() { return "foo"; };
+					dup2.barMixin = function() { return "bar"; };
+
+					// runtime dispatch works (isolation) — sanity check
+					expect( dup1.fooMixin() ).toBe( "foo" );
+					expect( dup2.barMixin() ).toBe( "bar" );
+					expect( function(){ proto.fooMixin(); } ).toThrow();
+					expect( function(){ proto.barMixin(); } ).toThrow();
+
+					// metadata is identical across all three despite divergent mixins
+					var metaProto = getMetadata( proto );
+					var metaDup1  = getMetadata( dup1 );
+					var metaDup2  = getMetadata( dup2 );
+
+					expect( metaDup1.name ).toBe( metaProto.name );
+					expect( metaDup2.name ).toBe( metaProto.name );
+					expect( arrayLen( metaDup1.properties ) ).toBe( arrayLen( metaProto.properties ) );
+					expect( arrayLen( metaDup2.properties ) ).toBe( arrayLen( metaProto.properties ) );
+					expect( arrayLen( metaDup1.functions ) ).toBe( arrayLen( metaProto.functions ) );
+					expect( arrayLen( metaDup2.functions ) ).toBe( arrayLen( metaProto.functions ) );
+				});
+			});
+
+			describe( title="concurrent duplication — ORM hot-path stress", body=function(){
+				it( title="50 threads × 20 duplicates each — all isolated, accessors dispatch correctly", body=function( currentSpec ){
+					var prototype = new LDEV3335.testPropertyTypes();
+					var threadCount = 50;
+					var perThread = 20;
+					var threadNames = [];
+					for ( var t=1; t<=threadCount; t++ ) {
+						var tname = "ldev6298-stress-" & t;
+						arrayAppend( threadNames, tname );
+						thread name="#tname#" tid=t proto=prototype perThread=perThread {
+							thread.results = [];
+							for ( var i=1; i<=attributes.perThread; i++ ) {
+								var dup = duplicate( attributes.proto );
+								var ageVal = ( attributes.tid * 1000 ) + i;
+								dup.setAge( ageVal );
+								dup.setName( "t" & attributes.tid & "-i" & i );
+								arrayAppend( thread.results, { age: dup.getAge(), name: dup.getName(), expectedAge: ageVal, expectedName: "t" & attributes.tid & "-i" & i } );
+							}
+						}
+					}
+					thread action="join" name="#arrayToList( threadNames )#";
+					for ( var t=1; t<=threadCount; t++ ) {
+						var tname = "ldev6298-stress-" & t;
+						var th = cfthread[ tname ];
+						if ( th.status != "COMPLETED" ) throw( object=th.error );
+						expect( arrayLen( th.results ) ).toBe( perThread );
+						for ( var r in th.results ) {
+							expect( r.age ).toBe( r.expectedAge );
+							expect( r.name ).toBe( r.expectedName );
+						}
+					}
+					// prototype itself untouched
+					expect( prototype.getAge() ).toBe( 25 );
+					expect( prototype.getName() ).toBe( "John" );
+				});
+				it( title="concurrent duplicate + mixin — mixin on one thread doesn't leak to another", body=function( currentSpec ){
+					var prototype = new LDEV3335.testWithAccessors();
+					var threadCount = 20;
+					var threadNames = [];
+					for ( var t=1; t<=threadCount; t++ ) {
+						var tname = "ldev6298-mix-" & t;
+						arrayAppend( threadNames, tname );
+						thread name="#tname#" tid=t proto=prototype {
+							var dup = duplicate( attributes.proto );
+							dup.tag = function() { return "thread-" & attributes.tid; };
+							dup.setA( "a-" & attributes.tid );
+							thread.tagResult = dup.tag();
+							thread.aResult = dup.getA();
+						}
+					}
+					thread action="join" name="#arrayToList( threadNames )#";
+					for ( var t=1; t<=threadCount; t++ ) {
+						var tname = "ldev6298-mix-" & t;
+						var th = cfthread[ tname ];
+						if ( th.status != "COMPLETED" ) throw( object=th.error );
+						expect( th.tagResult ).toBe( "thread-" & t );
+						expect( th.aResult ).toBe( "a-" & t );
+					}
+					// prototype never received the mixin
+					expect( function(){ prototype.tag(); } ).toThrow();
+				});
+				it( title="concurrent getMetadata across duplicates — shared javaAccessClass cache stays consistent", body=function( currentSpec ){
+					// F1: commit 2 makes ComponentProperties.javaAccessClass a lazy cache on a SHARED wrapper.
+					// Hammer getMetadata() concurrently across duplicates of one prototype to surface any
+					// race / disk-contention / stale-cache issue introduced by the share.
+					var prototype = new LDEV3335.testPropertyTypes();
+					var dups = [];
+					for ( var i=1; i<=20; i++ ) arrayAppend( dups, duplicate( prototype ) );
+					var threadNames = [];
+					for ( var t=1; t<=20; t++ ) {
+						var tname = "ldev6298-meta-" & t;
+						arrayAppend( threadNames, tname );
+						thread name="#tname#" comp=dups[ t ] {
+							thread.meta = getMetadata( attributes.comp );
+						}
+					}
+					thread action="join" name="#arrayToList( threadNames )#";
+					for ( var t=1; t<=20; t++ ) {
+						var tname = "ldev6298-meta-" & t;
+						var th = cfthread[ tname ];
+						if ( th.status != "COMPLETED" ) throw( object=th.error );
+						expect( arrayLen( th.meta.properties ) ).toBe( 3 );
+					}
 				});
 			});
 		});


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6298

**Commit 1 — `duplicateUTFMap`:** share the `UDFGSProperty` reference instead of `udf.duplicate()` + owner rebind. UDFGSProperty is a stateless flyweight (LDEV-3335) — dispatch resolves against the calling `this` scope, so a single instance can serve any duplicate of the same prototype. `_udfs` is populated exclusively via `registerUDF` which force-sets owner ([ComponentImpl.java:2056](core/src/main/java/lucee/runtime/ComponentImpl.java#L2056)), so `udf.getOwnerComponent()` is non-null here — no defensive null-check.

**Commit 2 — `_duplicate()` line 319:** share the `ComponentProperties` wrapper directly rather than calling `properties.duplicate()`. The wrapper's `duplicate()` already shared the underlying property metadata maps; only the wrapper itself was being allocated.

## Design choices that affect review

### pageSource comparison instead of identity (commit 1)

Identity comparison (`udfOwner == src`) would silently break chained duplicates: after `b = duplicate(a)`, the shared UDFGSProperty's owner still points at `a`. When `c = duplicate(b)`, identity-compare finds no match and the accessor doesn't get into `c._udfs`. `pageSource` comparison handles this — covered by the "chained duplicates" describe block in `test/tickets/LDEV6298.cfc`. Would manifest immediately as a missing-method exception on the third-level duplicate (loud, not silent).

### `ComponentProperties` post-init immutability invariant (commit 2)

Sharing requires the wrapper to be effectively immutable post-init. Audit of all mutators:

| Mutator | Where | Phase | Impact |
| --- | --- | --- | --- |
| `setInline()` | `ComponentImpl.java:2838` | Called from `ComponentLoader._loadComponent` line 622 on freshly-loaded inline components, **before any duplicate** | Pre-duplicate timing — sharing inherits the value safely |
| `properties.properties = new LinkedHashMap<>()` | `ComponentImpl.java:2472` | Inside `initProperties()`, called once at instantiation | Never re-runs per-duplicate |
| `properties.properties.put(...)` | `ComponentImpl.java:2453` | Inside `setProperty()` during init | Same as above |
| `javaAccessClass` lazy populate | `ComponentImpl.java:2407, 2418` | Post-init: written on first `getJavaAccessClass()` call | **Benign**: Class is derived from `pageSource` + remote-method keys — identical across all duplicates of the prototype. Sharing the cache produces no observable change and is an incidental perf win (fewer redundant resolutions). Idempotent under concurrent writes. |

Class-level Javadoc on `ComponentProperties` documents the share invariant. Hardening fields to `final` requires restructuring init flow — out of scope; tracked separately if needed.

## Verification

- Test suite passes identically on **unpatched Lucee 7.0.4.30-SNAPSHOT** and **this branch on 7.1** — confirms behaviour-preserving optimisation. If sharing altered semantics, the dynamism edge cases (mixins, chained duplicates, sibling isolation) would diverge between versions.
- Coverage in `test/tickets/LDEV6298.cfc` (20 specs across 8 suites): basic accessor dispatch, mass duplication, three-level chains with per-level mixins, sibling isolation (dup1 vs dup2), `getMetadata` consistency, inheritance + accessors, concurrent ORM stress (50×20 threads), concurrent `getMetadata` (exercises shared `javaAccessClass` lazy cache).
- LDEV-6271 (recent property-default-scope-seeding fix) tests pass on this branch.

## Risk

**Commit 1:** low. UDFGSProperty's flyweight contract (LDEV-3335) makes sharing safe by design. The pageSource subtlety would break loudly (missing-method exception) if it regressed, not silently.

**Commit 2:** low. Invariant audit covers all four mutators including the lazy `javaAccessClass` cache. The class-level Javadoc on `ComponentProperties` flags the share invariant for future contributors.
