### PR TITLE
LDEV-6301 restore ConcurrentHashMap in ComponentPathCache

### DIFF
--- a/core/src/main/java/lucee/runtime/config/ComponentPathCache.java
+++ b/core/src/main/java/lucee/runtime/config/ComponentPathCache.java
@@ -2,10 +2,10 @@ package lucee.runtime.config;
 
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lucee.runtime.CIPage;
 import lucee.runtime.Page;
@@ -17,7 +17,7 @@ import lucee.runtime.type.Struct;
 import lucee.runtime.type.StructImpl;
 
 public class ComponentPathCache {
-	private final Map<String, Reference<PageSource>> componentPathCache = new HashMap<>();
+	private final Map<String, Reference<PageSource>> componentPathCache = new ConcurrentHashMap<>();
 
 	public CIPage getPage(PageContext pc, String pathWithCFC) throws PageException {
 		Reference<PageSource> tmp = componentPathCache.get(pathWithCFC.toLowerCase());

--- a/loader/build.xml
+++ b/loader/build.xml
@@ -2,7 +2,7 @@
 <project default="core" basedir="." name="Lucee" 
   xmlns:resolver="antlib:org.apache.maven.resolver.ant">
 
-  <property name="version" value="7.0.4.30-SNAPSHOT"/>
+  <property name="version" value="7.0.4.31-SNAPSHOT"/>
 
   <taskdef uri="antlib:org.apache.maven.resolver.ant" resource="org/apache/maven/resolver/ant/antlib.xml">
     <classpath>

--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.lucee</groupId>
   <artifactId>lucee</artifactId>
-  <version>7.0.4.30-SNAPSHOT</version>
+  <version>7.0.4.31-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Lucee Loader Build</name>


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6301

## Context

`ComponentPathCache` (introduced in LDEV-5536, May 2025) backs the global component-path → `PageSource` cache hit on every component load. The original implementation used `ConcurrentHashMap`, marked with `// MUSTMUST new` to flag that requirement.

The cleanup commit for LDEV-5940 (`8d4f336a5`, Dec 2025) moved the field from lazy-init to eager final init — a sensible cleanup — but in the process silently downgraded the type to plain `HashMap` and deleted the `MUSTMUST` marker.

## Impact

`HashMap` is not thread-safe. Under concurrent component loading (request-handler threads, `arrayEach parallel=true`, async tasks), table corruption during resize can cause `get()` to return `null` while a value is present, return a `Reference` for the wrong key, or lose entries. Symptom: intermittent `invalid component definition, can't find component [X]` errors despite the component existing on disk and a sibling in the same directory loading successfully moments earlier.

Observed in CI flake on 7.1: https://github.com/lucee/Lucee/actions/runs/25163251577 — TestBox `MockBox.cfc` loaded fine, then a sibling `createObject` for `MockGenerator` failed during `arrayEach parallel=true` test discovery. The next CI run on the same branch passed cleanly.

6.2 is unaffected; it still uses the original `ConcurrentHashMap`.

## Change

Restores `ConcurrentHashMap`. Keeps eager final init (the good half of LDEV-5940).

## Test plan

- [x] Full test suite on 7.0 (`mvn test`): 4829 pass, 0 errors. Single failure (`LDEV1574 GetSystemMetrics CPU`) is a pre-existing environmental flake — `getProcessCpuLoad()` returning `-1` before its first sampling window.
- [ ] Watch CI for the next 7.1 merge — the LDEV-6301 fix should travel down with `7.0 → 7.1` and we expect the testbox `MockGenerator` flake to disappear.

## Related

LDEV-5658 reports a symptom-identical "can't find component" sibling failure but in regression window 7.0.0.81 → 7.0.0.100 (Dec 2024 → Feb 2025), well before this HashMap landed. Different root cause; worth re-examining once this fix is in.