### PR TITLE
LDEV-6395 drain orphan futures in parallel BIF dispatch

### DIFF
--- a/core/src/main/java/lucee/runtime/functions/closure/Each.java
+++ b/core/src/main/java/lucee/runtime/functions/closure/Each.java
@@ -72,20 +72,31 @@ public final class Each extends BIF implements ClosureFunc {
 	}
 
 	private static String _call(PageContext pc, Object obj, UDF udf, boolean parallel, int maxThreads, short type) throws PageException {
-		ExecutorService execute = null;
-		List<Future<Data<Object>>> futures = null;
-		Thread thread = null;
 		// 0 or less == default
 		if (maxThreads < 1) maxThreads = DEFAULT_MAX_THREAD;
 		// 1 == not parallel
 		else if (maxThreads == 1) parallel = false;
 
-		if (parallel) {
-			execute = ThreadUtil.createExecutorService(maxThreads);
-			futures = new ArrayList<Future<Data<Object>>>();
-			thread = ((PageContextImpl) pc).getThread();
+		if (!parallel) {
+			dispatch(pc, obj, udf, type, null, null);
+			return null;
 		}
 
+		ExecutorService execute = ThreadUtil.createExecutorService(maxThreads);
+		List<Future<Data<Object>>> futures = new ArrayList<Future<Data<Object>>>();
+		Thread thread = ((PageContextImpl) pc).getThread();
+		try {
+			dispatch(pc, obj, udf, type, execute, futures);
+			afterCall(pc, futures);
+		}
+		finally {
+			// drain orphans so they can't race the caller's post-parallel state (LDEV-6395)
+			ThreadUtil.finishParallelSection(pc, execute, thread, futures);
+		}
+		return null;
+	}
+
+	private static void dispatch(PageContext pc, Object obj, UDF udf, short type, ExecutorService execute, List<Future<Data<Object>>> futures) throws PageException {
 		// !!!! Don't combine the first 2 ifs with the ifs below, type overrules instanceof check
 		// Array
 		if (type == TYPE_ARRAY) {
@@ -155,26 +166,17 @@ public final class Each extends BIF implements ClosureFunc {
 			invoke(pc, (StringListData) obj, udf, execute, futures);
 		}
 		else throw new FunctionException(pc, "Each", 1, "data", "Cannot iterate over this type [" + Caster.toTypeName(obj.getClass()) + "]");
-
-		if (parallel) afterCall(pc, futures, execute, thread);
-
-		return null;
 	}
 
-	public static void afterCall(PageContext pc, List<Future<Data<Object>>> futures, ExecutorService es, Thread thread) throws PageException {
+	public static void afterCall(PageContext pc, List<Future<Data<Object>>> futures) throws PageException {
 		try {
 			Iterator<Future<Data<Object>>> it = futures.iterator();
-			// Future<String> f;
 			while (it.hasNext()) {
 				pc.write(it.next().get().output);
 			}
 		}
 		catch (Exception e) {
 			throw Caster.toPageException(e);
-		}
-		finally {
-			((PageContextImpl) pc).setThread(thread);
-			if (es != null) es.shutdown();
 		}
 	}
 

--- a/core/src/main/java/lucee/runtime/functions/closure/Every.java
+++ b/core/src/main/java/lucee/runtime/functions/closure/Every.java
@@ -72,23 +72,29 @@ public final class Every extends BIF implements ClosureFunc {
 	}
 
 	private static boolean _call(PageContext pc, Object obj, UDF udf, boolean parallel, int maxThreads, short type) throws PageException {
-
-		Thread thread = null;
-		ExecutorService execute = null;
-		List<Future<Data<Object>>> futures = null;
 		// 0 or less == default
 		if (maxThreads < 1) maxThreads = Each.DEFAULT_MAX_THREAD;
 		// 1 == not parallel
 		else if (maxThreads == 1) parallel = false;
 
-		if (parallel) {
-			execute = ThreadUtil.createExecutorService(maxThreads);
-			futures = new ArrayList<Future<Data<Object>>>();
-			thread = ((PageContextImpl) pc).getThread();
+		if (!parallel) return dispatch(pc, obj, udf, type, null, null);
+
+		ExecutorService execute = ThreadUtil.createExecutorService(maxThreads);
+		List<Future<Data<Object>>> futures = new ArrayList<Future<Data<Object>>>();
+		Thread thread = ((PageContextImpl) pc).getThread();
+		try {
+			// dispatch return is always true in async mode; afterCall produces the real result
+			dispatch(pc, obj, udf, type, execute, futures);
+			return afterCall(pc, futures);
 		}
+		finally {
+			// drain orphans so they can't race the caller's post-parallel state (LDEV-6395)
+			ThreadUtil.finishParallelSection(pc, execute, thread, futures);
+		}
+	}
 
+	private static boolean dispatch(PageContext pc, Object obj, UDF udf, short type, ExecutorService execute, List<Future<Data<Object>>> futures) throws PageException {
 		boolean res;
-
 		// !!!! Don't combine the first 3 ifs with the ifs below, type overrules instanceof check
 		// Array
 		if (type == TYPE_ARRAY) {
@@ -141,9 +147,6 @@ public final class Every extends BIF implements ClosureFunc {
 			res = invoke(pc, (StringListData) obj, udf, execute, futures);
 		}
 		else throw new FunctionException(pc, "Every", 1, "data", "Cannot iterate over this type [" + Caster.toTypeName(obj.getClass()) + "]");
-
-		if (parallel) res = afterCall(pc, futures, execute, thread);
-
 		return res;
 	}
 
@@ -311,7 +314,7 @@ public final class Every extends BIF implements ClosureFunc {
 		return null;
 	}
 
-	public static boolean afterCall(PageContext pc, List<Future<Data<Object>>> futures, ExecutorService es, Thread thread) throws PageException {
+	public static boolean afterCall(PageContext pc, List<Future<Data<Object>>> futures) throws PageException {
 		try {
 			Iterator<Future<Data<Object>>> it = futures.iterator();
 			Data<Object> d;
@@ -324,10 +327,6 @@ public final class Every extends BIF implements ClosureFunc {
 		}
 		catch (Exception e) {
 			throw Caster.toPageException(e);
-		}
-		finally {
-			((PageContextImpl) pc).setThread(thread);
-			if (es != null) es.shutdown();
 		}
 	}
 

--- a/core/src/main/java/lucee/runtime/functions/closure/Filter.java
+++ b/core/src/main/java/lucee/runtime/functions/closure/Filter.java
@@ -78,20 +78,29 @@ public final class Filter extends BIF implements ClosureFunc {
 	}
 
 	private static Collection _call(PageContext pc, Object obj, UDF udf, boolean parallel, int maxThreads, short type) throws PageException {
-
-		Thread thread = null;
-		ExecutorService execute = null;
-		List<Future<Data<Pair<Object, Object>>>> futures = null;
 		// 0 or less == default
 		if (maxThreads < 1) maxThreads = Each.DEFAULT_MAX_THREAD;
 		// 1 == not parallel
 		else if (maxThreads == 1) parallel = false;
-		if (parallel) {
-			execute = ThreadUtil.createExecutorService(maxThreads);
-			futures = new ArrayList<Future<Data<Pair<Object, Object>>>>();
-			thread = ((PageContextImpl) pc).getThread();
-		}
 
+		if (!parallel) return dispatch(pc, obj, udf, type, null, null);
+
+		ExecutorService execute = ThreadUtil.createExecutorService(maxThreads);
+		List<Future<Data<Pair<Object, Object>>>> futures = new ArrayList<Future<Data<Pair<Object, Object>>>>();
+		Thread thread = ((PageContextImpl) pc).getThread();
+		Collection coll;
+		try {
+			coll = dispatch(pc, obj, udf, type, execute, futures);
+			afterCall(pc, coll, futures);
+		}
+		finally {
+			// drain orphans so they can't race the caller's post-parallel state (LDEV-6395)
+			ThreadUtil.finishParallelSection(pc, execute, thread, futures);
+		}
+		return coll;
+	}
+
+	private static Collection dispatch(PageContext pc, Object obj, UDF udf, short type, ExecutorService execute, List<Future<Data<Pair<Object, Object>>>> futures) throws PageException {
 		Collection coll;
 		// !!!! Don't combine the first 3 ifs with the ifs below, type overrules instanceof check
 		// Array
@@ -144,9 +153,6 @@ public final class Filter extends BIF implements ClosureFunc {
 			coll = invoke(pc, (StringListData) obj, udf, execute, futures);
 		}
 		else throw new FunctionException(pc, "Filter", 1, "data", "Cannot iterate over this type [" + Caster.toTypeName(obj.getClass()) + "]");
-
-		if (parallel) afterCall(pc, coll, futures, execute, thread);
-
 		return coll;
 	}
 
@@ -333,7 +339,7 @@ public final class Filter extends BIF implements ClosureFunc {
 		return null;
 	}
 
-	public static void afterCall(PageContext pc, Collection coll, List<Future<Data<Pair<Object, Object>>>> futures, ExecutorService es, Thread thread) throws PageException {
+	public static void afterCall(PageContext pc, Collection coll, List<Future<Data<Pair<Object, Object>>>> futures) throws PageException {
 		try {
 			boolean isArray = false;
 			boolean isQuery = false;
@@ -356,10 +362,6 @@ public final class Filter extends BIF implements ClosureFunc {
 		}
 		catch (Exception e) {
 			throw Caster.toPageException(e);
-		}
-		finally {
-			((PageContextImpl) pc).setThread(thread);
-			if (es != null) es.shutdown();
 		}
 	}
 

--- a/core/src/main/java/lucee/runtime/functions/closure/Map.java
+++ b/core/src/main/java/lucee/runtime/functions/closure/Map.java
@@ -78,22 +78,30 @@ public final class Map extends BIF implements ClosureFunc {
 	}
 
 	private static Collection _call(PageContext pc, Object obj, UDF udf, boolean parallel, int maxThreads, Query resQry, short type) throws PageException {
-
-		Thread thread = null;
-		ExecutorService execute = null;
-		List<Future<Data<Object>>> futures = null;
 		// 0 or less == default
 		if (maxThreads < 1) maxThreads = Each.DEFAULT_MAX_THREAD;
 		// 1 == not parallel
 		else if (maxThreads == 1) parallel = false;
-		if (parallel) {
-			execute = ThreadUtil.createExecutorService(maxThreads);
-			futures = new ArrayList<Future<Data<Object>>>();
-			thread = ((PageContextImpl) pc).getThread();
-		}
 
+		if (!parallel) return dispatch(pc, obj, udf, resQry, type, null, null);
+
+		ExecutorService execute = ThreadUtil.createExecutorService(maxThreads);
+		List<Future<Data<Object>>> futures = new ArrayList<Future<Data<Object>>>();
+		Thread thread = ((PageContextImpl) pc).getThread();
 		Collection coll;
+		try {
+			coll = dispatch(pc, obj, udf, resQry, type, execute, futures);
+			afterCall(pc, coll, futures);
+		}
+		finally {
+			// drain orphans so they can't race the caller's post-parallel state (LDEV-6395)
+			ThreadUtil.finishParallelSection(pc, execute, thread, futures);
+		}
+		return coll;
+	}
 
+	private static Collection dispatch(PageContext pc, Object obj, UDF udf, Query resQry, short type, ExecutorService execute, List<Future<Data<Object>>> futures) throws PageException {
+		Collection coll;
 		// !!!! Don't combine the first 3 ifs with the ifs below, type overrules instanceof check
 		// Array
 		if (type == TYPE_ARRAY) {
@@ -144,9 +152,6 @@ public final class Map extends BIF implements ClosureFunc {
 			coll = invoke(pc, (StringListData) obj, udf, execute, futures);
 		}
 		else throw new FunctionException(pc, "Map", 1, "data", "Cannot iterate over this type [" + Caster.toTypeName(obj.getClass()) + "]");
-
-		if (parallel) afterCall(pc, coll, futures, execute, thread);
-
 		return coll;
 	}
 
@@ -337,7 +342,7 @@ public final class Map extends BIF implements ClosureFunc {
 		return null;
 	}
 
-	public static void afterCall(PageContext pc, Collection coll, List<Future<Data<Object>>> futures, ExecutorService es, Thread thread) throws PageException {
+	public static void afterCall(PageContext pc, Collection coll, List<Future<Data<Object>>> futures) throws PageException {
 		boolean isQuery = coll instanceof Query;
 		try {
 			Iterator<Future<Data<Object>>> it = futures.iterator();
@@ -351,10 +356,6 @@ public final class Map extends BIF implements ClosureFunc {
 		}
 		catch (Exception e) {
 			throw Caster.toPageException(e);
-		}
-		finally {
-			((PageContextImpl) pc).setThread(thread);
-			if (es != null) es.shutdown();
 		}
 	}
 

--- a/core/src/main/java/lucee/runtime/functions/closure/Some.java
+++ b/core/src/main/java/lucee/runtime/functions/closure/Some.java
@@ -72,22 +72,29 @@ public final class Some extends BIF implements ClosureFunc {
 	}
 
 	private static boolean _call(PageContext pc, Object obj, UDF udf, boolean parallel, int maxThreads, short type) throws PageException {
-
-		Thread thread = null;
-		ExecutorService execute = null;
-		List<Future<Data<Object>>> futures = null;
 		// 0 or less == default
 		if (maxThreads < 1) maxThreads = Each.DEFAULT_MAX_THREAD;
 		// 1 == not parallel
 		else if (maxThreads == 1) parallel = false;
-		if (parallel) {
-			execute = ThreadUtil.createExecutorService(maxThreads);
-			futures = new ArrayList<Future<Data<Object>>>();
-			thread = ((PageContextImpl) pc).getThread();
+
+		if (!parallel) return dispatch(pc, obj, udf, type, null, null);
+
+		ExecutorService execute = ThreadUtil.createExecutorService(maxThreads);
+		List<Future<Data<Object>>> futures = new ArrayList<Future<Data<Object>>>();
+		Thread thread = ((PageContextImpl) pc).getThread();
+		try {
+			// dispatch return is always false in async mode; afterCall produces the real result
+			dispatch(pc, obj, udf, type, execute, futures);
+			return afterCall(pc, futures);
 		}
+		finally {
+			// drain orphans so they can't race the caller's post-parallel state (LDEV-6395)
+			ThreadUtil.finishParallelSection(pc, execute, thread, futures);
+		}
+	}
 
+	private static boolean dispatch(PageContext pc, Object obj, UDF udf, short type, ExecutorService execute, List<Future<Data<Object>>> futures) throws PageException {
 		boolean res;
-
 		// Array
 		if (type == TYPE_ARRAY) {
 			res = invoke(pc, (Array) obj, udf, execute, futures);
@@ -137,9 +144,6 @@ public final class Some extends BIF implements ClosureFunc {
 			res = invoke(pc, (StringListData) obj, udf, execute, futures);
 		}
 		else throw new FunctionException(pc, "Some", 1, "data", "Cannot iterate over this type [" + Caster.toTypeName(obj.getClass()) + "]");
-
-		if (parallel) res = afterCall(pc, futures, execute, thread);
-
 		return res;
 	}
 
@@ -302,7 +306,7 @@ public final class Some extends BIF implements ClosureFunc {
 		return null;
 	}
 
-	public static boolean afterCall(PageContext pc, List<Future<Data<Object>>> futures, ExecutorService es, Thread thread) throws PageException {
+	public static boolean afterCall(PageContext pc, List<Future<Data<Object>>> futures) throws PageException {
 		try {
 			Iterator<Future<Data<Object>>> it = futures.iterator();
 			Data<Object> d;
@@ -315,10 +319,6 @@ public final class Some extends BIF implements ClosureFunc {
 		}
 		catch (Exception e) {
 			throw Caster.toPageException(e);
-		}
-		finally {
-			((PageContextImpl) pc).setThread(thread);
-			if (es != null) es.shutdown();
 		}
 	}
 

--- a/core/src/main/java/lucee/runtime/thread/ThreadUtil.java
+++ b/core/src/main/java/lucee/runtime/thread/ThreadUtil.java
@@ -23,9 +23,11 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.http.Cookie;
@@ -288,6 +290,32 @@ public final class ThreadUtil {
 			}
 		}
 		return Executors.newSingleThreadExecutor();
+	}
+
+	// Wait for any in-flight futures to finish so orphan workers can't race the caller's
+	// post-parallel mutations (LDEV-6395). Swallows per-future exceptions: caller has already
+	// surfaced the relevant one via afterCall.
+	public static void drainFutures(List<? extends Future<?>> futures) {
+		if (futures == null) return;
+		for (Future<?> f : futures) {
+			if (!f.isDone()) {
+				try {
+					f.get();
+				}
+				catch (Exception ignored) {}
+			}
+		}
+	}
+
+	// Shared cleanup for the parallel section of Each/Map/Filter/Some/Every (LDEV-6395):
+	// restore the parent's thread, shut down the executor, drain any remaining futures.
+	// Safe to call when parts were never set up — null pc/thread/es/futures are no-ops.
+	public static void finishParallelSection(PageContext pc, ExecutorService es, Thread thread, List<? extends Future<?>> futures) {
+		if (pc != null && thread != null) ((PageContextImpl) pc).setThread(thread);
+		if (es != null) {
+			es.shutdown();
+			drainFutures(futures);
+		}
 	}
 
 	/**


### PR DESCRIPTION
[LDEV-6395](https://luceeserver.atlassian.net/browse/LDEV-6395)

Parallel-mode `arrayEach` / `arrayMap` / `arrayFilter` / `arraySome` / `arrayEvery` could leave in-flight workers running in the background when the BIF returned (success or throw). Those orphan workers raced the parent's subsequent state mutations and silently threw `ConcurrentModificationException` deep inside `PageContextImpl.initialize`. The CMEs never reached user CFML — Lucee's outer catch swallowed them.

The race exists on platform threads too but is rare (FixedThreadPool caps concurrency at maxThreads). On Java 25 with virtual threads enabled it fires constantly: prior measurement was 6,897 CMEs in 3 minutes of normal traffic.

## What changed

Wrap each parallel BIF's executor lifecycle (creation → submit loop → afterCall) in a single try/finally that drains every submitted future via `Future.get()` before returning. Drain helper added to `ThreadUtil` to keep the 5 BIFs consistent.

## Behaviour change

Exception-path latency for parallel BIFs now includes a wait for the slowest in-flight task. On the success path it's a no-op — afterCall already awaited every future. The wait that was previously absorbed into pool/scheduler latency is now visible at the BIF caller, bounded by `maxThreads × task_time` after LDEV-6396.

## Validation

- 200,000-task soak under Java 25 + virtual threads + cap 32 on the orphan-race repro: 0 CMEs in JFR (cap-only baseline was 2 per 8k tasks, extrapolating to ~50 at 200k).
- 5-scenario stress suite at 16k tasks each, all VT, cap 32: 0 CMEs across all 5 JFRs.
- Lucee core `mvn test`: 5550 pass / 0 fail / 0 errors.

[LDEV-6395]: https://luceeserver.atlassian.net/browse/LDEV-6395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ