### PR TITLE
LDEV-6392 preserve parent include path stack on cloned PageContext

### DIFF
--- a/core/src/main/java/lucee/runtime/PageContextImpl.java
+++ b/core/src/main/java/lucee/runtime/PageContextImpl.java
@@ -343,8 +343,6 @@ public final class PageContextImpl extends PageContext {
 	private Map<Key, Threads> allThreads;
 	private boolean hasFamily = false;
 	private PageContextImpl parent = null;
-	private PageSource caller = null;
-	private PageSource callerTemplate = null;
 	private PageContextImpl root = null;
 
 	private List<String> parentTags;
@@ -460,8 +458,6 @@ public final class PageContextImpl extends PageContext {
 			boolean autoFlush, boolean isChild, boolean ignoreScopes, PageContextImpl tmplPC) {
 		applicationContext = initApplicationContext;
 		parent = null;
-		caller = null;
-		callerTemplate = null;
 		root = null;
 
 		boolean clone = tmplPC != null;
@@ -597,8 +593,6 @@ public final class PageContextImpl extends PageContext {
 			tmplPC.hasFamily = true;
 
 			this.parent = tmplPC;
-			this.caller = tmplPC.getCurrentPageSource();
-			this.callerTemplate = tmplPC.getCurrentTemplatePageSource();
 			this.root = tmplPC.root == null ? tmplPC : tmplPC.root;
 			this.tagName = tmplPC.tagName;
 			this.parentTags = tmplPC.parentTags == null ? null : (List) ((ArrayList) tmplPC.parentTags).clone();
@@ -619,7 +613,7 @@ public final class PageContextImpl extends PageContext {
 			while (it.hasNext()) {
 				this.includePathList.add(it.next());
 			}
-			it = pathList.iterator();
+			it = tmplPC.pathList.iterator();
 			while (it.hasNext()) {
 				this.pathList.add(it.next());
 			}
@@ -659,10 +653,7 @@ public final class PageContextImpl extends PageContext {
 
 		this.serverPassword = null;
 
-		// boolean isChild=parent!=null; // isChild is defined in the class outside this method
 		parent = null;
-		caller = null;
-		callerTemplate = null;
 		root = null;
 		// ORM
 		// if(ormSession!=null)releaseORM();
@@ -763,12 +754,10 @@ public final class PageContextImpl extends PageContext {
 			lazyStats = null;
 		}
 
-		if (!hasFamily) {
-			pathList.clear();
-			includePathList.clear();
-			// Only clear UDF stack if empty - active UDFs will clean themselves up
-			if (udfs.isEmpty()) udfs.clear();
-		}
+		pathList.clear();
+		includePathList.clear();
+		// Only clear UDF stack if empty - active UDFs will clean themselves up
+		if (udfs.isEmpty()) udfs.clear();
 		executionTime = 0;
 
 		bodyContentStack.release();
@@ -965,10 +954,8 @@ public final class PageContextImpl extends PageContext {
 
 	public PageSource[] getRelativePageSources(String realPath) {
 		if (StringUtil.startsWith(realPath, '/')) return getPageSources(realPath);
-
-		PageSource ps = getCurrentPageSource(null);
+		PageSource ps = pathList.peekLast();
 		if (ps == null) return null;
-
 		return new PageSource[] { ((PageSourceImpl) ps).getRealPageSource(this, realPath) };
 	}
 
@@ -1205,26 +1192,13 @@ public final class PageContextImpl extends PageContext {
 
 	@Override
 	public PageSource getCurrentPageSource() {
-		PageSource ps = pathList.peekLast();
-		if (ps != null) return ps;
-
-		if (parent != null && parent != this && parent.isInitialized()) { // second comparision should not be necesary, just in case ...
-			return parent.getCurrentPageSource();
-		}
-		else if (caller != null) return caller;
-		return null;
+		return pathList.peekLast();
 	}
 
 	@Override
 	public PageSource getCurrentPageSource(PageSource defaultvalue) {
 		PageSource ps = pathList.peekLast();
-		if (ps != null) return ps;
-
-		if (parent != null && parent != this && parent.isInitialized()) { // second comparision should not be necesary, just in case ...
-			return parent.getCurrentPageSource(defaultvalue);
-		}
-		else if (caller != null) return caller;
-		return defaultvalue;
+		return ps != null ? ps : defaultvalue;
 	}
 
 	/**
@@ -1232,14 +1206,7 @@ public final class PageContextImpl extends PageContext {
 	 */
 	@Override
 	public PageSource getCurrentTemplatePageSource() {
-		if (includePathList.isEmpty()) {
-			if (parent != null && parent != this && parent.isInitialized()) { // second comparision should not be necesary, just in case ...
-				return parent.getCurrentTemplatePageSource();
-			}
-			else if (callerTemplate != null) return callerTemplate;
-			return null;
-		}
-		return includePathList.getLast();
+		return includePathList.peekLast();
 	}
 
 	/**

--- a/test/tickets/LDEV3627.cfc
+++ b/test/tickets/LDEV3627.cfc
@@ -10,5 +10,82 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 			cfthread.t3627.result?:"undefined"
 		);
 	}
-	
-} 
+
+	// parallel arrayMap clones the PageContext via UDFCaller2 (different path than cfthread)
+	// each closure must still resolve LDEV3627.sub.Test relative to this test file
+	public void function testParallelMap(){
+		var results = arrayMap( [ 1, 2, 3, 4, 5 ], function( item ){
+			return new LDEV3627.sub.Test().test();
+		}, true );
+		assertEquals( 5, arrayLen( results ) );
+		for ( var r in results ) {
+			assertEquals( "test", r );
+		}
+	}
+
+	// clone-of-a-clone: cfthread clones the test PC, then parallel arrayMap inside the thread
+	// clones the thread's PC. Inner closure must transitively still resolve the relative CFC.
+	public void function testNestedParallelInThread(){
+		thread name="t3627_nested" {
+			thread.results = arrayMap( [ 1, 2, 3 ], function( item ){
+				return new LDEV3627.sub.Test().test();
+			}, true );
+		}
+		thread action="join" name="t3627_nested";
+		var results = cfthread.t3627_nested.results ?: [];
+		assertEquals( 3, arrayLen( results ) );
+		for ( var r in results ) {
+			assertEquals( "test", r );
+		}
+	}
+
+	// inverse nesting: parallel arrayMap clones first, then each closure spawns a cfthread
+	// the inner cfthread clones from the parallel clone. Same transitive requirement.
+	public void function testThreadInParallel(){
+		var results = arrayMap( [ 1, 2 ], function( item ){
+			var tname = "t3627_inner_" & item;
+			thread name="#tname#" {
+				thread.r = new LDEV3627.sub.Test().test();
+			}
+			thread action="join" name="#tname#";
+			return cfthread[ tname ].r ?: "undefined";
+		}, true );
+		assertEquals( 2, arrayLen( results ) );
+		for ( var r in results ) {
+			assertEquals( "test", r );
+		}
+	}
+
+	// cfinclude with a relative path inside a parallel closure exercises getRealPageSource(realPath)
+	// from a clone PC, which the LDEV-3689 parent-walk workaround did NOT cover.
+	public void function testParallelInclude(){
+		var results = arrayMap( [ 1, 2, 3 ], function( item ){
+			var out = "";
+			savecontent variable="out" {
+				include "LDEV3627/sub/snippet.cfm";
+			}
+			return trim( out );
+		}, true );
+		assertEquals( 3, arrayLen( results ) );
+		for ( var r in results ) {
+			assertEquals( "included", r );
+		}
+	}
+
+	// cfmodule template= with a relative path inside a parallel closure. Same untested reader,
+	// different tag entry point (Module.java -> getRelativePageSources).
+	public void function testParallelModule(){
+		var results = arrayMap( [ 1, 2, 3 ], function( item ){
+			var out = "";
+			savecontent variable="out" {
+				cfmodule( template="LDEV3627/sub/module-target.cfm", value=item );
+			}
+			return trim( out );
+		}, true );
+		assertEquals( 3, arrayLen( results ) );
+		for ( var i = 1; i <= 3; i++ ) {
+			assertEquals( "module:" & i, results[ i ] );
+		}
+	}
+
+}

--- a/test/tickets/LDEV3627/sub/module-target.cfm
+++ b/test/tickets/LDEV3627/sub/module-target.cfm
@@ -1,0 +1,4 @@
+<cfif thisTag.executionMode is "start">
+	<cfparam name="attributes.value" default="0">
+	<cfoutput>module:#attributes.value#</cfoutput>
+</cfif>

--- a/test/tickets/LDEV3627/sub/snippet.cfm
+++ b/test/tickets/LDEV3627/sub/snippet.cfm
@@ -1,0 +1,1 @@
+<cfoutput>included</cfoutput>


### PR DESCRIPTION
## Summary

[LDEV-6392](https://luceeserver.atlassian.net/browse/LDEV-6392) — cloned `PageContext` instances now carry a snapshot of the parent's active include path stack at clone time.

## Invariants

- A cloned PC (parallel-iteration closure under `parallel=true`, `cfthread`, or any task going through `ThreadUtil.clonePageContext` / `UDFCaller2`) sees the parent's path stack as it was at clone time.
- Snapshot semantics, not live read — appropriate for closure usage. Parallel iteration blocks until done; `cfthread` should not pick up changes from the parent's subsequent cfincludes.
- The three `getCurrentPageSource*()` accessors now read the local stack directly.

## What was removed (now-unreachable code)

With the stack correctly populated on every clone, the indirect lookup paths that existed to compensate for an empty stack are no longer reachable:

- `caller` / `callerTemplate` fields, their init/release nulling, and the clone-time stash
- Parent-chain walk + caller fallback in the three `getCurrentPageSource*()` accessors
- `getRelativePageSources()` indirection — reverts to direct `pathList.peekLast()`
- `hasFamily`-guarded skip on `pathList` / `includePathList` clear in `release()` — protected a read pattern that no longer exists

## What was kept

- `parent` field + `getParentPageContext()` accessor — backs a public API used by execution logging, the factory recycler, child-thread delegation, and an internal recycler-eligibility walk; independent of this work.
- `reuse = !pc.hasFamily()` recycler check in `CFMLFactoryImpl.release()` — children still reference parent's `root` and `applicationContext` by reference; recycling a parent with live children would invalidate them. Independent concern.

## Test plan

- [x] Full \`mvn test\` — green, including 5 new tests in \`LDEV3627.cfc\` covering the parallel-iteration clone path, nested clone-of-a-clone in both directions, relative \`cfinclude\` from parallel, and relative \`cfmodule\` from parallel
- [x] Existing tests still green: \`LDEV3627\`, \`LDEV3689\` (6 scenarios), \`LDEV3802\`
- [x] ORM extension load test — cfthread + ORM session scenario clean
- [x] Preside 7.1 boot + smoke (request lifecycle) — clean
- [x] ColdBox full test suite — passing better than documented baseline

Tested locally on Lucee 7.1.

[LDEV-6392]: https://luceeserver.atlassian.net/browse/LDEV-6392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ