### PR TITLE
LDEV-5866 PC and ScopeFactory pool improvements

### DIFF
--- a/core/src/main/java/lucee/runtime/CFMLFactoryImpl.java
+++ b/core/src/main/java/lucee/runtime/CFMLFactoryImpl.java
@@ -87,6 +87,12 @@ public final class CFMLFactoryImpl extends CFMLFactory {
 
 	private static final long MAX_AGE = 5 * 60000; // 5 minutes
 	private static final int MAX_SIZE = 10000;
+	private static final int PC_POOL_MAX_SIZE;
+	static {
+		// core-aware default: ~16 warm PCs per core, floor 100 so dev/small VMs are unchanged
+		int defaultSize = Math.max(100, Runtime.getRuntime().availableProcessors() * 16);
+		PC_POOL_MAX_SIZE = Caster.toIntValue(SystemUtil.getSystemPropOrEnvVar("lucee.pageContext.pool.maxsize", String.valueOf(defaultSize)), defaultSize);
+	}
 	private static final String LOG_TYPE_NAME = "factory";
 	private static JspEngineInfo info = new JspEngineInfoImpl("1.0");
 	private ConfigWebPro config;
@@ -297,7 +303,7 @@ public final class CFMLFactoryImpl extends CFMLFactory {
 				((PageContextImpl) parent).removeChildPageContext(pc);
 			}
 		}
-		if (pcs.size() < 100 && ((PageContextImpl) pc).getTimeoutStackTrace() == null && reuse)// not more than 100 PCs
+		if (pcs.size() < PC_POOL_MAX_SIZE && ((PageContextImpl) pc).getTimeoutStackTrace() == null && reuse)
 			pcs.push((PageContextImpl) pc);
 
 		if (runningPcs.size() > MAX_SIZE) clean(runningPcs);

--- a/core/src/main/java/lucee/runtime/type/scope/ScopeFactory.java
+++ b/core/src/main/java/lucee/runtime/type/scope/ScopeFactory.java
@@ -18,60 +18,67 @@
  **/
 package lucee.runtime.type.scope;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Arrays;
 
+import lucee.commons.io.SystemUtil;
 import lucee.runtime.PageContext;
+import lucee.runtime.op.Caster;
 
 /**
- * creates Local and Argument scopes and recyle it
+ * creates Local and Argument scopes and recyle it.
+ * Per-PageContext instance; pools are single-threaded by design (PC owns one request thread at a time).
+ * LIFO ordering: most-recently-recycled scope is reused first (cache-friendly).
  */
 public final class ScopeFactory {
 
-	private static final int MAX_SIZE = 50;
+	private static final int MAX_SIZE;
+	private static final int INITIAL_SIZE;
+	static {
+		MAX_SIZE = Caster.toIntValue(SystemUtil.getSystemPropOrEnvVar("lucee.scope.pool.maxsize", "50"), 50);
+		INITIAL_SIZE = Math.min(MAX_SIZE, 8);
+	}
 
-	int argumentCounter = 0;
-
-	private final ConcurrentLinkedQueue<Argument> arguments = new ConcurrentLinkedQueue<Argument>();
-	private final ConcurrentLinkedQueue<LocalImpl> locals = new ConcurrentLinkedQueue<LocalImpl>();
+	// Lazy-allocated LIFO stacks. Many ScopeFactory instances never recycle a scope; they pay nothing.
+	private Argument[] argPool;
+	private int argPoolTop = -1;
+	private LocalImpl[] localPool;
+	private int localPoolTop = -1;
 
 	/**
 	 * @return returns an Argument scope
 	 */
 	public Argument getArgumentInstance() {
-		Argument arg = arguments.poll();
-		if (arg != null) {
-			return arg;
-		}
-		return new ArgumentImpl();
+		return (argPoolTop < 0) ? new ArgumentImpl() : argPool[argPoolTop--];
 	}
 
 	/**
 	 * @return retruns a Local Instance
 	 */
 	public LocalImpl getLocalInstance() {
-		LocalImpl lcl = locals.poll();
-		if (lcl != null) {
-			return lcl;
-		}
-		return new LocalImpl();
+		return (localPoolTop < 0) ? new LocalImpl() : localPool[localPoolTop--];
 	}
 
 	/**
 	 * @param argument recycle an Argument scope for reuse
 	 */
 	public void recycle(PageContext pc, Argument argument) {
-		if (arguments.size() >= MAX_SIZE || argument.isBind()) return;
+		// isBind first: cheap field read, short-circuits captured-by-closure scopes (LDEV-3210)
+		if (argument.isBind() || argPoolTop + 1 >= MAX_SIZE) return;
 		argument.release(pc);
-		arguments.add(argument);
+		if (argPool == null) argPool = new Argument[INITIAL_SIZE];
+		else if (argPoolTop + 1 >= argPool.length) argPool = Arrays.copyOf(argPool, Math.min(argPool.length * 2, MAX_SIZE));
+		argPool[++argPoolTop] = argument;
 	}
 
 	/**
 	 * @param local recycle a Local scope for reuse
 	 */
 	public void recycle(PageContext pc, LocalImpl local) {
-		if (locals.size() >= MAX_SIZE || local.isBind()) return;
+		if (local.isBind() || localPoolTop + 1 >= MAX_SIZE) return;
 		local.release(pc);
-		locals.add(local);
+		if (localPool == null) localPool = new LocalImpl[INITIAL_SIZE];
+		else if (localPoolTop + 1 >= localPool.length) localPool = Arrays.copyOf(localPool, Math.min(localPool.length * 2, MAX_SIZE));
+		localPool[++localPoolTop] = local;
 	}
 
 	/**

--- a/core/src/main/java/resource/setting/sysprop-envvar.json
+++ b/core/src/main/java/resource/setting/sysprop-envvar.json
@@ -1094,6 +1094,22 @@
 		"default": 16
 	},
 	{
+		"sysprop": "lucee.scope.pool.maxsize",
+		"envvar": "LUCEE_SCOPE_POOL_MAXSIZE",
+		"desc": "Maximum size of the per-PageContext recycle pool for Argument and Local scope instances. Each PageContext has its own pool; this is the per-pool cap.",
+		"category": "performance",
+		"type": "numeric",
+		"default": 50
+	},
+	{
+		"sysprop": "lucee.pageContext.pool.maxsize",
+		"envvar": "LUCEE_PAGECONTEXT_POOL_MAXSIZE",
+		"desc": "Maximum number of idle PageContext instances kept in the per-CFMLFactory recycle pool for reuse. Default is core-aware: max(100, cores * 16).",
+		"category": "performance",
+		"type": "numeric",
+		"default": "max(100, cores * 16)"
+	},
+	{
 		"sysprop": "lucee.script.protect",
 		"envvar": "LUCEE_SCRIPT_PROTECT",
 		"desc": "Script protect setting used by default. Consult the Lucee admin page /Settings/Request for details on possible settings",


### PR DESCRIPTION
Replaces #2684.

## Summary

- Replace ScopeFactory ConcurrentLinkedQueue with inline LIFO array + lazy alloc
- Configurable PageContext pool cap (was hardcoded 100) with core-aware default
- Configurable scope pool cap (was hardcoded 50), env-var tuneable

## Why

ScopeFactory is per-PageContext and single-threaded by design (PC owns one
request thread at a time; worker threads get cloned PCs). The
ConcurrentLinkedQueue paid for concurrency that doesn't happen — Node alloc
per recycle, O(n) size(), sentinel Node retained per empty pool.

The hardcoded PC pool cap of 100 was the bigger perf bug. On a 32-core machine
running 32-thread parallel BIFs, the cap binds hard and every overflow task
allocates a fresh PageContext with a cold scope pool.

The two changes compound: the bigger PC pool only makes sense if empty
ScopeFactories are memory-cheap, which lazy alloc delivers.