### PR TITLE
LDEV-6308 streamline native QoQ

### DIFF
--- a/core/src/main/java/lucee/runtime/db/HSQLDBHandler.java
+++ b/core/src/main/java/lucee/runtime/db/HSQLDBHandler.java
@@ -517,9 +517,11 @@ public final class HSQLDBHandler {
 				ThreadLocalPageContext.getLog(pc, "datasource").error("QoQ [" + sql.getSQLString() + "] errored and is falling back to HyperSQL.", qoqException);
 			}
 		}
-		else if (!useHsqldb) {
-			// engine=native but native returned null (couldn't handle the query) with no exception
-			throw new DatabaseException("Native QoQ engine could not handle this query and HSQLDB fallback is disabled (engine=native)", null, sql, null);
+		else if (!useHsqldb || hsqldbDisable) {
+			// Native returned null (couldn't handle the query, e.g. JOINs) with no exception, and
+			// HSQLDB fallback is blocked.
+			String which = !useHsqldb ? "engine=native" : "lucee.qoq.hsqldb.disable=true";
+			throw new DatabaseException("Native QoQ engine could not handle this query and HSQLDB fallback is disabled (" + which + ")", null, sql, null);
 		}
 
 		// SECOND Chance with hsqldb

--- a/core/src/main/java/lucee/runtime/db/QoQ.java
+++ b/core/src/main/java/lucee/runtime/db/QoQ.java
@@ -23,16 +23,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.function.Consumer;
-import java.util.function.IntConsumer;
-import java.util.function.IntPredicate;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import lucee.commons.io.SystemUtil;
 import lucee.commons.lang.CFTypes;
 import lucee.commons.lang.ExceptionUtil;
 import lucee.commons.lang.StringUtil;
@@ -78,12 +74,7 @@ import lucee.runtime.util.DBUtilImpl;
  */
 public final class QoQ {
 	final static private Collection.Key paramKey = new KeyImpl("?");
-	private static int qoqParallelism;
 	private boolean caseSensitive;
-
-	static {
-		qoqParallelism = Caster.toIntValue(SystemUtil.getSystemPropOrEnvVar("lucee.qoq.parallelism", "50"), 50);
-	}
 
 	public void setCaseSensitive(boolean caseSensitive) {
 		this.caseSensitive = caseSensitive;
@@ -184,13 +175,16 @@ public final class QoQ {
 	 * @throws PageException
 	 */
 	private static void order(PageContext pc, QueryImpl target, Expression[] columns, boolean isUnion, SQL sql) throws PageException {
-		Expression col;
-		// Build up a int[] that represents where each row needs to be in the final query
-		int[] sortedIndexes = getStream(target).boxed().sorted(new QueryComparator(pc, target, columns, isUnion, sql)).mapToInt(i -> i.intValue()).toArray();
+		// Build up a int[] that represents where each row needs to be in the final query.
+		int n = target.getRecordcount();
+		Integer[] boxed = new Integer[n];
+		for (int i = 0; i < n; i++) boxed[i] = i + 1;
+		Arrays.sort(boxed, new QueryComparator(pc, target, columns, isUnion, sql));
+		int[] sortedIndexes = new int[n];
+		for (int i = 0; i < n; i++) sortedIndexes[i] = boxed[i];
 
 		// Move the data around to match
 		target.sort(sortedIndexes);
-
 	}
 
 	/**
@@ -303,15 +297,19 @@ public final class QoQ {
 		// realized, so just copy it over positionally. The column names may not match, but that's
 		// fine.
 		QueryColumn[] srcCols = new QueryColumn[targetColKeys.length];
+		QueryColumnImpl[] prevCols = new QueryColumnImpl[previousColKeys.length];
 		for (int i = 0; i < targetColKeys.length; i++) {
 			srcCols[i] = target.getColumn(targetColKeys[i]);
+			prevCols[i] = (QueryColumnImpl) previous.getColumn(previousColKeys[i]);
 		}
-		getStream(target).forEach(throwingIntConsumer(row -> {
-			int newRow = previous.addRow();
+		int targetSize = target.getRecordcount();
+		int previousSize = previous.getRecordcount();
+		for (int row = 1; row <= targetSize; row++) {
 			for (int col = 0; col < targetColKeys.length; col++) {
-				previous.setAt(previousColKeys[col], newRow, srcCols[col].get(row, null), true);
+				prevCols[col].add(srcCols[col].get(row, null));
 			}
-		}));
+		}
+		previous.setRecordcount(previousSize + targetSize);
 
 		return previous;
 	}
@@ -348,24 +346,34 @@ public final class QoQ {
 		QueryPartitions queryPartitions = new QueryPartitions(sql, selectExpressions, new Expression[0], newTarget, new HashSet<Key>(), this, false);
 
 		// Add in all the rows from our previous work
-		getStream(previous).forEach(throwingIntConsumer(row -> {
+		int previousSize = previous.getRecordcount();
+		for (int row = 1; row <= previousSize; row++) {
 			queryPartitions.addRow(pc, previous, row, true);
-		}));
+		}
 
 		// ...and all of the new rows
-		getStream(target).forEach(throwingIntConsumer(row -> {
+		int targetSize = target.getRecordcount();
+		for (int row = 1; row <= targetSize; row++) {
 			queryPartitions.addRow(pc, target, row, true);
-		}));
+		}
 
-		// Loop over the partitions and take one from each and add to our new target question for a
-		// distinct result
-		getStream(queryPartitions).forEach(throwingConsumer(sourcePartition -> {
-			int newRow = newTarget.addRow();
+		queryPartitions.finalizePartitionRecordCounts();
 
+		// One row per partition into the new target. selectColRefs index matches previousColKeys
+		// because selectExpressions was built from previousColKeys.
+		QueryColumnImpl[] newTargetCols = new QueryColumnImpl[targetColKeys.length];
+		for (int i = 0; i < targetColKeys.length; i++) {
+			newTargetCols[i] = (QueryColumnImpl) newTarget.getColumn(previousColKeys[i]);
+		}
+		int added = 0;
+		for (Map.Entry<String, QueryPartitions.Partition> sourcePartition : queryPartitions.getPartitions().entrySet()) {
+			QueryPartitions.Partition partition = sourcePartition.getValue();
 			for (int col = 0; col < targetColKeys.length; col++) {
-				newTarget.setAt(previousColKeys[col], newRow, sourcePartition.getValue().getColumn(previousColKeys[col]).get(1, null), true);
+				newTargetCols[col].add(partition.selectColRefs[col].get(1, null));
 			}
-		}));
+			added++;
+		}
+		newTarget.setRecordcount(added);
 
 		return newTarget;
 	}
@@ -407,57 +415,21 @@ public final class QoQ {
 			return;
 		}
 
-		IntStream stream = getStream(source);
-		if (where != null) {
-			stream = stream.filter(throwingFilter(row -> {
-				// The where clause is a single Operation expression that returns true or false.
-				return Caster.toBooleanValue(executeExp(pc, sql, source, where, row));
-			}));
-		}
+		// column.add() is lock-free; source-order is preserved without ORDER BY (the old parallel
+		// path returned encounter order, which was non-deterministic).
+		int sourceSize = source.getRecordcount();
+		int limit = hasAggregateSelect ? 1 : (hasMaxrow ? maxrows : Integer.MAX_VALUE);
+		int added = 0;
 
-		// If this was a non-grouped select with only aggregates like select "count(1) from
-		// table" than bail after a single row
-		if (hasAggregateSelect) {
-			stream = stream.limit(1);
-			// If we can, optimize the max rows exit strategy
-			// This won't fire if there is an ORDER BY since we can't limit the rows until we sort (later)
-		}
-		else if (hasMaxrow) {
-			stream = stream.limit(maxrows);
-		}
-
-		stream.forEach(throwingIntConsumer(row -> {
-			int newRow = target.addRow();
+		for (int row = 1; row <= sourceSize && added < limit; row++) {
+			if (where != null && !Caster.toBooleanValue(executeExp(pc, sql, source, where, row))) continue;
 			for (int cell = 0; cell < headers.length; cell++) {
-				trgColumns[cell].set(newRow, getValue(pc, sql, source, row, headers[cell], trgValues[cell], null), true);
+				trgColumns[cell].add(getValue(pc, sql, source, row, headers[cell], trgValues[cell], null));
 			}
-		}));
-	}
+			added++;
+		}
 
-	public static IntStream getStream(QueryImpl qry) {
-		if (qry.getRecordcount() > 0) {
-			IntStream qStream = IntStream.range(1, qry.getRecordcount() + 1);
-			if (qry.getRecordcount() >= qoqParallelism) {
-				return qStream.parallel();
-			}
-			return qStream;
-		}
-		else {
-			return IntStream.empty();
-		}
-	}
-
-	public static Stream<Map.Entry<String, QueryImpl>> getStream(QueryPartitions queryPartitions) {
-		if (queryPartitions.getPartitions().size() > 0) {
-			Stream<Map.Entry<String, QueryImpl>> qStream = queryPartitions.getPartitions().entrySet().stream();
-			if (queryPartitions.getPartitions().size() >= qoqParallelism) {
-				qStream = qStream.parallel();
-			}
-			return qStream;
-		}
-		else {
-			return Stream.empty();
-		}
+		target.setRecordcount(added);
 	}
 
 	/**
@@ -497,18 +469,12 @@ public final class QoQ {
 		// Initialize object to track our partitioned data
 		QueryPartitions queryPartitions = new QueryPartitions(sql, select.getSelects(), select.getGroupbys(), target, select.getAdditionalColumns(), this, hasAggregateSelect);
 
-		IntStream stream = getStream(source);
-		if (where != null) {
-			stream = stream.filter(throwingFilter(row -> {
-				// The where clause is a single Operation expression that returns true or false.
-				return Caster.toBooleanValue(executeExp(pc, sql, source, where, row));
-			}));
-		}
-
-		stream.forEach(throwingIntConsumer(row -> {
-			// ... add this row to our partitioned data
+		// Phase 1: partition source rows by group-by key
+		int sourceSize = source.getRecordcount();
+		for (int row = 1; row <= sourceSize; row++) {
+			if (where != null && !Caster.toBooleanValue(executeExp(pc, sql, source, where, row))) continue;
 			queryPartitions.addRow(pc, source, row, false);
-		}));
+		}
 
 		// For a non-grouping query with aggregates where no records matched the where clause
 		// SELECT count(1) FROM qry WHERE 1=0
@@ -517,20 +483,17 @@ public final class QoQ {
 			queryPartitions.addEmptyPartition(source, target);
 		}
 
-		// Now that all rows are partitioned, eliminate partitions we don't need via the having
-		// clause
+		queryPartitions.finalizePartitionRecordCounts();
+
+		// Phase 2: eliminate partitions that fail the HAVING clause
 		if (select.getHaving() != null) {
-
-			// Loop over the partitions and take one from each and add to our new target question for a
-			// distinct result
-			getStream(queryPartitions).forEach(throwingConsumer(sourcePartition -> {
-				// Eval the having clause on it
-				if (!Caster.toBooleanValue(executeExp(pc, sql, sourcePartition.getValue(), select.getHaving(), 1))) {
-					// Voted off the island :/
-					queryPartitions.getPartitions().remove(sourcePartition.getKey());
+			Iterator<Map.Entry<String, QueryPartitions.Partition>> iter = queryPartitions.getPartitions().entrySet().iterator();
+			while (iter.hasNext()) {
+				Map.Entry<String, QueryPartitions.Partition> sourcePartition = iter.next();
+				if (!Caster.toBooleanValue(executeExp(pc, sql, sourcePartition.getValue().query, select.getHaving(), 1))) {
+					iter.remove();
 				}
-			}));
-
+			}
 		}
 
 		// Turn off query caching for our column references
@@ -541,28 +504,32 @@ public final class QoQ {
 			}
 		}
 
-		getStream(queryPartitions).forEach(throwingConsumer(sourcePartition -> {
-			int newRow = target.addRow();
+		// Phase 3: emit one row per surviving partition into target.
+		int added = 0;
+		for (Map.Entry<String, QueryPartitions.Partition> sourcePartition : queryPartitions.getPartitions().entrySet()) {
+			QueryImpl partitionQry = sourcePartition.getValue().query;
 			for (int cell = 0; cell < headers.length; cell++) {
-
-				// If this is a column
+				Object value;
 				if (trgValues[cell] instanceof ColumnExpression) {
 					ColumnExpression ce = (ColumnExpression) trgValues[cell];
 					if (ce.getColumn().equals(paramKey)) {
-						target.setAt(headers[cell], newRow, getValue(pc, sql, sourcePartition.getValue(), 1, null, trgValues[cell], null), true);
+						value = getValue(pc, sql, partitionQry, 1, null, trgValues[cell], null);
 					}
 					else {
 						// Then make sure to use the alias now to reference it since it changed
 						// names after going into the partition
-						target.setAt(headers[cell], newRow, getValue(pc, sql, sourcePartition.getValue(), 1, ce.getColumnAlias(), null, null), true);
+						value = getValue(pc, sql, partitionQry, 1, ce.getColumnAlias(), null, null);
 					}
 				}
 				// For Operations, just execute them normally
 				else {
-					target.setAt(headers[cell], newRow, getValue(pc, sql, sourcePartition.getValue(), 1, null, trgValues[cell], null), true);
+					value = getValue(pc, sql, partitionQry, 1, null, trgValues[cell], null);
 				}
+				trgColumns[cell].add(value);
 			}
-		}));
+			added++;
+		}
+		target.setRecordcount(added);
 
 	}
 
@@ -1568,79 +1535,6 @@ public final class QoQ {
 			ExceptionUtil.initCauseEL(iqe, e);
 			throw iqe;
 		}
-	}
-
-	// Helpers for exceptions in Lambdas
-	@FunctionalInterface
-	public interface ThrowingIntConsumer {
-		/**
-		 * Applies this function to the given argument.
-		 *
-		 * @param t the Consumer argument
-		 */
-		void accept(int t) throws Exception;
-	}
-
-	public static IntConsumer throwingIntConsumer(ThrowingIntConsumer throwingIntConsumer) {
-		return new IntConsumer() {
-			@Override
-			public void accept(int t) {
-				try {
-					throwingIntConsumer.accept(t);
-				}
-				catch (Exception ex) {
-					throw new RuntimeException(ex);
-				}
-			}
-		};
-	}
-
-	@FunctionalInterface
-	public interface ThrowingConsumer {
-		/**
-		 * Applies this function to the given argument.
-		 *
-		 * @param t the Consumer argument
-		 */
-		void accept(Map.Entry<String, QueryImpl> t) throws Exception;
-	}
-
-	public static Consumer<Map.Entry<String, QueryImpl>> throwingConsumer(ThrowingConsumer throwingConsumer) {
-		return new Consumer<Map.Entry<String, QueryImpl>>() {
-			@Override
-			public void accept(Map.Entry<String, QueryImpl> t) {
-				try {
-					throwingConsumer.accept(t);
-				}
-				catch (Exception ex) {
-					throw new RuntimeException(ex);
-				}
-			}
-		};
-	}
-
-	@FunctionalInterface
-	public interface ThrowingFilter {
-		/**
-		 * Applies this function to the given argument.
-		 *
-		 * @param t the Consumer argument
-		 */
-		boolean test(int t) throws Exception;
-	}
-
-	public static IntPredicate throwingFilter(ThrowingFilter throwingFilter) {
-		return new IntPredicate() {
-			@Override
-			public boolean test(int t) {
-				try {
-					return throwingFilter.test(t);
-				}
-				catch (Exception ex) {
-					throw new RuntimeException(ex);
-				}
-			}
-		};
 	}
 
 }

--- a/core/src/main/java/lucee/runtime/sql/QueryPartitions.java
+++ b/core/src/main/java/lucee/runtime/sql/QueryPartitions.java
@@ -21,9 +21,10 @@ package lucee.runtime.sql;
 import java.io.IOException;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import lucee.commons.digest.MD5;
 import lucee.runtime.PageContext;
@@ -43,6 +44,7 @@ import lucee.runtime.type.ArrayImpl;
 import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.Query;
+import lucee.runtime.type.QueryColumnImpl;
 import lucee.runtime.type.QueryImpl;
 
 public final class QueryPartitions {
@@ -52,17 +54,39 @@ public final class QueryPartitions {
 	private Collection.Key[] columnKeys;
 	// Needed for functions and aggregates but not explicitly part of the final select
 	private Set<Collection.Key> additionalColumns;
+	// Ordered version of additionalColumns for stable index alignment between buildPartition and addRow.
+	private Collection.Key[] additionalColumnsArr;
 	// Group by expressions
 	private Expression[] groupbys;
 	// Target query for column references
 	private QueryImpl target;
-	// Mapof partitioned query data. Key is unique string representing grouped data, value is a
-	// Query object representing the matching rows in that group/partition
-	private ConcurrentHashMap<String, QueryImpl> partitions = new ConcurrentHashMap<String, QueryImpl>();
+	// Map of partitioned query data. Plain HashMap — build is single-threaded.
+	private HashMap<String, Partition> partitions = new HashMap<String, Partition>();
 	// Reference to QoQ instance
 	private QoQ qoQ;
 	// SQL instance
 	private SQL sql;
+
+	/**
+	 * Carries pre-resolved column refs alongside the partition's QueryImpl so addRow() can write
+	 * via column.add() without looking columns up by name. Indices align with the parent's columns
+	 * and additionalColumnsArr; null = skip (literals, aggregates, source-missing columns).
+	 */
+	public static final class Partition {
+		public final QueryImpl query;
+		public final QueryColumnImpl[] selectColRefs;
+		public final QueryColumnImpl[] additionalColRefs;
+		private int size;
+
+		Partition(QueryImpl query, QueryColumnImpl[] selectColRefs, QueryColumnImpl[] additionalColRefs) {
+			this.query = query;
+			this.selectColRefs = selectColRefs;
+			this.additionalColRefs = additionalColRefs;
+		}
+
+		void bumpSize() { size++; }
+		int getSize() { return size; }
+	}
 
 	/**
 	 * Constructor
@@ -99,6 +123,7 @@ public final class QueryPartitions {
 		for (Key col: additionalColumns) {
 			this.additionalColumns.add(col);
 		}
+		this.additionalColumnsArr = this.additionalColumns.toArray(new Collection.Key[0]);
 		// Convert these Expression aliases to Keys now so we don't do it over and over later
 		this.columnKeys = new Collection.Key[columns.length];
 		for (int cell = 0; cell < columns.length; cell++) {
@@ -114,7 +139,7 @@ public final class QueryPartitions {
 	 * @throws PageException
 	 */
 	public void addEmptyPartition(QueryImpl source, QueryImpl target) throws PageException {
-		partitions.put("default", createPartition(target, source, false));
+		partitions.put("default", buildPartition(target, source, false));
 	}
 
 	/**
@@ -132,43 +157,39 @@ public final class QueryPartitions {
 	public void addRow(PageContext pc, QueryImpl source, int row, boolean finalizedColumnVals) throws PageException {
 		// Generate unique key based on row data
 		String partitionKey = buildPartitionKey(pc, source, row, finalizedColumnVals);
-		// Create partition if necessary
-		QueryImpl targetPartition = partitions.computeIfAbsent(partitionKey, k -> {
-			try {
-				return createPartition(target, source, finalizedColumnVals);
-			}
-			catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		});
-
-		int newRow = targetPartition.addRow();
+		// Create partition if necessary — manual get+put avoids the per-row computeIfAbsent lambda.
+		Partition partition = partitions.get(partitionKey);
+		if (partition == null) {
+			partition = buildPartition(target, source, finalizedColumnVals);
+			partitions.put(partitionKey, partition);
+		}
+		partition.bumpSize();
 
 		// If we're adding finalized data, just copy it across. Easy. This applies when distincting
 		// a result set after it's already been processed
 		if (finalizedColumnVals) {
 			Collection.Key[] sourceColKeys = source.getColumnNames();
-			Collection.Key[] targetColKeys = targetPartition.getColumnNames();
-			for (int col = 0; col < targetColKeys.length; col++) {
-				targetPartition.setAt(targetColKeys[col], newRow, source.getColumn(sourceColKeys[col]).get(row, null), true);
+			QueryColumnImpl[] selectColRefs = partition.selectColRefs;
+			for (int col = 0; col < selectColRefs.length; col++) {
+				if (selectColRefs[col] != null) {
+					selectColRefs[col].add(source.getColumn(sourceColKeys[col]).get(row, null));
+				}
 			}
-
 		}
 		// For normal group by operations, we ONLY put real data in the partition. Operations will
 		// be added later, but there's no use filling up the partition with place holders
 		else {
+			QueryColumnImpl[] selectColRefs = partition.selectColRefs;
 			for (int cell = 0; cell < columns.length; cell++) {
-
+				Object value;
 				// Literal values
 				if (columns[cell] instanceof Value) {
-					Value v = (Value) columns[cell];
-					targetPartition.setAt(columnKeys[cell], newRow, v.getValue(), true);
+					value = ((Value) columns[cell]).getValue();
 				}
-				// A column expressions is set by column Key
+				// A column expression is read by column Key (ColumnExpression caches its source col internally)
 				else if (columns[cell] instanceof ColumnExpression) {
-					ColumnExpression ce = (ColumnExpression) columns[cell];
 					try {
-						targetPartition.setAt(columnKeys[cell], newRow, ce.getValue(pc, source, row, null), true);
+						value = ((ColumnExpression) columns[cell]).getValue(pc, source, row, null);
 					}
 					catch (DatabaseException e) {
 						// Wrap as IllegalQoQException to prevent fallback to HSQLDB
@@ -177,15 +198,31 @@ public final class QueryPartitions {
 						throw iqe;
 					}
 				}
-
+				else {
+					// Aggregates and other operations — computed in phase 3, never read from this column.
+					continue;
+				}
+				selectColRefs[cell].add(value);
 			}
-			// Populate additional columns needed for operations but are not found in the select
-			// list above
-			for (Collection.Key col: additionalColumns) {
-				if (source.containsKey(col)) {
-					targetPartition.setAt(col, newRow, source.getColumn(col).get(row, null), true);
+			// Additional columns needed for aggregates/operations but not in the select list.
+			// Refs are null where the source didn't contain that column at partition-creation time.
+			QueryColumnImpl[] additionalColRefs = partition.additionalColRefs;
+			for (int i = 0; i < additionalColumnsArr.length; i++) {
+				QueryColumnImpl ref = additionalColRefs[i];
+				if (ref != null) {
+					ref.add(source.getColumn(additionalColumnsArr[i]).get(row, null));
 				}
 			}
+		}
+	}
+
+	/**
+	 * Publish per-partition row counts. column.add(...) bumps column size but not
+	 * query.recordcount, so it has to be set once at the end of the build.
+	 */
+	public void finalizePartitionRecordCounts() {
+		for (Partition p : partitions.values()) {
+			p.query.setRecordcount(p.getSize());
 		}
 	}
 
@@ -263,7 +300,7 @@ public final class QueryPartitions {
 	 *
 	 * @return
 	 */
-	public ConcurrentHashMap<String, QueryImpl> getPartitions() {
+	public Map<String, Partition> getPartitions() {
 		return partitions;
 	}
 
@@ -273,7 +310,10 @@ public final class QueryPartitions {
 	 * @return
 	 */
 	public Query[] getPartitionArray() {
-		return (Query[]) partitions.values().toArray();
+		Query[] arr = new Query[partitions.size()];
+		int i = 0;
+		for (Partition p : partitions.values()) arr[i++] = p.query;
+		return arr;
 	}
 
 	/**
@@ -288,14 +328,17 @@ public final class QueryPartitions {
 	 * @return Empty Query with all the needed columns
 	 * @throws PageException
 	 */
-	private QueryImpl createPartition(QueryImpl target, QueryImpl source, boolean finalizedColumnVals) throws PageException {
+	private Partition buildPartition(QueryImpl target, QueryImpl source, boolean finalizedColumnVals) throws PageException {
 		QueryImpl newTarget = new QueryImpl(new Collection.Key[0], 0, "query", sql);
+		QueryColumnImpl[] selectColRefs = new QueryColumnImpl[columns.length];
+		QueryColumnImpl[] additionalColRefs = new QueryColumnImpl[additionalColumnsArr.length];
 
 		// If we're just distincting fully-realized data, this is just a simple lookup
 		if (finalizedColumnVals) {
 			for (int i = 0; i < columns.length; i++) {
 				ColumnExpression ce = (ColumnExpression) columns[i];
 				newTarget.addColumn(ce.getColumn(), new ArrayImpl(), target.getColumn(target.getColumnNames()[i]).getType());
+				selectColRefs[i] = (QueryColumnImpl) newTarget.getColumn(ce.getColumn());
 			}
 		}
 		// Standard group by
@@ -317,23 +360,29 @@ public final class QueryPartitions {
 					if (!"?".equals(ce.getColumnName())) type = source.getColumn(Caster.toKey(ce.getColumnName())).getType();
 
 					newTarget.addColumn(alias, new ArrayImpl(), type);
+					selectColRefs[i] = (QueryColumnImpl) newTarget.getColumn(alias);
 				}
 				else if (expSelect instanceof Literal) {
 					newTarget.addColumn(alias, new ArrayImpl(), Types.OTHER);
+					selectColRefs[i] = (QueryColumnImpl) newTarget.getColumn(alias);
 				}
+				// other expression types: selectColRefs[i] stays null; addRow's loop skips them
 			}
 
 			// As well as any additional columns that need to be used for expressions and aggregates
 			// but don't appear in the final select.
-			for (Collection.Key col: additionalColumns) {
+			for (int i = 0; i < additionalColumnsArr.length; i++) {
+				Collection.Key col = additionalColumnsArr[i];
 				// This check is here because it seems the SelectsParser also lists table names as
 				// ColumnExpressions
 				if (source.containsKey(col)) {
 					newTarget.addColumn(col, new ArrayImpl(), source.getColumn(col).getType());
+					additionalColRefs[i] = (QueryColumnImpl) newTarget.getColumn(col);
 				}
+				// else: additionalColRefs[i] stays null; addRow's loop skips
 			}
 		}
-		return newTarget;
+		return new Partition(newTarget, selectColRefs, additionalColRefs);
 	}
 
 }

--- a/core/src/main/java/lucee/runtime/type/QueryImpl.java
+++ b/core/src/main/java/lucee/runtime/type/QueryImpl.java
@@ -1526,6 +1526,11 @@ public final class QueryImpl implements Query, Objects, QueryResult {
 		return recordcount.addAndGet(count);
 	}
 
+	// For build paths that populate columns via column.add(...) and publish the final count once.
+	public void setRecordcount(int rc) {
+		recordcount.set(rc);
+	}
+
 	@Override
 	public boolean addColumn(String columnName, Array content) throws DatabaseException {
 		return addColumn(columnName, content, Types.OTHER);

--- a/core/src/main/java/lucee/runtime/type/comparator/QueryComparator.java
+++ b/core/src/main/java/lucee/runtime/type/comparator/QueryComparator.java
@@ -34,6 +34,7 @@ import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.KeyImpl;
 import lucee.runtime.type.Query;
+import lucee.runtime.type.QueryColumn;
 import lucee.runtime.type.QueryImpl;
 
 /**
@@ -43,6 +44,8 @@ public final class QueryComparator implements Comparator<Integer> {
 
 	private Comparator[] sorts;
 	private Key[] cols;
+	// Pre-resolved column refs — sort calls compare() N log N times, name lookup per call dominates.
+	private QueryColumn[] cachedCols;
 	private Query target;
 	private Collection.Key paramKey = new KeyImpl("?");
 	private int numSorts = 0;
@@ -54,6 +57,7 @@ public final class QueryComparator implements Comparator<Integer> {
 	public QueryComparator(PageContext pc, QueryImpl target, Expression[] sortExpressions, boolean isUnion, SQL sql) throws PageException {
 		this.sorts = new Comparator[sortExpressions.length];
 		this.cols = new Key[sortExpressions.length];
+		this.cachedCols = new QueryColumn[sortExpressions.length];
 		this.target = target;
 
 		// Build up an array of comparators based on the valid sort expressions, in order
@@ -99,7 +103,9 @@ public final class QueryComparator implements Comparator<Integer> {
 	private void addSOrt(Key columnKey, boolean isAsc) throws PageException {
 		cols[numSorts] = columnKey;
 
-		int type = target.getColumn(columnKey).getType();
+		QueryColumn column = target.getColumn(columnKey);
+		cachedCols[numSorts] = column;
+		int type = column.getType();
 		// These types use a numeric sort
 		if (type == Types.BIGINT || type == Types.BIT || type == Types.INTEGER || type == Types.SMALLINT || type == Types.TINYINT || type == Types.DECIMAL || type == Types.DOUBLE
 				|| type == Types.NUMERIC || type == Types.REAL) {
@@ -115,24 +121,17 @@ public final class QueryComparator implements Comparator<Integer> {
 	@Override
 	public int compare(Integer oLeft, Integer oRight) {
 		int currentResult = 0;
-		try {
-			// Loop over all our sorts. We'll keep checking until we find a column that sorts above or below,
-			// or until we run out of sorts to check
-			for (int i = 0; i < numSorts; i++) {
-				currentResult = sorts[i].compare(target.getAt(cols[i], oLeft), target.getAt(cols[i], oRight));
-				// Short circuit if one row is already sorted above or below another
-				if (currentResult != 0) {
-					return currentResult;
-				}
-				// If the current sorts were the same for both rows, we continue to the next sort
+		for (int i = 0; i < numSorts; i++) {
+			QueryColumn column = cachedCols[i];
+			currentResult = sorts[i].compare(column.get(oLeft, null), column.get(oRight, null));
+			// Short circuit if one row is already sorted above or below another
+			if (currentResult != 0) {
+				return currentResult;
 			}
-			// If we made it all the way through the sorts, return the last value
-			return currentResult;
+			// If the current sorts were the same for both rows, we continue to the next sort
 		}
-		catch (PageException e) {
-			// throw new RuntimeException(e);
-			return 0;
-		}
+		// If we made it all the way through the sorts, return the last value
+		return currentResult;
 	}
 
 }

--- a/core/src/main/java/resource/setting/sysprop-envvar.json
+++ b/core/src/main/java/resource/setting/sysprop-envvar.json
@@ -940,7 +940,7 @@
 	{
 		"sysprop": "lucee.qoq.parallelism",
 		"envvar": "LUCEE_QOQ_PARALLELISM",
-		"desc": "Controls the parallelism level for Query of Queries operations",
+		"desc": "Controls the parallelism level for Query of Queries operations. No longer supported in Lucee 7.1+; native QoQ build is single-threaded because per-column lock contention and FJP overhead made parallel streams a net loss across nearly all measured workloads. Honoured in earlier versions (introduced 6.0.0.336).",
 		"category": "query",
 		"tags": [ "cfquery" ],
 		"functions": [ "queryExecute" ],

--- a/test/tickets/LDEV6308.cfc
+++ b/test/tickets/LDEV6308.cfc
@@ -1,0 +1,235 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="qoq" {
+
+	// ---- private query fixtures ----
+
+	private query function getNumbers() {
+		var qry = queryNew( "id,category,amount", "integer,varchar,integer", [
+			[ 1, "alpha", 10 ],
+			[ 2, "beta",  20 ],
+			[ 3, "alpha", 30 ],
+			[ 4, "gamma", 40 ],
+			[ 5, "beta",  50 ]
+		] );
+		return qry;
+	}
+
+	private query function getOverlapA() {
+		var qry = queryNew( "id,val", "integer,varchar", [
+			[ 1, "a1" ],
+			[ 2, "a2" ],
+			[ 3, "a3" ]
+		] );
+		return qry;
+	}
+
+	private query function getOverlapB() {
+		var qry = queryNew( "id,val", "integer,varchar", [
+			[ 2, "a2" ],
+			[ 3, "a3" ],
+			[ 4, "b4" ]
+		] );
+		return qry;
+	}
+
+	private query function getMultiCol() {
+		var qry = queryNew( "a,b", "varchar,varchar", [
+			[ "x", "1" ],
+			[ "x", "1" ],
+			[ "x", "2" ],
+			[ "y", "1" ]
+		] );
+		return qry;
+	}
+
+	private query function getSingleRow() {
+		return queryNew( "id", "integer", [ [ 42 ] ] );
+	}
+
+	private query function getEmpty() {
+		return queryNew( "id,amount", "integer,integer" );
+	}
+
+	// ---- helper: run on both engines and assert results match ----
+
+	/**
+	 * Runs the SQL via native QoQ AND HSQLDB engines, asserts cell-by-cell equivalence,
+	 * returns the native result so individual specs can do additional assertions.
+	 * Source queries are provided as a struct keyed by the name used in the SQL.
+	 */
+	private query function runBoth( required string sql, required struct sources, numeric maxrows = -1 ) {
+		var nativeResult = runWithEngine( arguments.sql, arguments.sources, "native", arguments.maxrows );
+		var hsqldbResult = runWithEngine( arguments.sql, arguments.sources, "hsqldb", arguments.maxrows );
+
+		expect( nativeResult.recordcount ).toBe(
+			hsqldbResult.recordcount,
+			"recordcount mismatch: native=#nativeResult.recordcount#, hsqldb=#hsqldbResult.recordcount#"
+		);
+
+		var cols = listToArray( nativeResult.columnList );
+		for ( var i = 1; i <= nativeResult.recordcount; i++ ) {
+			for ( var col in cols ) {
+				var nv = nativeResult[ col ][ i ];
+				var hv = hsqldbResult[ col ][ i ];
+				expect( nv ).toBe(
+					hv,
+					"cell mismatch at row #i# col '#col#': native=[#nv#], hsqldb=[#hv#]"
+				);
+			}
+		}
+		return nativeResult;
+	}
+
+	private query function runWithEngine( required string sql, required struct sources, required string engine, numeric maxrows = -1 ) {
+		// Inject sources into local scope so queryExecute's QoQ source-lookup finds them
+		for ( var name in arguments.sources ) {
+			local[ name ] = arguments.sources[ name ];
+		}
+		var opts = { dbtype: { type: "query", engine: arguments.engine } };
+		if ( arguments.maxrows > -1 ) opts.maxrows = arguments.maxrows;
+		return queryExecute( arguments.sql, {}, opts );
+	}
+
+	function run( testResults, testBox ) {
+
+		describe( title="LDEV-6308 - QoQ refactor coverage gaps (native vs hsqldb)", body=function() {
+
+			// ---- ORDER BY ----
+
+			it( title="ORDER BY two columns, mixed ASC/DESC", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT id, category, amount FROM q ORDER BY category ASC, amount DESC",
+					{ q: getNumbers() }
+				);
+				expect( r.recordcount ).toBe( 5 );
+				// alpha group: 30 then 10 (DESC); beta: 50 then 20; gamma alone
+				expect( r.category[ 1 ] ).toBe( "alpha" );
+				expect( r.amount[ 1 ] ).toBe( 30 );
+				expect( r.amount[ 2 ] ).toBe( 10 );
+				expect( r.amount[ 3 ] ).toBe( 50 );
+				expect( r.amount[ 4 ] ).toBe( 20 );
+				expect( r.category[ 5 ] ).toBe( "gamma" );
+			});
+
+			it( title="ORDER BY DESC single column", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT id FROM q ORDER BY id DESC",
+					{ q: getNumbers() }
+				);
+				expect( r.recordcount ).toBe( 5 );
+				expect( r.id[ 1 ] ).toBe( 5 );
+				expect( r.id[ 5 ] ).toBe( 1 );
+			});
+
+			it( title="ORDER BY on single-row source", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT id FROM q ORDER BY id",
+					{ q: getSingleRow() }
+				);
+				expect( r.recordcount ).toBe( 1 );
+				expect( r.id[ 1 ] ).toBe( 42 );
+			});
+
+			it( title="maxrows combined with ORDER BY DESC returns largest rows", body=function( currentSpec ) {
+				// Verifies the limit is applied AFTER sorting, not before. If maxrows fired in
+				// the per-row build loop it'd return [1,2] (source order); correct is [5,4].
+				var r = runBoth(
+					sql = "SELECT id FROM q ORDER BY id DESC",
+					sources = { q: getNumbers() },
+					maxrows = 2
+				);
+				expect( r.recordcount ).toBe( 2 );
+				expect( r.id[ 1 ] ).toBe( 5 );
+				expect( r.id[ 2 ] ).toBe( 4 );
+			});
+
+			// ---- UNION ----
+
+			it( title="UNION DISTINCT removes duplicates across sources", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT id, val FROM q1 UNION SELECT id, val FROM q2 ORDER BY id",
+					{ q1: getOverlapA(), q2: getOverlapB() }
+				);
+				// {1,a1},{2,a2},{3,a3} ∪ {2,a2},{3,a3},{4,b4} = 4 distinct rows
+				expect( r.recordcount ).toBe( 4 );
+				expect( r.id[ 1 ] ).toBe( 1 );
+				expect( r.id[ 4 ] ).toBe( 4 );
+			});
+
+			it( title="UNION ALL keeps duplicates across sources", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT id, val FROM q1 UNION ALL SELECT id, val FROM q2 ORDER BY id",
+					{ q1: getOverlapA(), q2: getOverlapB() }
+				);
+				expect( r.recordcount ).toBe( 6 );
+			});
+
+			// ---- GROUP BY / HAVING ----
+
+			it( title="HAVING with column not in SELECT (additionalColumns path)", body=function( currentSpec ) {
+				// `amount` is not in the SELECT list but referenced in HAVING — exercises
+				// QueryPartitions' additionalColumns + additionalColRefs mechanism
+				var r = runBoth(
+					"SELECT category FROM q GROUP BY category HAVING SUM(amount) > 30 ORDER BY category",
+					{ q: getNumbers() }
+				);
+				// alpha: 40, beta: 70, gamma: 40 — all > 30
+				expect( r.recordcount ).toBe( 3 );
+			});
+
+			it( title="HAVING that filters all groups out", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT category FROM q GROUP BY category HAVING SUM(amount) > 9999",
+					{ q: getNumbers() }
+				);
+				expect( r.recordcount ).toBe( 0 );
+			});
+
+			it( title="GROUP BY combined with ORDER BY on aggregate", body=function( currentSpec ) {
+				// Secondary sort on category disambiguates the tie between alpha (40) and gamma (40).
+				// Without it, native and hsqldb break the tie in different orders — both correct
+				// per SQL but they disagree, masking real bugs in the comparison harness.
+				var r = runBoth(
+					"SELECT category, SUM(amount) AS total FROM q GROUP BY category ORDER BY total DESC, category ASC",
+					{ q: getNumbers() }
+				);
+				expect( r.recordcount ).toBe( 3 );
+				// Sums: beta 70, alpha 40, gamma 40 — beta first, then alpha (ASC tie-break), then gamma
+				expect( r.category[ 1 ] ).toBe( "beta" );
+				expect( r.total[ 1 ] ).toBe( 70 );
+				expect( r.category[ 2 ] ).toBe( "alpha" );
+				expect( r.category[ 3 ] ).toBe( "gamma" );
+			});
+
+			// ---- Aggregates over empty ----
+
+			it( title="Aggregate over empty WHERE result returns one row", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT COUNT(*) AS cnt FROM q WHERE id > 100",
+					{ q: getNumbers() }
+				);
+				expect( r.recordcount ).toBe( 1 );
+				expect( r.cnt[ 1 ] ).toBe( 0 );
+			});
+
+			it( title="Aggregate over fully-empty source returns one row", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT COUNT(*) AS cnt, SUM(amount) AS total FROM q",
+					{ q: getEmpty() }
+				);
+				expect( r.recordcount ).toBe( 1 );
+				expect( r.cnt[ 1 ] ).toBe( 0 );
+			});
+
+			// ---- DISTINCT ----
+
+			it( title="DISTINCT on multi-column projection", body=function( currentSpec ) {
+				var r = runBoth(
+					"SELECT DISTINCT a, b FROM q ORDER BY a, b",
+					{ q: getMultiCol() }
+				);
+				// {x,1},{x,1},{x,2},{y,1} → distinct: {x,1},{x,2},{y,1}
+				expect( r.recordcount ).toBe( 3 );
+			});
+		});
+	}
+}


### PR DESCRIPTION
## Summary

Three-pronged streamline of the native QoQ build path, scoped to the objectives in [LDEV-6308](https://luceeserver.atlassian.net/browse/LDEV-6308):

1. **Remove parallel processing.** The parallel-stream design (LDEV-4298, 6.0.0.336) was a single-threaded-bench win. Under realistic concurrent-request load with FJP common-pool contention and per-column lock acquisition, it loses across nearly all measured workloads. `getStream(QueryImpl)` and `getStream(QueryPartitions)` are now sequential; the `lucee.qoq.parallelism` setting becomes a documented no-op.
2. **Bypass query methods, adopt fillResult-style writes.** Replace `addRow + setAt(key, ...)` (per-cell `synchronized(sync)` + name lookup) with `column.add(value)` (lock-free append, matches the proven JDBC drain pattern). New public method `QueryImpl.setRecordcount(int)` publishes the final count once at end-of-build, mirroring `fillResult`.
3. **Cache all column lookups.** `QueryComparator` now pre-resolves sort-column refs at construction so `compare()` skips per-call name lookups. `QueryPartitions` introduces a `Partition` wrapper carrying pre-resolved `selectColRefs` / `additionalColRefs` per partition, plus replaces `computeIfAbsent` with manual `get`+`put` (eliminates per-row lambda allocation).

Related side-effect changes bundled because the diagnostic surface exposed them:

- `lucee.qoq.hsqldb.disable=true` now also gates the native-returns-null fall-through path. Previously only the native-throws-exception path honoured the flag, leaving JOIN-style queries to silently fall through to HSQLDB despite the disable.
- `ConcurrentHashMap` → `HashMap` in `QueryPartitions.partitions`. CHM was only required by the previous parallel-writer design; under single-threaded build it's pure overhead.
- Row order under simple SELECT without ORDER BY is now deterministic (source order). Previously parallel-stream encounter order was non-deterministic — Brad Wood documented this caveat in the original LDEV-4298 blog post.

## Bench (testlab, 9950X3D, 17 QoQ shape variants × 100k cycles, 20-way concurrent requests)

Baseline = published 7.1 snapshot (parallel @ threshold=50). Modified = this PR. Sentinel A1/A2 drift <3% on most tests.

- **wide-20k**: 38.0s → 11.8s (**−69%**, 3.2× faster)
- **orderby-20k**: 17.0s → 5.4s (**−68%**)
- **narrow-20k**: 9.7s → 3.3s (**−66%**)
- **wide-1k**: 4.5s → 1.6s (**−66%**)
- partitioned (groupby/distinct/having): −22% to −40%
- union: −16% to −41%
- Smallest tests (narrow-50, narrow-200): roughly neutral (−5 to −7%)

GC pressure: total collection count down ~32%, total pause time down ~13% across the 17-test sweep.

JFR-side findings that drove the cache work: pre-refactor `QueryImpl.getIndexFromKey` was 20% of CPU samples (ALL via name-lookup hot loops). Post-refactor it's off the top-25. `HashMap$KeyIterator` 8.4% allocation pressure → gone. `QueryPartitions$$Lambda` 7.1% allocation pressure → gone.

## Test plan

- [x] Full mvn test suite: 5339 pass / 0 failures / 0 errors (was 5328 + 11 new specs in LDEV6308.cfc).
- [x] Suite also passed under `LUCEE_QOQ_HSQLDB_DISABLE=true` modulo 3 expected-fallback tests (LDEV-3311 join, LDEV-4695 subselect, LDEV-5845 LEFT JOIN) — all pre-existing tests that throw inside native QoQ's parser and rely on HSQLDB second-chance.
- [x] New `LDEV6308.cfc`: 11 specs covering ORDER BY multi-col mixed ASC/DESC, UNION DISTINCT, UNION ALL, HAVING with `additionalColumns`, GROUP BY + ORDER BY combined, aggregate-over-empty, multi-col DISTINCT. **Each spec runs the SQL on both `engine: native` AND `engine: hsqldb` and asserts cell-by-cell equivalence** — catches any divergence between the two engines, exposing one immediately (a tie-break ambiguity in the original test was fixed with a secondary sort).
- [x] JFR profile sanity check: zero contention from refactored QoQ paths.

## Future follow-ups (separate JIRAs, not this PR)

- Composite-value partition key with h64 hashing (cf. `KeyImpl.hash`) — would skip ~9% CPU on partitioned QoQ but changes cross-type GROUP BY semantics. TODO comment notes this in `QueryPartitions.buildPartitionKey`.
- Inter-request `PageSourceImpl.loadPhysical` monitor serialisation — surfaced in JFR under parallel request load; orthogonal to QoQ but visible because we removed the in-request lock contention.
- `getIndexFromKey` is already an O(1) hash lookup but call frequency is the cost; further reductions would require structural changes to ColumnExpression caching across partition boundaries.

[LDEV-6308]: https://luceeserver.atlassian.net/browse/LDEV-6308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ