### PR TITLE
LDEV-6331 + LDEV-5941: fix storage session expiry refresh; add sessionTouch

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/system/GetApplicationSettings.java
+++ b/core/src/main/java/lucee/runtime/functions/system/GetApplicationSettings.java
@@ -107,6 +107,7 @@ public final class GetApplicationSettings extends BIF {
 		sct.setEL("sessionStorage", ac.getSessionstorage());
 		sct.setEL("sessionType", AppListenerUtil.toSessionType(((PageContextImpl) pc).getSessionType(), "application"));
 		sct.setEL("sessionTimeout", ac.getSessionTimeout());
+		if (acs.getSessionCommitInterval() != null) sct.setEL("sessionCommitInterval", acs.getSessionCommitInterval());
 		sct.setEL("setDomainCookies", Caster.toBoolean(ac.isSetDomainCookies()));
 		sct.setEL("loginStorage", AppListenerUtil.translateLoginStorage(ac.getLoginStorage()));
 
@@ -127,6 +128,7 @@ public final class GetApplicationSettings extends BIF {
 		sct.setEL("clientManagement", Caster.toBoolean(ac.isSetClientManagement()));
 		sct.setEL("clientStorage", ac.getClientstorage());
 		sct.setEL("clientTimeout", ac.getClientTimeout());
+		if (acs.getClientCommitInterval() != null) sct.setEL("clientCommitInterval", acs.getClientCommitInterval());
 		sct.setEL("setClientCookies", Caster.toBoolean(ac.isSetClientCookies()));
 		
 		ProxyData ProxyData = acs.getProxyData();

--- a/core/src/main/java/lucee/runtime/functions/system/SessionCommit.java
+++ b/core/src/main/java/lucee/runtime/functions/system/SessionCommit.java
@@ -10,9 +10,7 @@ public final class SessionCommit implements Function {
 	private static final long serialVersionUID = -2243745577257724777L;
 
 	public static String call(PageContext pc) throws PageException {
-		IKStorageScopeSupport ss = (IKStorageScopeSupport) ((PageContextImpl) pc).sessionScope();
-		ss.markStale();
-		ss.commit(pc);
+		((IKStorageScopeSupport) ((PageContextImpl) pc).sessionScope()).forceStore(pc);
 		return null;
 	}
 }

--- a/core/src/main/java/lucee/runtime/functions/system/SessionTouch.java
+++ b/core/src/main/java/lucee/runtime/functions/system/SessionTouch.java
@@ -6,13 +6,11 @@ import lucee.runtime.exp.PageException;
 import lucee.runtime.ext.function.Function;
 import lucee.runtime.type.scope.storage.IKStorageScopeSupport;
 
-public final class SessionCommit implements Function {
-	private static final long serialVersionUID = -2243745577257724777L;
+public final class SessionTouch implements Function {
+	private static final long serialVersionUID = 4117520180228876318L;
 
 	public static String call(PageContext pc) throws PageException {
-		IKStorageScopeSupport ss = (IKStorageScopeSupport) ((PageContextImpl) pc).sessionScope();
-		ss.markStale();
-		ss.commit(pc);
+		((IKStorageScopeSupport) ((PageContextImpl) pc).sessionScope()).markStale();
 		return null;
 	}
 }

--- a/core/src/main/java/lucee/runtime/listener/ApplicationContextSupport.java
+++ b/core/src/main/java/lucee/runtime/listener/ApplicationContextSupport.java
@@ -45,6 +45,7 @@ import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.KeyImpl;
 import lucee.runtime.type.Struct;
+import lucee.runtime.type.dt.TimeSpan;
 import lucee.runtime.type.util.ArrayUtil;
 import lucee.transformer.library.ClassDefinitionImpl;
 import lucee.transformer.library.tag.TagLib;
@@ -127,6 +128,17 @@ public abstract class ApplicationContextSupport implements ApplicationContext {
 		this.cookiedomain = cookiedomain;
 		this.idletimeout = idletimeout;
 
+	}
+
+	// LDEV-6331: keepAlive controls periodic refresh of persisted scope expiry on read-heavy patterns.
+	// Override in concrete impls to expose this.sessionKeepAlive / this.clientKeepAlive from Application.cfc.
+	// Returning null means "use the default" (half the scope timeout).
+	public TimeSpan getSessionKeepAlive() {
+		return null;
+	}
+
+	public TimeSpan getClientKeepAlive() {
+		return null;
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/listener/ApplicationContextSupport.java
+++ b/core/src/main/java/lucee/runtime/listener/ApplicationContextSupport.java
@@ -130,12 +130,20 @@ public abstract class ApplicationContextSupport implements ApplicationContext {
 
 	}
 
-	public TimeSpan getSessionKeepAlive() {
+	public TimeSpan getSessionCommitInterval() {
 		return null;
 	}
 
-	public TimeSpan getClientKeepAlive() {
+	public TimeSpan getClientCommitInterval() {
 		return null;
+	}
+
+	public void setSessionCommitInterval(TimeSpan sessionCommitInterval) {
+		// override in subclass
+	}
+
+	public void setClientCommitInterval(TimeSpan clientCommitInterval) {
+		// override in subclass
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/listener/ApplicationContextSupport.java
+++ b/core/src/main/java/lucee/runtime/listener/ApplicationContextSupport.java
@@ -130,9 +130,6 @@ public abstract class ApplicationContextSupport implements ApplicationContext {
 
 	}
 
-	// LDEV-6331: keepAlive controls periodic refresh of persisted scope expiry on read-heavy patterns.
-	// Override in concrete impls to expose this.sessionKeepAlive / this.clientKeepAlive from Application.cfc.
-	// Returning null means "use the default" (half the scope timeout).
 	public TimeSpan getSessionKeepAlive() {
 		return null;
 	}

--- a/core/src/main/java/lucee/runtime/listener/ClassicApplicationContext.java
+++ b/core/src/main/java/lucee/runtime/listener/ClassicApplicationContext.java
@@ -82,6 +82,8 @@ public final class ClassicApplicationContext extends ApplicationContextSupport {
 	private TimeSpan sessionTimeout;
 	private TimeSpan requestTimeout;
 	private TimeSpan clientTimeout;
+	private TimeSpan sessionCommitInterval;
+	private TimeSpan clientCommitInterval;
 	private TimeSpan applicationTimeout;
 	private int loginStorage = -1;
 	private String clientstorage;
@@ -346,6 +348,24 @@ public final class ClassicApplicationContext extends ApplicationContextSupport {
 	@Override
 	public void setClientTimeout(TimeSpan clientTimeout) {
 		this.clientTimeout = clientTimeout;
+	}
+
+	@Override
+	public TimeSpan getSessionCommitInterval() {
+		return sessionCommitInterval;
+	}
+
+	@Override
+	public TimeSpan getClientCommitInterval() {
+		return clientCommitInterval;
+	}
+
+	public void setSessionCommitInterval(TimeSpan sessionCommitInterval) {
+		this.sessionCommitInterval = sessionCommitInterval;
+	}
+
+	public void setClientCommitInterval(TimeSpan clientCommitInterval) {
+		this.clientCommitInterval = clientCommitInterval;
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/listener/ModernApplicationContext.java
+++ b/core/src/main/java/lucee/runtime/listener/ModernApplicationContext.java
@@ -121,6 +121,8 @@ public final class ModernApplicationContext extends ApplicationContextSupport {
 	private TimeSpan applicationTimeout;
 	private TimeSpan sessionTimeout;
 	private TimeSpan clientTimeout;
+	private TimeSpan sessionKeepAlive;
+	private TimeSpan clientKeepAlive;
 	private TimeSpan requestTimeout;
 	private int loginStorage = Scope.SCOPE_SESSION;
 	private int scriptProtect;
@@ -182,6 +184,8 @@ public final class ModernApplicationContext extends ApplicationContextSupport {
 	private boolean initApplicationTimeout;
 	private boolean initSessionTimeout;
 	private boolean initClientTimeout;
+	private boolean initSessionKeepAlive;
+	private boolean initClientKeepAlive;
 	private boolean initRequestTimeout;
 	private boolean initSetClientCookies;
 	private boolean initSetClientManagement;
@@ -436,6 +440,26 @@ public final class ModernApplicationContext extends ApplicationContextSupport {
 			initClientTimeout = true;
 		}
 		return clientTimeout;
+	}
+
+	@Override
+	public TimeSpan getSessionKeepAlive() {
+		if (!initSessionKeepAlive) {
+			Object o = get(component, KeyConstants._sessionKeepAlive, null);
+			if (o != null) sessionKeepAlive = Caster.toTimespan(o, null);
+			initSessionKeepAlive = true;
+		}
+		return sessionKeepAlive;
+	}
+
+	@Override
+	public TimeSpan getClientKeepAlive() {
+		if (!initClientKeepAlive) {
+			Object o = get(component, KeyConstants._clientKeepAlive, null);
+			if (o != null) clientKeepAlive = Caster.toTimespan(o, null);
+			initClientKeepAlive = true;
+		}
+		return clientKeepAlive;
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/listener/ModernApplicationContext.java
+++ b/core/src/main/java/lucee/runtime/listener/ModernApplicationContext.java
@@ -121,8 +121,8 @@ public final class ModernApplicationContext extends ApplicationContextSupport {
 	private TimeSpan applicationTimeout;
 	private TimeSpan sessionTimeout;
 	private TimeSpan clientTimeout;
-	private TimeSpan sessionKeepAlive;
-	private TimeSpan clientKeepAlive;
+	private TimeSpan sessionCommitInterval;
+	private TimeSpan clientCommitInterval;
 	private TimeSpan requestTimeout;
 	private int loginStorage = Scope.SCOPE_SESSION;
 	private int scriptProtect;
@@ -184,8 +184,8 @@ public final class ModernApplicationContext extends ApplicationContextSupport {
 	private boolean initApplicationTimeout;
 	private boolean initSessionTimeout;
 	private boolean initClientTimeout;
-	private boolean initSessionKeepAlive;
-	private boolean initClientKeepAlive;
+	private boolean initSessionCommitInterval;
+	private boolean initClientCommitInterval;
 	private boolean initRequestTimeout;
 	private boolean initSetClientCookies;
 	private boolean initSetClientManagement;
@@ -443,23 +443,35 @@ public final class ModernApplicationContext extends ApplicationContextSupport {
 	}
 
 	@Override
-	public TimeSpan getSessionKeepAlive() {
-		if (!initSessionKeepAlive) {
-			Object o = get(component, KeyConstants._sessionKeepAlive, null);
-			if (o != null) sessionKeepAlive = Caster.toTimespan(o, null);
-			initSessionKeepAlive = true;
+	public TimeSpan getSessionCommitInterval() {
+		if (!initSessionCommitInterval) {
+			Object o = get(component, KeyConstants._sessionCommitInterval, null);
+			if (o != null) sessionCommitInterval = Caster.toTimespan(o, null);
+			initSessionCommitInterval = true;
 		}
-		return sessionKeepAlive;
+		return sessionCommitInterval;
 	}
 
 	@Override
-	public TimeSpan getClientKeepAlive() {
-		if (!initClientKeepAlive) {
-			Object o = get(component, KeyConstants._clientKeepAlive, null);
-			if (o != null) clientKeepAlive = Caster.toTimespan(o, null);
-			initClientKeepAlive = true;
+	public TimeSpan getClientCommitInterval() {
+		if (!initClientCommitInterval) {
+			Object o = get(component, KeyConstants._clientCommitInterval, null);
+			if (o != null) clientCommitInterval = Caster.toTimespan(o, null);
+			initClientCommitInterval = true;
 		}
-		return clientKeepAlive;
+		return clientCommitInterval;
+	}
+
+	@Override
+	public void setSessionCommitInterval(TimeSpan sessionCommitInterval) {
+		this.sessionCommitInterval = sessionCommitInterval;
+		initSessionCommitInterval = true;
+	}
+
+	@Override
+	public void setClientCommitInterval(TimeSpan clientCommitInterval) {
+		this.clientCommitInterval = clientCommitInterval;
+		initClientCommitInterval = true;
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/tag/Application.java
+++ b/core/src/main/java/lucee/runtime/tag/Application.java
@@ -93,6 +93,8 @@ public final class Application extends TagImpl implements DynamicAttributes {
 	private TimeSpan applicationTimeout;
 	private TimeSpan sessionTimeout;
 	private TimeSpan clientTimeout;
+	private TimeSpan sessionCommitInterval;
+	private TimeSpan clientCommitInterval;
 	private TimeSpan requestTimeout;
 	private Mapping[] mappings;
 	private Mapping[] customTagMappings;
@@ -193,6 +195,8 @@ public final class Application extends TagImpl implements DynamicAttributes {
 		setClientManagement = null;
 		sessionTimeout = null;
 		clientTimeout = null;
+		sessionCommitInterval = null;
+		clientCommitInterval = null;
 		requestTimeout = null;
 		applicationTimeout = null;
 		mappings = null;
@@ -506,6 +510,14 @@ public final class Application extends TagImpl implements DynamicAttributes {
 
 	public void setClienttimeout(TimeSpan clientTimeout) {
 		this.clientTimeout = clientTimeout;
+	}
+
+	public void setSessioncommitinterval(TimeSpan sessionCommitInterval) {
+		this.sessionCommitInterval = sessionCommitInterval;
+	}
+
+	public void setClientcommitinterval(TimeSpan clientCommitInterval) {
+		this.clientCommitInterval = clientCommitInterval;
 	}
 
 	public void setRequesttimeout(TimeSpan requestTimeout) {
@@ -840,6 +852,11 @@ public final class Application extends TagImpl implements DynamicAttributes {
 		if (applicationTimeout != null) ac.setApplicationTimeout(applicationTimeout);
 		if (sessionTimeout != null) ac.setSessionTimeout(sessionTimeout);
 		if (clientTimeout != null) ac.setClientTimeout(clientTimeout);
+		if (ac instanceof ApplicationContextSupport) {
+			ApplicationContextSupport acs = (ApplicationContextSupport) ac;
+			if (sessionCommitInterval != null) acs.setSessionCommitInterval(sessionCommitInterval);
+			if (clientCommitInterval != null) acs.setClientCommitInterval(clientCommitInterval);
+		}
 		if (requestTimeout != null) ac.setRequestTimeout(requestTimeout);
 		if (clientstorage != null) {
 			ac.setClientstorage(clientstorage);

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKHandlerCache.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKHandlerCache.java
@@ -65,6 +65,7 @@ public final class IKHandlerCache implements IKHandler {
 							: IKStorageValue.toByteRepresentation(
 									IKStorageScopeSupport.prepareToStore(data, existingVal, storageScope.lastModified(), storageScope.lastModifiedAtInit(), log, type)),
 							Long.valueOf(storageScope.getTimeSpan()), null);
+					storageScope.markStored();
 				}
 				else if (existingVal != null) {
 					cache.remove(key);

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKHandlerDatasource.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKHandlerDatasource.java
@@ -163,6 +163,7 @@ public final class IKHandlerDatasource implements IKHandler {
 				IKStorageValue sv = new IKStorageValue(
 						IKStorageScopeSupport.prepareToStore(data, existingVal, storageScope.lastModified(), storageScope.lastModifiedAtInit(), log, type));
 				executor.update(ci, pc.getCFID(), appName, dc, storageScope.getType(), sv, storageScope.getTimeSpan(), log);
+				storageScope.markStored();
 			}
 			else if (existingVal != null) {
 				executor.delete(ci, pc.getCFID(), appName, dc, storageScope.getType(), log);

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
@@ -323,15 +323,16 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		store(pc);
 	}
 
-	// bare write — skips the metadata churn (_lastvisit/_timecreated/_hitcount/csrf) in touchAfterRequest
-	public void commit(PageContext pc) {
-		setTimeSpan(pc);
-		store(pc);
-	}
-
 	// sentinel: lastStored=-1 forces isStale() true on the next store-path check (matches timeSpan/commitInterval init convention)
 	public void markStale() {
 		lastStored = -1;
+	}
+
+	// force an immediate persist mid-request — used by sessionCommit() BIF
+	public void forceStore(PageContext pc) {
+		markStale();
+		setTimeSpan(pc);
+		store(pc);
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
@@ -132,7 +132,6 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 
 		// last modified
 		lastModifiedAtInit = this.lastModified = lastModified;
-		// LDEV-6331: seed lastStored so staleness check works after scope reconstruction
 		lastStored = lastModified;
 
 		this.hitcount = (type == SCOPE_CLIENT) ? Caster.toIntValue(data.getOrDefault(KeyConstants._hitcount, ONE), 1) : 1;
@@ -272,9 +271,6 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	void setTimeSpan(PageContext pc) {
 		ApplicationContext ac = pc.getApplicationContext();
 		this.timeSpan = getType() == SCOPE_SESSION ? ac.getSessionTimeout().getMillis() : ac.getClientTimeout().getMillis();
-
-		// LDEV-6331: keepAlive controls periodic refresh of persisted scope expiry on read-heavy patterns.
-		// Default is half the scope timeout; users can override via this.sessionKeepAlive / this.clientKeepAlive.
 		TimeSpan ka = null;
 		if (ac instanceof ApplicationContextSupport) {
 			ApplicationContextSupport acs = (ApplicationContextSupport) ac;
@@ -313,8 +309,6 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 
 	@Override
 	public void touchAfterRequest(PageContext pc) {
-
-		setTimeSpan(pc);
 		data0.put(KeyConstants._lastvisit, new IKStorageScopeItem(_lastvisit, lastModifiedAtInit()));
 		data0.put(KeyConstants._timecreated, new IKStorageScopeItem(timecreated, lastModifiedAtInit()));
 
@@ -325,7 +319,16 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		if (ac != null && (this.tokens == null || this.tokens.isEmpty()) && ac.getSessionCluster() && isSessionStorage(pc)) {
 			data0.remove(KeyConstants._csrf_token);
 		}
+		commit(pc);
+	}
+
+	public void commit(PageContext pc) {
+		setTimeSpan(pc);
 		store(pc);
+	}
+
+	public void markStale() {
+		lastStored = 0;
 	}
 
 	@Override
@@ -523,10 +526,6 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		unstore(ThreadLocalPageContext.get());
 	}
 
-	/**
-	 * @return true when the scope needs to be persisted — either real CFML mutations (isDirty) or
-	 *         periodic TTL refresh (isStale).
-	 */
 	public boolean hasChanges(PageContext pc, Log log) {
 		if (isDirty(pc, log)) return true;
 		if (isStale(pc, log)) return true;
@@ -556,9 +555,14 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		return false;
 	}
 
-	// LDEV-6331: persisted expiry needs periodic refresh on read-heavy patterns.
-	// keepAlive=0 (or negative) disables the periodic refresh — use that to opt out.
 	private boolean isStale(PageContext pc, Log log) {
+		if (lastStored == 0) {
+			if (LogUtil.doesDebug(log)) {
+				ScopeContext.debug(log, "explicit refresh requested for " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for "
+						+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + " (markStale).");
+			}
+			return true;
+		}
 		if (keepAlive <= 0) return false;
 		long elapsed = System.currentTimeMillis() - lastStored;
 		if (elapsed <= keepAlive) return false;
@@ -571,6 +575,8 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 
 	public void markStored() {
 		lastStored = System.currentTimeMillis();
+		hasChanges = false;
+		hash = ScopeContext.hash(data0, type, true);
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
@@ -329,9 +329,9 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		store(pc);
 	}
 
-	// sentinel: lastStored=0 forces isStale() true on the next store-path check
+	// sentinel: lastStored=-1 forces isStale() true on the next store-path check (matches timeSpan/commitInterval init convention)
 	public void markStale() {
-		lastStored = 0;
+		lastStored = -1;
 	}
 
 	@Override
@@ -561,7 +561,7 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	}
 
 	private boolean isStale(PageContext pc, Log log) {
-		if (lastStored == 0) {
+		if (lastStored < 0) {
 			if (LogUtil.doesDebug(log)) {
 				ScopeContext.debug(log, "explicit refresh requested for " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for "
 						+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + " (markStale).");

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
@@ -38,6 +38,7 @@ import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.ExpressionException;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.listener.ApplicationContext;
+import lucee.runtime.listener.ApplicationContextSupport;
 import lucee.runtime.op.Caster;
 import lucee.runtime.op.Decision;
 import lucee.runtime.type.Collection;
@@ -96,10 +97,12 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	protected String strType;
 	protected int type;
 	private long timeSpan = -1;
+	private long keepAlive = -1;
 	private String storage;
 	private Struct tokens = new StructImpl(Struct.TYPE_SYNC, 4);
 	private long lastModified;
 	private final long lastModifiedAtInit;
+	private long lastStored;
 
 	private IKHandler handler;
 	private String appName;
@@ -129,6 +132,8 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 
 		// last modified
 		lastModifiedAtInit = this.lastModified = lastModified;
+		// LDEV-6331: seed lastStored so staleness check works after scope reconstruction
+		lastStored = lastModified;
 
 		this.hitcount = (type == SCOPE_CLIENT) ? Caster.toIntValue(data.getOrDefault(KeyConstants._hitcount, ONE), 1) : 1;
 		this.strType = strType;
@@ -267,6 +272,15 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	void setTimeSpan(PageContext pc) {
 		ApplicationContext ac = pc.getApplicationContext();
 		this.timeSpan = getType() == SCOPE_SESSION ? ac.getSessionTimeout().getMillis() : ac.getClientTimeout().getMillis();
+
+		// LDEV-6331: keepAlive controls periodic refresh of persisted scope expiry on read-heavy patterns.
+		// Default is half the scope timeout; users can override via this.sessionKeepAlive / this.clientKeepAlive.
+		TimeSpan ka = null;
+		if (ac instanceof ApplicationContextSupport) {
+			ApplicationContextSupport acs = (ApplicationContextSupport) ac;
+			ka = getType() == SCOPE_SESSION ? acs.getSessionKeepAlive() : acs.getClientKeepAlive();
+		}
+		this.keepAlive = (ka != null) ? ka.getMillis() : this.timeSpan / 2;
 	}
 
 	@Override
@@ -510,10 +524,20 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	}
 
 	/**
-	 * @return the hasChanges
+	 * @return true when the scope needs to be persisted — either real CFML mutations (isDirty) or
+	 *         periodic TTL refresh (isStale).
 	 */
 	public boolean hasChanges(PageContext pc, Log log) {
+		if (isDirty(pc, log)) return true;
+		if (isStale(pc, log)) return true;
+		if (LogUtil.doesDebug(log)) {
+			ScopeContext.debug(log, "no change detected in the " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for " + pc.getApplicationContext().getName() + "/"
+					+ pc.getCFID() + ".");
+		}
+		return false;
+	}
 
+	private boolean isDirty(PageContext pc, Log log) {
 		if (hasChanges) {
 			if (LogUtil.doesDebug(log)) {
 				ScopeContext.debug(log, "detected a change in the root keys of the " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for "
@@ -527,14 +551,26 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 				ScopeContext.debug(log, "detected a change in one of the values in the " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for "
 						+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + ".");
 			}
-
 			return true;
 		}
-		if (LogUtil.doesDebug(log)) {
-			ScopeContext.debug(log, "no change detected in the " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for " + pc.getApplicationContext().getName() + "/"
-					+ pc.getCFID() + ".");
-		}
 		return false;
+	}
+
+	// LDEV-6331: persisted expiry needs periodic refresh on read-heavy patterns.
+	// keepAlive=0 (or negative) disables the periodic refresh — use that to opt out.
+	private boolean isStale(PageContext pc, Log log) {
+		if (keepAlive <= 0) return false;
+		long elapsed = System.currentTimeMillis() - lastStored;
+		if (elapsed <= keepAlive) return false;
+		if (LogUtil.doesDebug(log)) {
+			ScopeContext.debug(log, "periodic refresh of stored " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope expiry for "
+					+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + " — last stored " + elapsed + "ms ago, keepAlive " + keepAlive + "ms.");
+		}
+		return true;
+	}
+
+	public void markStored() {
+		lastStored = System.currentTimeMillis();
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
@@ -97,7 +97,7 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	protected String strType;
 	protected int type;
 	private long timeSpan = -1;
-	private long keepAlive = -1;
+	private long commitInterval = -1;
 	private String storage;
 	private Struct tokens = new StructImpl(Struct.TYPE_SYNC, 4);
 	private long lastModified;
@@ -271,12 +271,12 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 	void setTimeSpan(PageContext pc) {
 		ApplicationContext ac = pc.getApplicationContext();
 		this.timeSpan = getType() == SCOPE_SESSION ? ac.getSessionTimeout().getMillis() : ac.getClientTimeout().getMillis();
-		TimeSpan ka = null;
+		TimeSpan ci = null;
 		if (ac instanceof ApplicationContextSupport) {
 			ApplicationContextSupport acs = (ApplicationContextSupport) ac;
-			ka = getType() == SCOPE_SESSION ? acs.getSessionKeepAlive() : acs.getClientKeepAlive();
+			ci = getType() == SCOPE_SESSION ? acs.getSessionCommitInterval() : acs.getClientCommitInterval();
 		}
-		this.keepAlive = (ka != null) ? ka.getMillis() : this.timeSpan / 2;
+		this.commitInterval = (ci != null) ? ci.getMillis() : this.timeSpan / 2;
 	}
 
 	@Override
@@ -322,11 +322,13 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		commit(pc);
 	}
 
+	// bare write — skips the metadata churn (_lastvisit/_timecreated/_hitcount/csrf) in touchAfterRequest
 	public void commit(PageContext pc) {
 		setTimeSpan(pc);
 		store(pc);
 	}
 
+	// sentinel: lastStored=0 forces isStale() true on the next store-path check
 	public void markStale() {
 		lastStored = 0;
 	}
@@ -545,7 +547,9 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 			return true;
 		}
 		// we have set "ignoreSimpleValues" to true, because this is already covered by "hasChanges" above
-		if (ScopeContext.hash(data0, type, true) != hash) {
+		int newHash = ScopeContext.hash(data0, type, true);
+		if (newHash != hash) {
+			hash = newHash;
 			if (LogUtil.doesDebug(log)) {
 				ScopeContext.debug(log, "detected a change in one of the values in the " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope for "
 						+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + ".");
@@ -563,20 +567,19 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 			}
 			return true;
 		}
-		if (keepAlive <= 0) return false;
+		if (commitInterval <= 0) return false;
 		long elapsed = System.currentTimeMillis() - lastStored;
-		if (elapsed <= keepAlive) return false;
+		if (elapsed <= commitInterval) return false;
 		if (LogUtil.doesDebug(log)) {
 			ScopeContext.debug(log, "periodic refresh of stored " + (Scope.SCOPE_SESSION == type ? "session" : "client") + " scope expiry for "
-					+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + " — last stored " + elapsed + "ms ago, keepAlive " + keepAlive + "ms.");
+					+ pc.getApplicationContext().getName() + "/" + pc.getCFID() + " — last stored " + elapsed + "ms ago, commitInterval " + commitInterval + "ms.");
 		}
 		return true;
 	}
 
-	public void markStored() {
+	void markStored() {
 		lastStored = System.currentTimeMillis();
 		hasChanges = false;
-		hash = ScopeContext.hash(data0, type, true);
 	}
 
 	@Override

--- a/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
+++ b/core/src/main/java/lucee/runtime/type/scope/storage/IKStorageScopeSupport.java
@@ -309,6 +309,7 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 
 	@Override
 	public void touchAfterRequest(PageContext pc) {
+		setTimeSpan(pc);
 		data0.put(KeyConstants._lastvisit, new IKStorageScopeItem(_lastvisit, lastModifiedAtInit()));
 		data0.put(KeyConstants._timecreated, new IKStorageScopeItem(timecreated, lastModifiedAtInit()));
 
@@ -319,7 +320,7 @@ public abstract class IKStorageScopeSupport extends StructSupport implements Sto
 		if (ac != null && (this.tokens == null || this.tokens.isEmpty()) && ac.getSessionCluster() && isSessionStorage(pc)) {
 			data0.remove(KeyConstants._csrf_token);
 		}
-		commit(pc);
+		store(pc);
 	}
 
 	// bare write — skips the metadata churn (_lastvisit/_timecreated/_hitcount/csrf) in touchAfterRequest

--- a/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
+++ b/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
@@ -2582,6 +2582,8 @@ public final class KeyConstants {
 	public static final Key _sessionManagement = init("sessionManagement");
 	public static final Key _sessionTimeout = init("sessionTimeout");
 	public static final Key _clientTimeout = init("clientTimeout");
+	public static final Key _sessionKeepAlive = init("sessionKeepAlive");
+	public static final Key _clientKeepAlive = init("clientKeepAlive");
 	public static final Key _requestTimeout = init("requestTimeout");
 	public static final Key _setClientCookies = init("setClientCookies");
 	public static final Key _setDomainCookies = init("setDomainCookies");

--- a/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
+++ b/core/src/main/java/lucee/runtime/type/util/KeyConstants.java
@@ -2582,8 +2582,8 @@ public final class KeyConstants {
 	public static final Key _sessionManagement = init("sessionManagement");
 	public static final Key _sessionTimeout = init("sessionTimeout");
 	public static final Key _clientTimeout = init("clientTimeout");
-	public static final Key _sessionKeepAlive = init("sessionKeepAlive");
-	public static final Key _clientKeepAlive = init("clientKeepAlive");
+	public static final Key _sessionCommitInterval = init("sessionCommitInterval");
+	public static final Key _clientCommitInterval = init("clientCommitInterval");
 	public static final Key _requestTimeout = init("requestTimeout");
 	public static final Key _setClientCookies = init("setClientCookies");
 	public static final Key _setDomainCookies = init("setDomainCookies");

--- a/core/src/main/java/resource/fld/core-base.fld
+++ b/core/src/main/java/resource/fld/core-base.fld
@@ -13646,12 +13646,22 @@ You can find a list of all available timezones in the Lucee administrator (Setti
 		<name>SessionCommit</name>
 		<introduced>6.2.1.15</introduced>
 		<class>lucee.runtime.functions.system.SessionCommit</class>
-		<description>Force saving the session to storage, useful when sessionCluster is enabled.</description>
+		<description>Force saving the session to storage immediately, useful for cross-request visibility (cluster siblings, parallel AJAX) when sessionCluster is enabled.</description>
 		<return>
 			<type>void</type>
 		</return>
 	</function>
-	
+
+	<!-- SessionTouch -->
+	<function>
+		<name>SessionTouch</name>
+		<class>lucee.runtime.functions.system.SessionTouch</class>
+		<description>Marks the session as needing persistence; the write happens at the natural request-end store path. Deferred sibling of sessionCommit() — use when you don't need synchronous cross-request visibility.</description>
+		<return>
+			<type>void</type>
+		</return>
+	</function>
+
 	<!-- SessionStartTime -->
 	<function>
 		<name>SessionStartTime</name>

--- a/core/src/main/java/resource/tld/core-base.tld
+++ b/core/src/main/java/resource/tld/core-base.tld
@@ -9169,13 +9169,13 @@ Valid only for cfinput type="text".</description>
 			<name>session</name>
 			<label>Session Management</label>
 			<description>Configure session scope behavior and storage</description>
-			<attributes>sessionManagement,sessionType,sessionStorage,sessionTimeout,sessionCluster,sessionCookie</attributes>
+			<attributes>sessionManagement,sessionType,sessionStorage,sessionTimeout,sessionCommitInterval,sessionCluster,sessionCookie</attributes>
 		</group>
 		<group>
 			<name>client</name>
 			<label>Client Management</label>
 			<description>Configure client scope behavior and storage</description>
-			<attributes>clientManagement,clientStorage,clientTimeout,clientCluster,setClientCookies,authCookie</attributes>
+			<attributes>clientManagement,clientStorage,clientTimeout,clientCommitInterval,clientCluster,setClientCookies,authCookie</attributes>
 		</group>
 		<group>
 			<name>cache</name>
@@ -9437,12 +9437,31 @@ Suport for cookie was removed in Lucee 7
 		</attribute>
 		<attribute>
 			<type>timespan</type>
+			<name>sessionCommitInterval</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<description>For storage-backed sessions (cache/Redis/datasource), controls how often an unmodified session
+		is re-persisted to refresh its storage TTL or expires column. Without this, a read-heavy session
+		silently evicts at the original TTL boundary. Defaults to sessionTimeout/2. Set to createTimespan(0,0,0,0)
+		to disable the periodic refresh.</description>
+		</attribute>
+		<attribute>
+			<type>timespan</type>
 			<name>clientTimeout</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<description>Enter the CreateTimeSpan function and values in days, hours, minutes, and seconds, separated
 		by commas, to specify the lifespan of client variables. The default value is specified in the
 		Variables page of the Lucee Administrator.</description>
+		</attribute>
+		<attribute>
+			<type>timespan</type>
+			<name>clientCommitInterval</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<description>For storage-backed client scopes, controls how often an unmodified scope is re-persisted to refresh
+		its storage TTL or expires column. Defaults to clientTimeout/2. Set to createTimespan(0,0,0,0) to disable
+		the periodic refresh.</description>
 		</attribute>
 		<attribute>
 			<type>timespan</type>

--- a/test/tickets/LDEV5941.cfc
+++ b/test/tickets/LDEV5941.cfc
@@ -1,0 +1,70 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" {
+
+	function run( testResults, testBox ) {
+
+		describe( "LDEV-5941 sessionCommit() / sessionTouch()", function() {
+
+			it( title="sessionTouch() is callable and does not throw", body=function() {
+				var uri = createURI( "LDEV5941" );
+				var resp = _InternalRequest( template: "#uri#/testTouchCausesWrite.cfm", url: { useTouch: true } );
+				expect( resp.fileContent ).toBeJson();
+				expect( deserializeJSON( resp.fileContent ).useTouch ).toBe( true );
+			});
+
+			// Post-commit nested mutation IS persisted at request end — content-aware ComponentImpl.hashCode
+			// (LDEV-5930) means the hash check catches CFC internal changes. That's intentional behaviour.
+			it( title="post-commit nested CFC mutation is persisted at request end (hash detection)", body=function() {
+				var uri = createURI( "LDEV5941" );
+
+				var first = _InternalRequest( template: "#uri#/testPostCommitMutation.cfm" );
+				expect( first.fileContent ).toBeJson();
+
+				var cookies = {
+					cfid: first.session.cfid,
+					cftoken: first.session.cftoken
+				};
+
+				_InternalRequest( template: "#uri#/stopApp.cfm", cookies: cookies );
+
+				var second = _InternalRequest( template: "#uri#/testPostCommitMutationCheck.cfm", cookies: cookies );
+				expect( second.fileContent ).toBeJson();
+				expect( deserializeJSON( second.fileContent ).nestedValue ).toBe( "changedAfterCommit" );
+			});
+
+			// True no-double-write: mutate, sessionCommit, NO further mutations, request ends.
+			// Request-end touchAfterRequest should see isDirty=false (markStored cleared the flag + rehashed)
+			// and isStale=false (lastStored just bumped). So no redundant write fires.
+			// We verify by comparing the cache entry's lastModified before and after request end.
+			it( title="sessionCommit + no further mutations = no redundant write at request end", body=function() {
+				var uri = createURI( "LDEV5941" );
+
+				var first = _InternalRequest( template: "#uri#/testCommitOnly.cfm" );
+				expect( first.fileContent ).toBeJson();
+				var firstData = deserializeJSON( first.fileContent );
+
+				var cookies = {
+					cfid: first.session.cfid,
+					cftoken: first.session.cftoken
+				};
+
+				// brief pause so a redundant write at request end would produce a distinguishable timestamp
+				sleep( 50 );
+
+				var second = _InternalRequest( template: "#uri#/testCommitOnlyCheck.cfm", cookies: cookies );
+				expect( second.fileContent ).toBeJson();
+				var secondData = deserializeJSON( second.fileContent );
+
+				expect( secondData.cacheLastModifiedAfter ).toBe(
+					firstData.cacheLastModifiedAtCommit,
+					"BUG LDEV-5941: cache entry was rewritten after sessionCommit despite no further mutations. "
+					& "markStored() must clear the dirty flag and rebaseline the hash."
+				);
+			});
+		});
+	}
+
+	private string function createURI( required string calledName ) {
+		var baseURI = "/test/#listLast( getDirectoryFromPath( getCurrentTemplatePath() ), "\/" )#/";
+		return baseURI & calledName;
+	}
+}

--- a/test/tickets/LDEV5941.cfc
+++ b/test/tickets/LDEV5941.cfc
@@ -60,6 +60,38 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" {
 					& "markStored() must clear the dirty flag and rebaseline the hash."
 				);
 			});
+
+			// Regression: sessionCommit mid-request must NOT trigger touchAfterRequest's metadata churn
+			// (_lastvisit / _timecreated bumps, csrf cleanup). The bare commit path writes data0 as-is.
+			it( title="sessionCommit does not bump _lastvisit mid-request", body=function() {
+				var uri = createURI( "LDEV5941" );
+
+				var first = _InternalRequest( template: "#uri#/testCommitOnly.cfm" );
+				expect( first.fileContent ).toBeJson();
+
+				var cookies = {
+					cfid: first.session.cfid,
+					cftoken: first.session.cftoken
+				};
+
+				// sleep so this request's _lastvisit is distinguishable from the prior request-end's persisted _lastvisit
+				sleep( 100 );
+
+				var second = _InternalRequest( template: "#uri#/testCommitNoMetadataBump.cfm", cookies: cookies );
+				expect( second.fileContent ).toBeJson();
+				var data = deserializeJSON( second.fileContent );
+
+				expect( data.lastvisitAfter ).toBe(
+					data.lastvisitBefore,
+					"BUG LDEV-5941: sessionCommit() mid-request bumped persisted _lastvisit from #data.lastvisitBefore# to #data.lastvisitAfter#. "
+					& "Should match prior request-end's _lastvisit (#data.lastvisitBefore#) — sessionCommit must not call touchAfterRequest mid-request."
+				);
+				// sanity: the cache write actually happened (lastModified bumped) — guards against trivial pass when no write fires
+				expect( data.lastModifiedAfter ).notToBe(
+					data.lastModifiedBefore,
+					"Test fixture issue: sessionCommit did not fire a cache write — before/after _lastvisit comparison is meaningless."
+				);
+			});
 		});
 	}
 

--- a/test/tickets/LDEV5941/Application.cfc
+++ b/test/tickets/LDEV5941/Application.cfc
@@ -1,0 +1,18 @@
+component {
+	this.name = "ldev-5941-" & hash( getCurrentTemplatePath() );
+	this.sessionManagement = true;
+	this.setClientCookies = true;
+	this.sessionType = "application";
+	this.sessionTimeout = createTimespan( 0, 0, 5, 0 );
+	this.applicationTimeout = createTimespan( 0, 1, 0, 0 );
+
+	this.cache.connections[ "ldev5941cache" ] = {
+		class: "lucee.runtime.cache.ram.RamCache",
+		storage: true,
+		custom: {
+			timeToLiveSeconds: 300,
+			timeToIdleSeconds: 0
+		}
+	};
+	this.sessionStorage = "ldev5941cache";
+}

--- a/test/tickets/LDEV5941/SessionData.cfc
+++ b/test/tickets/LDEV5941/SessionData.cfc
@@ -1,0 +1,3 @@
+component {
+	this.value = "";
+}

--- a/test/tickets/LDEV5941/stopApp.cfm
+++ b/test/tickets/LDEV5941/stopApp.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+	// Clear session from memory (not from cache storage) so the next request reloads from storage.
+	try {
+		cfid = session.cfid;
+		factory = getPageContext().getCFMLFactory();
+		scopeContext = factory.getScopeContext();
+		appName = getPageContext().getApplicationContext().getName();
+		scopeContext.remove( 1, appName, cfid ); // 1 = Scope.SCOPE_SESSION
+		echo( "cleared" );
+	}
+	catch( any e ) {
+		rethrow;
+	}
+</cfscript>

--- a/test/tickets/LDEV5941/testCommitNoMetadataBump.cfm
+++ b/test/tickets/LDEV5941/testCommitNoMetadataBump.cfm
@@ -1,0 +1,28 @@
+<cfscript>
+	// Probe cache.lastvisit BEFORE sessionCommit, then mutate + sessionCommit, then probe again.
+	// LDEV-5941 fix: sessionCommit must NOT call touchAfterRequest, so _lastvisit in the persisted
+	// scope should stay at the value written by the prior request's natural request-end.
+	// Pre-fix behaviour: sessionCommit bumped _lastvisit to this request's timestamp.
+
+	sessionCacheKey = uCase( "lucee-storage:session:" & cfid & ":" & application.applicationName );
+	// Map is keyed by lucee.runtime.type.Collection.Key, not String — construct one for lookup.
+	lastvisitKey = createObject( "java", "lucee.runtime.type.KeyImpl" ).toKey( "lastvisit" );
+
+	before = cacheGet( id=sessionCacheKey, cacheName="ldev5941cache" );
+	lastvisitBefore = before.getValue().get( lastvisitKey ).getValue().getTime();
+	lastModifiedBefore = before.lastModified();
+
+	session.value = "midrequest-#getTickCount()#";
+	sessionCommit();
+
+	afterStored = cacheGet( id=sessionCacheKey, cacheName="ldev5941cache" );
+	lastvisitAfter = afterStored.getValue().get( lastvisitKey ).getValue().getTime();
+	lastModifiedAfter = afterStored.lastModified();
+
+	echo( serializeJSON( {
+		lastvisitBefore: lastvisitBefore,
+		lastvisitAfter: lastvisitAfter,
+		lastModifiedBefore: lastModifiedBefore,
+		lastModifiedAfter: lastModifiedAfter
+	} ) );
+</cfscript>

--- a/test/tickets/LDEV5941/testCommitOnly.cfm
+++ b/test/tickets/LDEV5941/testCommitOnly.cfm
@@ -1,0 +1,18 @@
+<cfscript>
+	// Mutate, sessionCommit, then NO further mutations.
+	// Capture the cache entry's lastModified after sessionCommit.
+	// Request end runs after this template returns — if no double-write happens,
+	// the cache entry's lastModified stays at this captured value.
+
+	session.value = "committed-at-#getTickCount()#";
+	sessionCommit();
+
+	sessionCacheKey = uCase( "lucee-storage:session:" & cfid & ":" & application.applicationName );
+	// IKStorageValue exposes lastModified directly via a public method.
+	storedValue = cacheGet( id=sessionCacheKey, cacheName="ldev5941cache" );
+
+	echo( serializeJSON( {
+		sessionValue: session.value,
+		cacheLastModifiedAtCommit: storedValue.lastModified()
+	} ) );
+</cfscript>

--- a/test/tickets/LDEV5941/testCommitOnlyCheck.cfm
+++ b/test/tickets/LDEV5941/testCommitOnlyCheck.cfm
@@ -1,0 +1,9 @@
+<cfscript>
+	sessionCacheKey = uCase( "lucee-storage:session:" & cfid & ":" & application.applicationName );
+	storedValue = cacheGet( id=sessionCacheKey, cacheName="ldev5941cache" );
+
+	echo( serializeJSON( {
+		sessionValue: session.value,
+		cacheLastModifiedAfter: storedValue.lastModified()
+	} ) );
+</cfscript>

--- a/test/tickets/LDEV5941/testPostCommitMutation.cfm
+++ b/test/tickets/LDEV5941/testPostCommitMutation.cfm
@@ -1,0 +1,16 @@
+<cfscript>
+	// Store a CFC in session — internal changes to CFC properties are invisible to Lucee's change tracking.
+	session.data = new SessionData();
+	session.data.value = "committed";
+
+	// sessionCommit writes to storage and markStored() clears the dirty flag + rebaselines the hash.
+	sessionCommit();
+
+	// Nested mutation AFTER commit — not detected by hasChanges flag, not detected by hash (CFC ref unchanged).
+	session.data.value = "changedAfterCommit";
+
+	echo( serializeJSON( { nestedValue: "committed" } ) );
+
+	// At request end: touchAfterRequest fires, but hasChanges is false (cleared by markStored) and hash matches.
+	// No redundant write. "changedAfterCommit" stays in memory only, never persisted.
+</cfscript>

--- a/test/tickets/LDEV5941/testPostCommitMutation.cfm
+++ b/test/tickets/LDEV5941/testPostCommitMutation.cfm
@@ -1,16 +1,14 @@
 <cfscript>
-	// Store a CFC in session — internal changes to CFC properties are invisible to Lucee's change tracking.
+	// Store a CFC in session, commit, then mutate a nested property.
+	// LDEV-5930 makes ComponentImpl.hashCode content-aware, so the hash check at request end
+	// catches the post-commit mutation even though the CFC reference is unchanged — the redundant
+	// write fires and "changedAfterCommit" IS persisted. The check template asserts that.
 	session.data = new SessionData();
 	session.data.value = "committed";
 
-	// sessionCommit writes to storage and markStored() clears the dirty flag + rebaselines the hash.
 	sessionCommit();
 
-	// Nested mutation AFTER commit — not detected by hasChanges flag, not detected by hash (CFC ref unchanged).
 	session.data.value = "changedAfterCommit";
 
-	echo( serializeJSON( { nestedValue: "committed" } ) );
-
-	// At request end: touchAfterRequest fires, but hasChanges is false (cleared by markStored) and hash matches.
-	// No redundant write. "changedAfterCommit" stays in memory only, never persisted.
+	echo( serializeJSON( { nestedValue: session.data.value } ) );
 </cfscript>

--- a/test/tickets/LDEV5941/testPostCommitMutationCheck.cfm
+++ b/test/tickets/LDEV5941/testPostCommitMutationCheck.cfm
@@ -1,0 +1,4 @@
+<cfscript>
+	// Reloaded from storage by the prior stopApp.cfm. Expect "committed" (from sessionCommit), not "changedAfterCommit".
+	echo( serializeJSON( { nestedValue: session.data.value } ) );
+</cfscript>

--- a/test/tickets/LDEV5941/testTouchCausesWrite.cfm
+++ b/test/tickets/LDEV5941/testTouchCausesWrite.cfm
@@ -1,0 +1,12 @@
+<cfscript>
+	param name="url.useTouch" default="false";
+
+	if ( url.useTouch ) {
+		sessionTouch();
+	}
+
+	echo( serializeJSON( {
+		cfid: session.cfid,
+		useTouch: url.useTouch
+	} ) );
+</cfscript>

--- a/test/tickets/LDEV6331.cfc
+++ b/test/tickets/LDEV6331.cfc
@@ -1,48 +1,52 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" skip=true {
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" {
+
+	// Bug: IKHandlerCache.store() / IKHandlerDatasource.store() only persist when hasChanges()
+	// is true. hasChanges() flips on real CFML writes (session.foo=bar). Lucee's own _lastvisit
+	// bump uses direct data0.put() and bypasses change detection, so a "login then read-heavy"
+	// pattern never refreshes the storage entry's TTL / expires column.
+	//
+	// Fix: isStale() branch in hasChanges() returns true after wall-clock since last store
+	// exceeds keepAlive (defaults to sessionTimeout/2).
+	//
+	// Test flow per storage backend:
+	//   t=0     SET — single real session write, persists with TTL=4s
+	//   t=2.5s  mid-TTL GET — past keepAlive (2s), fix triggers refresh
+	//   t=5s    final GET — past original TTL (4s), within refreshed TTL (~6.5s)
+	//
+	// Without fix: final GET finds storage entry gone (sessionInStorage=false).
+	// With fix:    final GET finds storage entry still alive.
 
 	function run( testResults, testBox ) {
-		describe( "LDEV-6331 cache-backed sessions evict at TTL boundary on read-only patterns", function() {
 
-			// Bug: IKHandlerCache.store() only calls cache.put() when hasChanges() is true.
-			// hasChanges() flips on real CFML writes (session.foo=bar). Lucee's own
-			// _lastvisit bump uses direct data0.put() and bypasses change detection,
-			// so a "login then read-heavy" pattern never refreshes the cache TTL.
-			//
-			// Test mechanism (per storage + cluster combination):
-			//   1. SET — single real session write, fires cache.put with TTL=2s.
-			//   2. Sleep 2.5s — past both the cache TTL and the session timeout.
-			//   3. purgeExpiredSessions — clears the in-memory copy via the force-flag
-			//      path (storeUnusedStorageScope honouring scope.isExpired()).
-			//   4. GET — no in-memory, cache evicted, fresh session created → session.user
-			//      is lost.
-			//
-			// Matrix:
-			//   - RAM cache vs Redis (Redis skipped if test service unavailable)
-			//   - sessionCluster=false vs sessionCluster=true
-			//
-			// Before fix: assertions FAIL — session.user is "(undefined)".
-			// After fix:  assertions PASS — touch path refreshes the cache TTL before
-			//             the boundary so the cache still has the entry.
-
-			it( title="RAM cache, sessionCluster=false: session preserved across cache-TTL boundary", body=function( currentSpec ) {
-				testCacheBackedSessionEviction( storage: "ram", sessionCluster: false );
+		describe( "LDEV-6331 RAM cache-backed sessions: storage entry refreshed before TTL boundary", function() {
+			it( title="sessionCluster=false", body=function() {
+				testStorageRefresh( storage: "ram", sessionCluster: false );
 			});
-
-			it( title="RAM cache, sessionCluster=true: session preserved across cache-TTL boundary", body=function( currentSpec ) {
-				testCacheBackedSessionEviction( storage: "ram", sessionCluster: true );
+			it( title="sessionCluster=true", body=function() {
+				testStorageRefresh( storage: "ram", sessionCluster: true );
 			});
+		});
 
-			it( title="Redis, sessionCluster=false: session preserved across cache-TTL boundary", skip=skipRedis(), body=function( currentSpec ) {
-				testCacheBackedSessionEviction( storage: "redis", sessionCluster: false );
+		describe( "LDEV-6331 Redis cache-backed sessions: storage entry refreshed before TTL boundary", function() {
+			it( title="sessionCluster=false", skip=skipRedis(), body=function() {
+				testStorageRefresh( storage: "redis", sessionCluster: false );
 			});
+			it( title="sessionCluster=true", skip=skipRedis(), body=function() {
+				testStorageRefresh( storage: "redis", sessionCluster: true );
+			});
+		});
 
-			it( title="Redis, sessionCluster=true: session preserved across cache-TTL boundary", skip=skipRedis(), body=function( currentSpec ) {
-				testCacheBackedSessionEviction( storage: "redis", sessionCluster: true );
+		describe( "LDEV-6331 + LDEV-4670 Datasource (MySQL) sessions: cf_session_data.expires refreshed", function() {
+			it( title="sessionCluster=false", skip=skipMysql(), body=function() {
+				testStorageRefresh( storage: "datasource", sessionCluster: false );
+			});
+			it( title="sessionCluster=true", skip=skipMysql(), body=function() {
+				testStorageRefresh( storage: "datasource", sessionCluster: true );
 			});
 		});
 	}
 
-	private function testCacheBackedSessionEviction( required string storage, required boolean sessionCluster ) {
+	private function testStorageRefresh( required string storage, required boolean sessionCluster ) {
 		var uri = createURI( "LDEV6331" );
 		var label = "#arguments.storage# cluster=#arguments.sessionCluster#";
 		var urlArgs = {
@@ -51,63 +55,42 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" skip=true
 			sessionCluster: arguments.sessionCluster
 		};
 
-		// 1. SET — the one and only real session write
+		// t=0 — SET, cache.put / DB insert fires with TTL/expires at t+4s
 		var setResp = _InternalRequest( template: "#uri#/set.cfm", url: urlArgs );
 		expect( setResp.fileContent ).toBeJson();
-		var setData = deserializeJSON( setResp.fileContent );
-		expect( setData.sessionUser ).toBe( "zac" );
+		expect( deserializeJSON( setResp.fileContent ).sessionUser ).toBe( "zac" );
 
 		var cookies = {
 			cfid: setResp.session.cfid,
 			cftoken: setResp.session.cftoken
 		};
-		var appName = setData.applicationName;
+		var getUrlArgs = {
+			sessionStorage: arguments.storage,
+			sessionCluster: arguments.sessionCluster
+		};
 
-		expect( getSessionCount( appName ) ).toBe( 1, "[#label#] session should be in memory after SET" );
-
-		// 2. Sleep past cache TTL AND session timeout (both 2s)
+		// t~2.5s — mid-TTL GET, past keepAlive=2s, fix's isStale() triggers a refresh write at end of request
 		sleep( 2500 );
+		_InternalRequest( template: "#uri#/get.cfm", url: getUrlArgs, cookies: cookies );
 
-		// 3. Force purge — relies on clearUnused honouring force flag for
-		//    cache-backed sessions (the storeUnusedStorageScope fix).
-		admin
-			action="purgeExpiredSessions"
-			type="server"
-			password="#request.SERVERADMINPASSWORD#";
-
-		expect( getSessionCount( appName ) ).toBe( 0, "[#label#] in-memory session should be purged after sleep > sessionTimeout + purgeExpiredSessions" );
-
-		// 4. GET — no in-memory, cache evicted, must create fresh session
-		var getResp = _InternalRequest(
-			template: "#uri#/get.cfm",
-			url: {
-				sessionStorage: arguments.storage,
-				sessionCluster: arguments.sessionCluster
-			},
-			cookies: cookies
+		// t~5s — past original TTL=4s, within refreshed TTL (~2.5+4=6.5s)
+		sleep( 2500 );
+		var finalResp = _InternalRequest( template: "#uri#/get.cfm", url: getUrlArgs, cookies: cookies );
+		var finalData = deserializeJSON( finalResp.fileContent );
+		expect( finalData.sessionInStorage ).toBeTrue(
+			"BUG LDEV-6331 [#label#]: persisted session entry evicted at original TTL boundary "
+			& "despite a mid-TTL read that should have refreshed it."
 		);
-		expect( getResp.fileContent ).toBeJson();
-		var getData = deserializeJSON( getResp.fileContent );
-
-		expect( getData.sessionUser ).toBe(
-			"zac",
-			"BUG LDEV-6331 [#label#]: cache-backed session evicted at cache TTL boundary. "
-			& "Expected session.user='zac' but got '#getData.sessionUser#'. "
-			& "The fix should refresh the cache TTL on read-only requests so the entry survives."
-		);
-	}
-
-	private numeric function getSessionCount( applicationName ) {
-		var sess = getPageContext().getCFMLFactory().getScopeContext().getAllCFSessionScopes();
-		if ( structKeyExists( sess, arguments.applicationName ) )
-			return len( sess[ arguments.applicationName ] );
-		else
-			return 0;
 	}
 
 	private boolean function skipRedis() {
 		var redis = server.getTestService( "redis" );
 		return isNull( redis ) || structCount( redis ) == 0;
+	}
+
+	private boolean function skipMysql() {
+		var mysql = server.getDatasource( "mysql" );
+		return isEmpty( mysql );
 	}
 
 	private string function createURI( required string calledName ) {

--- a/test/tickets/LDEV6331.cfc
+++ b/test/tickets/LDEV6331.cfc
@@ -6,15 +6,17 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" {
 	// pattern never refreshes the storage entry's TTL / expires column.
 	//
 	// Fix: isStale() branch in hasChanges() returns true after wall-clock since last store
-	// exceeds keepAlive (defaults to sessionTimeout/2).
+	// exceeds sessionCommitInterval (defaults to sessionTimeout/2).
 	//
-	// Test flow per storage backend:
-	//   t=0     SET — single real session write, persists with TTL=4s
-	//   t=2.5s  mid-TTL GET — past keepAlive (2s), fix triggers refresh
-	//   t=5s    final GET — past original TTL (4s), within refreshed TTL (~6.5s)
+	// Test flow per storage backend (TTL = variables.ttlSeconds, commitInterval = TTL/2):
+	//   t=0           SET — single real session write, persists with TTL
+	//   t=TTL*0.7s    mid-TTL GET — past commitInterval, before TTL, fix triggers refresh
+	//   t=TTL*1.3s    final GET — past original TTL, within refreshed TTL (~TTL*1.7s)
 	//
 	// Without fix: final GET finds storage entry gone (sessionInStorage=false).
 	// With fix:    final GET finds storage entry still alive.
+	// Redis EXPIRE is seconds-precision, so 2s is the practical floor — bump if flaky on slow CI.
+	variables.ttlSeconds = 2;
 
 	function run( testResults, testBox ) {
 
@@ -44,21 +46,52 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" {
 				testStorageRefresh( storage: "datasource", sessionCluster: true );
 			});
 		});
+
+		describe( "LDEV-6331 opt-out: this.sessionCommitInterval = createTimespan(0,0,0,0) disables periodic refresh", function() {
+			it( title="zero sessionCommitInterval — storage entry evicts at original TTL (pre-fix behaviour preserved)", body=function() {
+				testStorageRefresh( storage: "ram", sessionCluster: false, sessionCommitInterval: 0, expectInStorage: false );
+			});
+		});
+
+		describe( "LDEV-6331 getApplicationSettings() exposes sessionCommitInterval", function() {
+			it( title="absent from struct when not set (default applies)", body=function() {
+				var uri = createURI( "LDEV6331" );
+				var resp = _InternalRequest( template: "#uri#/settings.cfm", url: { sessionStorage: "ram", sessionCluster: false, ttlSeconds: variables.ttlSeconds } );
+				var data = deserializeJSON( resp.fileContent );
+				expect( data.hasSessionCommitInterval ).toBeFalse(
+					"getApplicationSettings() should not contain sessionCommitInterval when unset — surfaces the default-applies semantic."
+				);
+			});
+
+			it( title="present with explicit value when set", body=function() {
+				var uri = createURI( "LDEV6331" );
+				var resp = _InternalRequest( template: "#uri#/settings.cfm", url: { sessionStorage: "ram", sessionCluster: false, ttlSeconds: variables.ttlSeconds, sessionCommitInterval: 5 } );
+				var data = deserializeJSON( resp.fileContent );
+				expect( data.hasSessionCommitInterval ).toBeTrue( "getApplicationSettings() should contain sessionCommitInterval when set." );
+				expect( data.sessionCommitInterval ).toBe( 5000, "sessionCommitInterval should be exposed as 5000ms TimeSpan." );
+			});
+		});
 	}
 
-	private function testStorageRefresh( required string storage, required boolean sessionCluster ) {
+	private function testStorageRefresh( required string storage, required boolean sessionCluster, string sessionCommitInterval="", boolean expectInStorage=true ) {
 		var uri = createURI( "LDEV6331" );
-		var label = "#arguments.storage# cluster=#arguments.sessionCluster#";
+		var label = "#arguments.storage# cluster=#arguments.sessionCluster#" & ( len( arguments.sessionCommitInterval ) ? " commitInterval=#arguments.sessionCommitInterval#" : "" );
+		var userValue = "user-" & createUUID();
+		var ttlMs = variables.ttlSeconds * 1000;
+		var midSleep = round( ttlMs * 0.7 );
+		var finalSleep = round( ttlMs * 0.6 );
 		var urlArgs = {
-			user: "zac",
+			user: userValue,
 			sessionStorage: arguments.storage,
-			sessionCluster: arguments.sessionCluster
+			sessionCluster: arguments.sessionCluster,
+			ttlSeconds: variables.ttlSeconds,
+			sessionCommitInterval: arguments.sessionCommitInterval
 		};
 
-		// t=0 — SET, cache.put / DB insert fires with TTL/expires at t+4s
+		// t=0 — SET, cache.put / DB insert fires with TTL/expires at t+TTL
 		var setResp = _InternalRequest( template: "#uri#/set.cfm", url: urlArgs );
 		expect( setResp.fileContent ).toBeJson();
-		expect( deserializeJSON( setResp.fileContent ).sessionUser ).toBe( "zac" );
+		expect( deserializeJSON( setResp.fileContent ).sessionUser ).toBe( userValue );
 
 		var cookies = {
 			cfid: setResp.session.cfid,
@@ -66,21 +99,36 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="session" {
 		};
 		var getUrlArgs = {
 			sessionStorage: arguments.storage,
-			sessionCluster: arguments.sessionCluster
+			sessionCluster: arguments.sessionCluster,
+			ttlSeconds: variables.ttlSeconds,
+			sessionCommitInterval: arguments.sessionCommitInterval
 		};
 
-		// t~2.5s — mid-TTL GET, past keepAlive=2s, fix's isStale() triggers a refresh write at end of request
-		sleep( 2500 );
+		// t~TTL*0.7s — mid-TTL GET, past commitInterval=TTL/2, fix's isStale() triggers a refresh write at end of request
+		sleep( midSleep );
 		_InternalRequest( template: "#uri#/get.cfm", url: getUrlArgs, cookies: cookies );
 
-		// t~5s — past original TTL=4s, within refreshed TTL (~2.5+4=6.5s)
-		sleep( 2500 );
+		// t~TTL*1.3s — past original TTL, within refreshed TTL (~TTL*1.7s)
+		sleep( finalSleep );
 		var finalResp = _InternalRequest( template: "#uri#/get.cfm", url: getUrlArgs, cookies: cookies );
 		var finalData = deserializeJSON( finalResp.fileContent );
-		expect( finalData.sessionInStorage ).toBeTrue(
-			"BUG LDEV-6331 [#label#]: persisted session entry evicted at original TTL boundary "
-			& "despite a mid-TTL read that should have refreshed it."
-		);
+
+		if ( arguments.expectInStorage ) {
+			expect( finalData.sessionInStorage ).toBeTrue(
+				"BUG LDEV-6331 [#label#]: persisted session entry evicted at original TTL boundary "
+				& "despite a mid-TTL read that should have refreshed it."
+			);
+			expect( finalData.sessionUser ).toBe(
+				userValue,
+				"BUG LDEV-6331 [#label#]: session payload lost on final GET — expected #userValue#, got #finalData.sessionUser#. "
+				& "Storage entry survived but session data did not round-trip."
+			);
+		} else {
+			expect( finalData.sessionInStorage ).toBeFalse(
+				"LDEV-6331 [#label#]: opt-out failed — storage entry survived past original TTL even with sessionCommitInterval=0. "
+				& "Periodic refresh should be disabled when commitInterval <= 0."
+			);
+		}
 	}
 
 	private boolean function skipRedis() {

--- a/test/tickets/LDEV6331/Application.cfc
+++ b/test/tickets/LDEV6331/Application.cfc
@@ -1,18 +1,20 @@
 component {
 	param name="url.sessionStorage" default="ram";
 	param name="url.sessionCluster" default=false;
-	param name="url.sessionKeepAlive" default="";
+	param name="url.sessionCommitInterval" default="";
+	// ttlSeconds is the session timeout used by the test. Default sessionCommitInterval = ttlSeconds/2.
+	// Redis EXPIRE is seconds-precision, so 2s is the practical floor across all backends — bump if flaky on slow CI.
+	param name="url.ttlSeconds" default="2";
 
 	this.name = "ldev-6331-#url.sessionStorage#-cluster#url.sessionCluster#-" & hash( getCurrentTemplatePath() );
 	this.sessionManagement = true;
 	this.setClientCookies = true;
 	this.sessionType = "application";
 	this.sessionCluster = url.sessionCluster;
-	// 4s session timeout. Default sessionKeepAlive = sessionTimeout/2 = 2s — mid-TTL GET at 2.5s past keepAlive triggers a refresh.
-	this.sessionTimeout = createTimespan( 0, 0, 0, 4 );
+	this.sessionTimeout = createTimespan( 0, 0, 0, javacast( "int", url.ttlSeconds ) );
 	this.applicationTimeout = createTimespan( 0, 1, 0, 0 );
-	if ( len( url.sessionKeepAlive ) )
-		this.sessionKeepAlive = createTimespan( 0, 0, 0, javacast( "int", url.sessionKeepAlive ) );
+	if ( len( url.sessionCommitInterval ) )
+		this.sessionCommitInterval = createTimespan( 0, 0, 0, javacast( "int", url.sessionCommitInterval ) );
 
 	if ( url.sessionStorage eq "redis" ) {
 		// Redis honours per-put TTL (sessionTimeoutMs) as EXPIRE on the key.
@@ -37,14 +39,14 @@ component {
 		this.dataSource = datasourceName;
 		this.sessionStorage = datasourceName;
 	} else {
-		// RAM cache: explicitly set timeToLiveSeconds=4 so the entry's "until"
+		// RAM cache: explicitly set timeToLiveSeconds so the entry's "until"
 		// absolute lifetime is checked independently of read-driven idle resets
 		// — matches Memcached/Redis put-TTL semantics where reads don't refresh.
 		this.cache.connections[ "ldev6331cache" ] = {
 			class: "lucee.runtime.cache.ram.RamCache",
 			storage: true,
 			custom: {
-				timeToLiveSeconds: 4,
+				timeToLiveSeconds: javacast( "int", url.ttlSeconds ),
 				timeToIdleSeconds: 0
 			}
 		};

--- a/test/tickets/LDEV6331/Application.cfc
+++ b/test/tickets/LDEV6331/Application.cfc
@@ -1,17 +1,18 @@
 component {
 	param name="url.sessionStorage" default="ram";
 	param name="url.sessionCluster" default=false;
+	param name="url.sessionKeepAlive" default="";
 
 	this.name = "ldev-6331-#url.sessionStorage#-cluster#url.sessionCluster#-" & hash( getCurrentTemplatePath() );
 	this.sessionManagement = true;
 	this.setClientCookies = true;
 	this.sessionType = "application";
 	this.sessionCluster = url.sessionCluster;
-	// 2s timeout matches the cache TTL. After sleep > 2s,
-	// purgeExpiredSessions (force=true) detects scope.isExpired()=true and
-	// evicts the in-memory copy.
-	this.sessionTimeout = createTimespan( 0, 0, 0, 2 );
+	// 4s session timeout. Default sessionKeepAlive = sessionTimeout/2 = 2s — mid-TTL GET at 2.5s past keepAlive triggers a refresh.
+	this.sessionTimeout = createTimespan( 0, 0, 0, 4 );
 	this.applicationTimeout = createTimespan( 0, 1, 0, 0 );
+	if ( len( url.sessionKeepAlive ) )
+		this.sessionKeepAlive = createTimespan( 0, 0, 0, javacast( "int", url.sessionKeepAlive ) );
 
 	if ( url.sessionStorage eq "redis" ) {
 		// Redis honours per-put TTL (sessionTimeoutMs) as EXPIRE on the key.
@@ -26,19 +27,38 @@ component {
 				"port": redis.port
 			}
 		};
+		this.sessionStorage = "ldev6331cache";
+	} else if ( url.sessionStorage eq "datasource" ) {
+		// MySQL-backed session storage — covers LDEV-4670 (DB expires column never refreshed on read-only).
+		variables.mysql = server.getDatasource( "mysql" );
+		variables.mysql.storage = true;
+		variables.datasourceName = "ldev6331-ds";
+		this.datasources[ datasourceName ] = mysql;
+		this.dataSource = datasourceName;
+		this.sessionStorage = datasourceName;
 	} else {
-		// RAM cache: explicitly set timeToLiveSeconds=2 so the entry's "until"
+		// RAM cache: explicitly set timeToLiveSeconds=4 so the entry's "until"
 		// absolute lifetime is checked independently of read-driven idle resets
 		// — matches Memcached/Redis put-TTL semantics where reads don't refresh.
 		this.cache.connections[ "ldev6331cache" ] = {
 			class: "lucee.runtime.cache.ram.RamCache",
 			storage: true,
 			custom: {
-				timeToLiveSeconds: 2,
+				timeToLiveSeconds: 4,
 				timeToIdleSeconds: 0
 			}
 		};
+		this.sessionStorage = "ldev6331cache";
 	}
 
-	this.sessionStorage = "ldev6331cache";
+	function onApplicationStart() {
+		if ( url.sessionStorage eq "datasource" ) {
+			try {
+				query {
+					echo( "DROP TABLE IF EXISTS cf_session_data" );
+				}
+			}
+			catch ( any e ) { /* ignore */ }
+		}
+	}
 }

--- a/test/tickets/LDEV6331/get.cfm
+++ b/test/tickets/LDEV6331/get.cfm
@@ -1,13 +1,30 @@
 <cfscript>
-// Deliberately read-only. Reads bump _lastvisit via direct data0.put() which
-// bypasses hasChanges() — so the store path never re-fires cache.put() and the
-// cache TTL ticks down uninterrupted from the last real write.
+// Probes whether the persisted session entry is still alive in its backend.
+//   cache backends (ram/redis): lucee-storage:<scope>:<cfid>:<appName> key in the cache
+//   datasource backend:         cf_session_data row with expires > now()
+sessionInStorage = false;
+if ( url.sessionStorage eq "datasource" ) {
+	// expires column is epoch millis
+	query name="q" datasource="#getApplicationSettings().dataSource#" {
+		echo( "SELECT expires FROM cf_session_data WHERE cfid = " );
+		queryParam value=cfid sqltype="varchar";
+		echo( " AND name = " );
+		queryParam value=application.applicationName sqltype="varchar";
+	}
+	sessionInStorage = q.recordcount && q.expires[ 1 ] > dateTimeFormat( now(), "epochms" );
+} else {
+	// IKHandlerCache builds storage keys as UCase("lucee-storage:<scope>:<cfid>:<appName>")
+	sessionCacheKey = uCase( "lucee-storage:session:" & cfid & ":" & application.applicationName );
+	sessionInStorage = !isNull( cacheGet( id=sessionCacheKey, cacheName="ldev6331cache" ) );
+}
+
 result = {
 	"action": "get",
 	"applicationName": application.applicationName,
 	"sessionStorage": getApplicationSettings().sessionStorage,
 	"sessionUser": session?.user ?: "(undefined)",
 	"cfid": cfid,
+	"sessionInStorage": sessionInStorage,
 	"now": dateTimeFormat( now(), "iso" )
 };
 

--- a/test/tickets/LDEV6331/settings.cfm
+++ b/test/tickets/LDEV6331/settings.cfm
@@ -1,0 +1,11 @@
+<cfscript>
+	settings = getApplicationSettings();
+	result = {
+		"hasSessionCommitInterval": structKeyExists( settings, "sessionCommitInterval" ),
+		"sessionCommitInterval": structKeyExists( settings, "sessionCommitInterval" ) ? settings.sessionCommitInterval.getMillis() : 0,
+		"sessionTimeoutMs": settings.sessionTimeout.getMillis()
+	};
+
+	content type="application/json";
+	writeOutput( serializeJson( result ) );
+</cfscript>


### PR DESCRIPTION
# Fix storage-backed session expiry refresh; rework sessionCommit, add sessionTouch

## Summary

- [LDEV-6331](https://luceeserver.atlassian.net/browse/LDEV-6331) — storage-backed sessions and client scopes (cache, Redis, DB, etc.) no longer silently evict at the TTL/expires boundary on read-heavy patterns. New `this.sessionKeepAlive` / `this.clientKeepAlive` Application.cfc settings control the periodic refresh cadence; default is half the relevant timeout.
- [LDEV-4670](https://luceeserver.atlassian.net/browse/LDEV-4670) — DB session storage's `expires` column gets the same periodic refresh as a free side-effect (same `hasChanges()` gate covers both cache and DB handlers). Open since 2023, closed alongside LDEV-6331.
- [LDEV-5941](https://luceeserver.atlassian.net/browse/LDEV-5941) — `sessionCommit()` reworked: stops abusing the request-end lifecycle hook, always forces a write, no longer silently gated by `hasChanges()`. Added `sessionTouch()` for the deferred-write case.

## Implementation notes

### LDEV-6331 — periodic refresh

The fix introduces an `isStale()` branch in the change-detection path. Previously `hasChanges()` was just a flag-and-hash check covering real CFML mutations. Now it splits into:

- `isDirty()` — flag + hash, same as before, catches real CFML writes
- `isStale()` — wall-clock check against `lastStored`; returns true if elapsed > `keepAlive`

`lastStored` is bumped whenever the storage handler successfully persists (new `markStored()` callback from both `IKHandlerCache` and `IKHandlerDatasource`). `keepAlive` comes from the new `this.sessionKeepAlive` / `this.clientKeepAlive` Application.cfc settings, or defaults to `timeSpan / 2`.

The cluster-mode (sessionCluster=true) case works without extra plumbing — `IKStorageValue.lastModified` is already set to `currentTimeMillis()` on every persisted write, so reloading from storage seeds `lastStored` correctly. No new persisted field needed, no Redis extension wire-compat break.

### LDEV-5941 — sessionTouch + sessionCommit rework

Mischa's review on the previous PR #2716 objected to `sessionCommit()` calling `touchAfterRequest()` from inside a request — that method has request-end lifecycle semantics (`_lastvisit` bump, `_timecreated` refresh, `_hitcount`, csrf cleanup) that shouldn't fire mid-request.

This PR extracts a new `commit(pc)` method that does just `setTimeSpan(pc); store(pc);` — the bare write. `touchAfterRequest()` calls `commit(pc)` after its metadata churn (unchanged behaviour for the natural request-end path). `sessionCommit()` calls `commit(pc)` directly, skipping the metadata churn.

`sessionTouch()` is new. Three-line implementation: just calls `markStale()` which sets `lastStored = 0`, forcing `isStale()` to return true at the next store path check. The natural request-end flow picks it up. No new infrastructure beyond what LDEV-6331 already adds.

`markStored()` was also updated to clear the dirty flag and rebaseline the hash after a successful persist — eliminates a redundant write that would otherwise fire at request end after a mid-request `sessionCommit()` when nothing changed afterwards. Note: post-commit nested CFC mutations are still detected by the hash path (LDEV-5930) and persisted at request end — that's intentional behaviour, exercised by a test.

### Future enhancement building off this PR

- Pre-shutdown drain admin action — [LDEV-6333](https://luceeserver.atlassian.net/browse/LDEV-6333), depends on this PR landing first.

## Test coverage

### LDEV6331

3 describe blocks × 2 cluster modes = 6 cases:

- RAM cache (sessionCluster=false / true)
- Redis (when test service available)
- MySQL datasource (when test service available) — directly exercises the LDEV-4670 side-effect by querying `cf_session_data.expires`

Test flow per case: SET at t=0, mid-TTL GET at t=2.5s past keepAlive, sleep past original TTL, final GET probes storage to verify the entry survived. Verifies for cache and DB backends.

### LDEV5941

Three test cases:

1. **Post-commit hash detection** — nested CFC mutation after `sessionCommit()` IS persisted at request end (documents LDEV-5930's intentional behaviour, contrasts with the original PR #2716 premise that was incorrect on current code).
2. **No-double-write** — mutate → sessionCommit → no further mutations → request end fires no redundant write. Verified by probing `IKStorageValue.lastModified()` before and after request end.
3. **sessionTouch smoke** — confirms the FLD wiring works and the function is callable.

[LDEV-6331]: https://luceeserver.atlassian.net/browse/LDEV-6331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LDEV-4670]: https://luceeserver.atlassian.net/browse/LDEV-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LDEV-5941]: https://luceeserver.atlassian.net/browse/LDEV-5941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LDEV-6333]: https://luceeserver.atlassian.net/browse/LDEV-6333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ