### PR TITLE
LDEV-3027 escape reflected request path in MissingIncludeException (CVE-2026-29519)

### DIFF
--- a/core/src/main/java/lucee/runtime/exp/MissingIncludeException.java
+++ b/core/src/main/java/lucee/runtime/exp/MissingIncludeException.java
@@ -63,7 +63,9 @@ public final class MissingIncludeException extends PageExceptionImpl {
 	}
 
 	private void setDetail(PageSource ps) {
-		setAdditional(KeyConstants._Detail, "File not found: " + ps.getDisplayPath());
+		// CVE-2026-29519: the requested path is reflected into HTML error output, so escape it here at the
+		// single point where untrusted request-path data enters the exception detail.
+		setAdditional(KeyConstants._Detail, "File not found: " + StringUtil.escapeHTML(StringUtil.emptyIfNull(ps.getDisplayPath())));
 	}
 
 	/**
@@ -74,9 +76,11 @@ public final class MissingIncludeException extends PageExceptionImpl {
 	}
 
 	private static String createMessage(PageSource pageSource) {
+		// CVE-2026-29519: escape the requested path before it becomes the (HTML-rendered) exception message.
+		String realpath = StringUtil.escapeHTML(StringUtil.emptyIfNull(pageSource.getRealpathWithVirtual()));
 		String dsp = pageSource.getDisplayPath();
-		if (dsp == null) return "Page [" + pageSource.getRealpathWithVirtual() + "] not found";
-		return "Page [" + pageSource.getRealpathWithVirtual() + "] [" + dsp + "] not found";
+		if (dsp == null) return "Page [" + realpath + "] not found";
+		return "Page [" + realpath + "] [" + StringUtil.escapeHTML(dsp) + "] not found";
 	}
 
 	@Override

--- a/test/tickets/LDEV3027.cfc
+++ b/test/tickets/LDEV3027.cfc
@@ -1,0 +1,64 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="security" {
+
+	/*
+	 * CVE-2026-29519 / LDEV-3027 — reflected XSS via HTML in the request path.
+	 *
+	 * When a requested template cannot be found, Lucee raises a
+	 * MissingIncludeException whose message and detail embed the requested
+	 * path (PageSource.getRealpathWithVirtual() / getDisplayPath()). That
+	 * text is reflected into the (HTML) detailed error page unescaped, so an
+	 * attacker-supplied path segment such as
+	 *     /foo/<img src=x onerror=alert(1)>/index.cfm/
+	 * executes as live markup in the victim's browser.
+	 *
+	 * Fix: escape the requested path where it enters the exception message
+	 * and detail (MissingIncludeException), mirroring the existing escaping
+	 * of the REST 404 path in PageContextImpl. These tests assert the raw
+	 * markup never survives into message/detail and that the escaped form is
+	 * present instead.
+	 */
+
+	function run( testResults, testBox ) {
+
+		describe( "CVE-2026-29519: MissingInclude must HTML-escape the requested path", function() {
+
+			it( title = "message + detail must not contain raw <img onerror> markup", body = function( currentSpec ) {
+				var payload = "<img src=x onerror=alert(1)>";
+				var caught  = false;
+				try {
+					// Non-existent template whose path carries the payload — this
+					// is exactly what the request-path vector produces internally.
+					include template = "/#payload#_LDEV3027_does_not_exist.cfm";
+				}
+				catch ( missinginclude e ) {
+					caught = true;
+					// Only a RAW tag-open is dangerous. Escaping turns "<" into "&lt;",
+					// which neutralises the XSS; the attribute text "onerror=" legitimately
+					// survives inside the escaped "&lt;img ... onerror=...&gt;" and must NOT
+					// be asserted against (that was a false-positive in an earlier draft).
+					expect( e.message ).notToInclude( "<img" );
+					expect( e.detail  ).notToInclude( "<img" );
+					// the path is still reported, just neutralised
+					expect( e.message & " " & e.detail ).toInclude( "&lt;img" );
+				}
+				expect( caught ).toBeTrue( "expected a missinginclude exception" );
+			});
+
+			it( title = "script-tag payload must be escaped in message + detail", body = function( currentSpec ) {
+				var payload = "<script>alert(document.domain)</script>";
+				var caught  = false;
+				try {
+					include template = "/#payload#_LDEV3027_does_not_exist.cfm";
+				}
+				catch ( missinginclude e ) {
+					caught = true;
+					expect( e.message ).notToInclude( "<script>" );
+					expect( e.detail  ).notToInclude( "<script>" );
+					expect( e.message & " " & e.detail ).toInclude( "&lt;script&gt;" );
+				}
+				expect( caught ).toBeTrue( "expected a missinginclude exception" );
+			});
+
+		});
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the reflected XSS in URL path parsing tracked as **LDEV-3027** / **CVE-2026-29519**.

When a requested template cannot be found, Lucee raises a `MissingIncludeException` whose message and detail embed the requested path (`PageSource.getRealpathWithVirtual()` / `getDisplayPath()`). That text is rendered into the detailed error page unescaped, so an HTML/JS payload placed in a URL path segment executes in the victim's browser, e.g.:

```
http://host/foo/<img src=x onerror=alert(1)>/index.cfm/
```

The issue affects the 5.3.x, 6.1.x, 6.2.x and 7.0.x lines.

## Fix

HTML-escape the requested path with `StringUtil.escapeHTML` at the single points where untrusted request-path data enters the exception message and detail — mirroring the existing escaping of the REST 404 path in `PageContextImpl` (`HTMLEntities.escapeHTML(pathInfo)`). Null-guarded with `StringUtil.emptyIfNull`, since `escapeHTML` NPEs on a null argument.

## Test

Adds `test/tickets/LDEV3027.cfc`: triggers the exception via a payload-bearing missing include and asserts the message/detail contain no raw tag-open (`<img`, `<script>`) and instead the escaped form (`&lt;img`, `&lt;script&gt;`). Passes locally with `mvn test -DtestFilter=LDEV3027`.

## Notes

- Targets `7.0` (active stable). Backport candidate for the `6.2` LTS line and the other affected branches.
- Jira: https://luceeserver.atlassian.net/browse/LDEV-3027
