### PR TITLE
LDEV-6354 don't abort S3 bundle listing on a malformed version or key

### DIFF
--- a/core/src/main/java/lucee/runtime/config/s3/BundleProvider.java
+++ b/core/src/main/java/lucee/runtime/config/s3/BundleProvider.java
@@ -12,7 +12,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.CodeSource;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
@@ -452,16 +454,22 @@ public final class BundleProvider extends DefaultHandler {
 	// 1146:size:305198;bundle:name:xmlgraphics.batik.awt.util;version:version EQ 1.8.0;;last-mod:{ts
 	// '2024-01-14 22:32:05'};
 
+	private URL markerURL(String key) throws MalformedURLException {
+		// S3 object keys can contain characters (e.g. spaces) that are illegal in a URI
+		// query and would otherwise abort the entire paginated listing walk.
+		return new URL(this.url.toExternalForm() + "?marker=" + URLEncoder.encode(key, StandardCharsets.UTF_8));
+	}
+
 	public List<Element> read(boolean flush) throws IOException, GeneralSecurityException, SAXException {
 		if (elementsSorted == null) {
 			synchronized (elements) {
 				if (elementsSorted == null) {
 					int count = 100;
 					URL url = null;
-					if (lastKey != null) url = new URL(this.url.toExternalForm() + "?marker=" + lastKey);
+					if (lastKey != null) url = markerURL(lastKey);
 
 					do {
-						if (url == null) url = isTruncated ? new URL(this.url.toExternalForm() + "?marker=" + this.lastKey) : this.url;
+						if (url == null) url = isTruncated ? markerURL(this.lastKey) : this.url;
 						HTTPResponse rsp = HTTPEngine4Impl.get(url, null, null, BundleProvider.CONNECTION_TIMEOUT, true, null, null, null, null);
 						if (rsp != null) {
 							int sc = rsp.getStatusCode();

--- a/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
+++ b/core/src/main/java/lucee/runtime/osgi/OSGiUtil.java
@@ -326,8 +326,15 @@ public final class OSGiUtil {
 			return defaultValue;
 		}
 
-		if (qualifier == null) return new Version(major, minor, micro);
-		return new Version(major, minor, micro, qualifier);
+		try {
+			if (qualifier == null) return new Version(major, minor, micro);
+			return new Version(major, minor, micro, qualifier);
+		}
+		catch (IllegalArgumentException e) {
+			// a malformed qualifier (e.g. a space in an S3 listing entry) makes the OSGi
+			// Version constructor throw; this overload must return defaultValue instead.
+			return defaultValue;
+		}
 	}
 
 	public static Version toVersion(String version) throws BundleException {

--- a/test/tickets/LDEV6354.cfc
+++ b/test/tickets/LDEV6354.cfc
@@ -1,0 +1,22 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" {
+	public function run( testResults, testBox ) {
+		describe( title="LDEV-6354 OSGiUtil.toVersion tolerates a malformed qualifier instead of throwing", body=function() {
+
+			it( title="returns the default for a qualifier containing a space (the S3 'GA copy' entry)", body=function( currentSpec ) {
+				var OSGiUtil = createObject( "java", "lucee.runtime.osgi.OSGiUtil" );
+				var fallback = createObject( "java", "org.osgi.framework.Version" ).init( "9.9.9" );
+				// must NOT throw IllegalArgumentException; this overload contractually returns the default
+				var result = OSGiUtil.toVersion( "3.9.0.GA copy", fallback );
+				expect( result.toString() ).toBe( "9.9.9" );
+			});
+
+			it( title="still parses a well-formed OSGi version + qualifier", body=function( currentSpec ) {
+				var OSGiUtil = createObject( "java", "lucee.runtime.osgi.OSGiUtil" );
+				var fallback = createObject( "java", "org.osgi.framework.Version" ).init( "9.9.9" );
+				var result = OSGiUtil.toVersion( "3.9.0.GA", fallback );
+				expect( result.toString() ).toBe( "3.9.0.GA" );
+			});
+
+		});
+	}
+}


### PR DESCRIPTION
## LDEV-6354

https://luceeserver.atlassian.net/browse/LDEV-6354

### Problem

Lucee's S3 `BundleProvider` (the fallback resolver that lists `bundle-download.s3.amazonaws.com` when a bundle isn't found locally or on update.lucee.org) aborts the **entire** listing walk when the bucket contains a single entry whose name yields a malformed OSGi version. Resolution of *every* S3-hosted bundle then fails — a request for e.g. `org.xerial.sqlite-jdbc` surfaces a parse error about `javassist`:

```
java.io.IOException: java.lang.IllegalArgumentException: invalid version "3.9.0.GA copy": invalid qualifier "GA copy"
    at org.osgi.framework.Version.validate(Version.java:203)
    at lucee.runtime.config.s3.BundleProvider.read(BundleProvider.java:520)
    at lucee.runtime.config.s3.BundleProvider.getBundleAsURL(BundleProvider.java:267)
    ...
Caused by: java.lang.IllegalArgumentException: Illegal character in query at index 67:
    https://bundle-download.s3.amazonaws.com/?marker=javassist-3.9.0.GA copy.jar
```

The bucket currently contains `javassist-3.9.0.GA copy.jar` (a Finder-style "copy" duplicate) plus several space-containing `.meta-cache/*.json` keys.

### Root cause & fix

**1. `OSGiUtil.toVersion(String, boolean, Version)` violated its default-return contract.** For `3.9.0.GA copy` it parses major/minor/micro, then calls `new Version(3, 9, 0, "GA copy")`, whose constructor `validate()` rejects the space and throws `IllegalArgumentException`. That construction (the restrictive path) wasn't guarded — unlike the non-restrictive branch immediately above it. Because this overload takes a `defaultValue`, callers expect it never to throw; instead the exception escaped the SAX parse in `BundleProvider.read()`. Fixed by wrapping the construction in `try/catch (IllegalArgumentException)` returning `defaultValue`.

**2. `BundleProvider.read()` built the pagination URL by naive concatenation** (`"?marker=" + lastKey`), throwing `Illegal character in query` when a key contains a space. The listing is truncated (>1000 keys) so `?marker=` pagination runs in normal operation. Fixed by URL-encoding the marker.

Either fix alone resolves the reported crash; together they make S3 bundle resolution resilient to any single malformed listing entry.

### Test

`test/tickets/LDEV6354.cfc` asserts `OSGiUtil.toVersion("3.9.0.GA copy", default)` returns the default instead of throwing, and that a well-formed qualifier still parses.

### Note

The malformed bucket entries should also be cleaned up server-side (tracked in LDEV-6354) — that fixes already-released versions immediately; this PR prevents recurrence from any future malformed entry.

Downstream report: https://github.com/wheels-dev/wheels/issues/2312