### PR TITLE
LDEV-4867 / LDEV-4866 preserve SQL comments in queryExecute() and fix query parser bounds (v7 port)

### DIFF
--- a/core/src/main/java/lucee/commons/lang/ParserString.java
+++ b/core/src/main/java/lucee/commons/lang/ParserString.java
@@ -57,7 +57,18 @@ public final class ParserString {
 	 * @param text CFML Code
 	 */
 	public ParserString(String text) {
-		init(text);
+		init(text, false);
+	}
+
+	/**
+	 * Constructor that optionally strips SQL comments before parsing.
+	 * Use for QoQ SQL parsing where the internal parser cannot handle comments.
+	 *
+	 * @param text SQL text
+	 * @param doIgnoreComments if true, strip SQL comments from text before parsing
+	 */
+	public ParserString(String text, boolean doIgnoreComments) {
+		init(text, doIgnoreComments);
 	}
 
 	/**
@@ -66,7 +77,8 @@ public final class ParserString {
 	 * 
 	 * @param str
 	 */
-	protected void init(String str) {
+	protected void init(String str, boolean doIgnoreComments) {
+		if (doIgnoreComments) str = stripSqlComments(str);
 		int len = str.length();
 		text = new char[len];
 		lcText = new char[len];
@@ -699,6 +711,43 @@ public final class ParserString {
 			pos++;
 		}
 		return (start < pos);
+	}
+
+	/**
+	 * Strip out all sql comments
+	 * 
+	 * @return SQL text with comments stripped out
+	 */
+	public String stripSqlComments(String sql) {
+		char c;
+		int sqlLen = sql.length();
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < sqlLen; i++) {
+			c = sql.charAt(i);
+			if ( i < (sqlLen - 1)) {
+				// handle multi line comment
+				if (c == '/' && sql.charAt(i + 1) == '*') {
+					int end = sql.indexOf("*/", i + 2);
+					if (end != -1) {
+						i = end + 1;
+						continue;
+					}
+				}
+
+				// handle single line comment
+				if (c == '-' && i < (sqlLen - 1) && sql.charAt(i + 1) == '-') {
+					int end = sql.indexOf('\n', i + 1);
+					if (end == -1) {
+						break; // end of sql string
+					}
+					i = end;
+					continue;
+				}
+			}
+			sb.append(c);
+		}
+		return sb.toString().trim();
 	}
 
 	public void revertRemoveSpace() {

--- a/core/src/main/java/lucee/runtime/db/HSQLDBHandler.java
+++ b/core/src/main/java/lucee/runtime/db/HSQLDBHandler.java
@@ -463,7 +463,7 @@ public final class HSQLDBHandler {
 			if (spe.getCause() != null && spe.getCause() instanceof IllegalQoQException) {
 				throw Caster.toPageException(spe);
 			}
-			prettySQL = SQLPrettyfier.prettyfie(sql.getSQLString());
+			prettySQL = SQLPrettyfier.prettyfie(sql.getSQLString(), true);
 			try {
 				QueryImpl query = executer.execute(pc, sql, prettySQL, maxrows);
 				query.setExecutionTime(stopwatch.time());
@@ -520,7 +520,7 @@ public final class HSQLDBHandler {
 				tables = hsql2.getInvokedTables();
 			}
 			else {
-				if (prettySQL == null) prettySQL = SQLPrettyfier.prettyfie(sql.getSQLString());
+				if (prettySQL == null) prettySQL = SQLPrettyfier.prettyfie(sql.getSQLString(), true);
 				HSQLUtil hsql = new HSQLUtil(prettySQL);
 				tables = hsql.getInvokedTables();
 				isUnion = hsql.isUnion();

--- a/core/src/main/java/lucee/runtime/db/SQLImpl.java
+++ b/core/src/main/java/lucee/runtime/db/SQLImpl.java
@@ -114,8 +114,8 @@ public final class SQLImpl implements SQL, Serializable {
 		int index = 0;
 		for (int i = 0; i < sqlLen; i++) {
 			c = strSQL.charAt(i);
-			if (!inQuotes && sqlLen + 1 > i) {
-				// read multi line
+			if (!inQuotes && i < (sqlLen - 1)) {
+				// read multi line comment - skip for display purposes
 				if (c == '/' && strSQL.charAt(i + 1) == '*') {
 					int end = strSQL.indexOf("*/", i + 2);
 					if (end != -1) {
@@ -125,15 +125,17 @@ public final class SQLImpl implements SQL, Serializable {
 					}
 				}
 
-				// read single line
-				if (c == '-' && strSQL.charAt(i + 1) == '-') {
+				// read single line comment - skip for display purposes
+				if (c == '-' && i < (sqlLen - 1) && strSQL.charAt(i + 1) == '-') {
 					int end = strSQL.indexOf('\n', i + 1);
-					if (end != -1) {
-						i = end + 1;
-						if (i == sqlLen) break;
-						c = strSQL.charAt(i);
+					if (end == -1) {
+						i = sqlLen; // end of sql string
+					} else {
+						i = end;
 					}
-					else break;
+					if (i == sqlLen) break;
+					//c = strSQL.charAt(i);
+					continue;
 				}
 			}
 

--- a/core/src/main/java/lucee/runtime/db/SQLPrettyfier.java
+++ b/core/src/main/java/lucee/runtime/db/SQLPrettyfier.java
@@ -39,7 +39,7 @@ public final class SQLPrettyfier {
 
 	public static String prettyfie(String sql, boolean validZql) {
 
-		ParserString ps = new ParserString(sql.trim());
+		ParserString ps = new ParserString(sql.trim(), true);
 		boolean insideString = false;
 		// short insideKlammer=0;
 		StringBuilder sb = new StringBuilder(sql.length());

--- a/core/src/main/java/lucee/runtime/sql/SelectParser.java
+++ b/core/src/main/java/lucee/runtime/sql/SelectParser.java
@@ -63,7 +63,7 @@ public final class SelectParser {
 	// select <select-statement> from <tables> where <where-statement>
 	public Selects parse(String sql) throws SQLParserException {
 		columnIndex = 0;
-		ParserString raw = new ParserString(sql.trim());
+		ParserString raw = new ParserString(sql.trim(), true);
 		Selects selects = new Selects();
 		Select select = new Select();
 

--- a/core/src/main/java/lucee/runtime/tag/util/QueryParamConverter.java
+++ b/core/src/main/java/lucee/runtime/tag/util/QueryParamConverter.java
@@ -146,26 +146,27 @@ public final class QueryParamConverter {
 
 		for (int i = 0; i < sqlLen; i++) {
 			c = sql.charAt(i);
-			if (!inQuotes && sqlLen + 1 > i) {
-				// read multi line
+			if (!inQuotes && i < (sqlLen - 1)) {
+				// read multi line comment - preserve it in output so DB drivers (e.g. ProxySQL routing) can see it
 				if (c == '/' && sql.charAt(i + 1) == '*') {
 					int end = sql.indexOf("*/", i + 2);
 					if (end != -1) {
+						sb.append(sql.substring(i, end+2));
 						i = end + 2;
 						if (i == sqlLen) break;
 						c = sql.charAt(i);
 					}
 				}
 
-				// read single line
-				if (c == '-' && sql.charAt(i + 1) == '-') {
+				// read single line comment - preserve it in output
+				if (c == '-' && i < (sqlLen - 1) && sql.charAt(i + 1) == '-') {
 					int end = sql.indexOf('\n', i + 1);
-					if (end != -1) {
-						i = end + 1;
-						if (i == sqlLen) break;
-						c = sql.charAt(i);
-					}
-					else break;
+					if (end == -1) {
+						end = sqlLen-1; // end of sql string
+					} 
+					sb.append(sql.substring(i, end+1));
+					i = end;
+					continue;
 				}
 			}
 
@@ -190,7 +191,7 @@ public final class QueryParamConverter {
 						continue;
 					}
 
-					if (++_qm > initialParamSize) throw new ApplicationException("there are more question marks in the SQL than params defined", "SQL: " + sql + "");
+					if (++_qm > initialParamSize) throw new ApplicationException("There are more question marks ["+(qm+1)+"] in the SQL than params defined ["+initialParamSize+"], at position ["+ i +"]", "SQL: " + sql + ", ParsedSQL:" + sb.toString());
 				}
 				else if (c == ':') {
 

--- a/test/tickets/LDEV4866.cfc
+++ b/test/tickets/LDEV4866.cfc
@@ -1,25 +1,41 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" labels="query" skip=true {
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="query" {
 
 	variables.ds = server.getDatasource( service="h2", dbFile=server._getTempDir( "LDEV4866" ) );
+	variables.params = { a:1, b:2 };
 
 	function run( testResults , testBox ) {
 		describe( title='LDEV-4866' , body=function(){
-			it( title='test query parsing, just a -' , body=function() {
-				```
-				<cfquery name="test" datasource="#ds#">
-					-
-				</cfquery>
-				```
+			it( title='test query parsing, /* */-' , body=function() {
+				doQuery("#chr(13)# /* */- ");
+				doQuery("#chr(13)# /* */- ");
+				doQuery("/* */-");
+			});
+			it( title='test query parsing, just a - whitespace' , body=function() {
+				doQuery("#chr(9)# - #chr(13)# ");
 			});
 
+			it( title='test query parsing, just a -' , body=function() {
+				doQuery("-");
+			});
+
+			it( title='test query parsing, just a / whitespace' , body=function() {
+				doQuery("#chr(9)# / #chr(13)# ");
+			});
 			it( title='test query parsing, just a /' , body=function() {
-				```
-				<cfquery name="test" datasource="#ds#">
-					/
-				</cfquery>
-				```
+				doQuery("/");
 			});
 		});
+	}
+
+	private function doQuery(sql){
+		try {
+			query name="test" datasource="#ds#" params="#params#" {
+				echo( sql );
+			}
+		} catch (e) {
+			 if ( e.stackTrace.indexOf("lucee.runtime.exp.DatabaseException:") neq 0 )
+				rethrow;
+		}
 	}
 
 }

--- a/test/tickets/LDEV4867.cfc
+++ b/test/tickets/LDEV4867.cfc
@@ -1,36 +1,176 @@
 component extends="org.lucee.cfml.test.LuceeTestCase" labels="query" {
 
-	variables.ds = server.getDatasource( service="h2", dbFile=server._getTempDir( "LDEV4867" ) );
+	function beforeAll(){
+		variables.ds = server.getDatasource( service="h2", dbFile=server._getTempDir( "LDEV4867" ) );
+		variables.params = {
+			id: {
+				value: 1, sqltype="numeric"
+			}
+		};
+
+		variables.LF = chr( 10 );
+		variables.qry = QueryNew( "engine,id", "varchar,numeric", [
+			[ "lucee", 1 ],
+			[ "ralio" , 2 ]
+		]);
+		_setupDatabase();
+	};
 
 	function run( testResults , testBox ) {
-		describe( title='LDEV-4867' , body=function(){
-			it( title='test query parsing, removing comments' , body=function() {
-				```
-				<cfquery name="local.test" datasource="#ds#" result="local.result">
-					-- foo
-					/* bar */
-						SELECT 'test'
-				</cfquery>
-				```
-				//systemOutput( local.result.sql, true );
-				expect ( local.result.sql ).toInclude( "-- foo" );
-				expect ( local.result.sql ).toInclude( "/* bar */" );
+		describe( title='LDEV-4867', body=function(){
+
+			it( title='test query parsing, removing comments', body=function() {
+				doTest( ["-- foo", "/* bar */", "SELECT engine from qry where id = :id "]
+					,[ "-- foo" , "/* bar */" ]
+				);
 			});
 
-			it( title='test query parsing, with a ? in a comment' , body=function() {
-				```
-				<cfquery name="local.test" datasource="#ds#" result="local.result">
-					-- foo
-					/* bar? */
-						SELECT 'test'
-				</cfquery>
-				```
+			it( title='test query parsing, mixed nested comments', body=function() {
+				doTest( ["/* bar -- foo */", "SELECT engine from qry where id = :id ", "/* bar -- foo */"]
+					,[ "/* bar -- foo */" ]
+				);
+				doTest( ["--foo /* bar */", "SELECT engine from qry where id = :id ", "--foo /* bar */"]
+					,[ "--foo /* bar */" ]
+				);
+			});
 
-				//systemOutput( local.result.sql, true );
-				expect ( local.result.sql ).toInclude("-- foo");
-				expect ( local.result.sql ).toInclude("/* bar? */");
+			it( title='test query parsing, nested comment blocks', skip=true, body=function() {
+				// Nested comments aren't generally supported anyway....
+				doTest( ["/* bar /* #LF# -- foo #LF# */ */", "SELECT engine from qry where id = :id "]
+					,[ "/* bar /* #LF# -- foo #LF# */ */" ]
+				);
+			});
+
+			it( title='test query parsing, with a ? in a comment', body=function() {
+				doTest( [ "-- foo", "/* bar? */", "SELECT engine"," from qry", "where id = :id" ]
+					,[ "-- foo", "/* bar? */" ]
+				);
+			});
+
+			it( title='test query parsing, with a ? in a /* */ comment', body=function() {
+				doTest( [ "-- foo", "/* bar? */", "SELECT engine"," from qry", "where id = :id" ],
+					[ "-- foo", "/* bar? */" ] );
+			});
+
+			it( title='test query parsing, with a ? and : in a comment', body=function() {
+				doTest( [ "-- foo ? :do", "/* bar? :*/", "SELECT engine"," from qry", "where id = :id" ],
+					[ "-- foo ? :do", "/* bar? :*/" ]
+				);
+			});
+
+			it( title='test query parsing, with a ? in a comment', body=function() {
+				doTest( [ "-- foo ? :do", "/* bar? :*/", "SELECT engine"," from qry", "where id = :id" ],
+					[ "-- foo ? :do", "/* bar? :*/" ]
+				);
+			});
+
+			it( title='test query parsing, with a ? in a trailing line comment', body=function() {
+				doTest( [ "SELECT engine"," from qry", "where id = :id",  "-- foo ? :do" ],
+					[ "-- foo ? :do" ]
+				);
+			});
+
+			it( title='test query parsing, with a ? in a trailing comment block', body=function() {
+				doTest( [ "SELECT engine"," from qry", "where id = :id",  "/* foo ? :do */" ],
+					[ "/* foo ? :do */" ]
+				);
 			});
 		});
+	}
+
+	private function doTest( array sql, array comments ){
+		var newlines = ArrayToList( arguments.sql, chr( 10 ) );
+		executeTest( newlines, comments, "[LF]" );
+
+		var paddedNewlines = ArrayToList( arguments.sql, " " & chr( 10 ) & " " );
+		executeTest( paddedNewlines, comments, "[ LF ]" );
+
+		var leading =  ArrayToList( arguments.sql, " " & chr( 10 ) );
+		executeTest( leading, comments, "[ LF]" );
+
+		var trailing =  ArrayToList( arguments.sql, chr( 10 ) & " " );
+		executeTest( trailing, comments, "[LF ]" );
+
+		var emptySqlComment =  ArrayToList( arguments.sql, "--" & chr( 10 ) & " " );
+		executeTest( emptySqlComment, comments, "[--LF ]" );
+
+		var emptySqlCommentParam =  ArrayToList( arguments.sql, "--?" & chr( 10 ) & " " );
+		executeTest( emptySqlCommentParam, comments, "[--?LF ]" );
+
+		var emptySqlCommentParam2 =  ArrayToList( arguments.sql, "--:foo" & chr( 10 ) & " " );
+		executeTest( emptySqlCommentParam2, comments, "[--:fooLF ]" );
+	}
+
+	private function executeTest( string sql, array comments, string seperatorWhitespace ){
+		_executeTest( arguments.sql, arguments.comments,
+			arguments.seperatorWhitespace & ", no extra" );
+		_executeTest( " " & chr( 10 ) & arguments.sql, arguments.comments,
+			arguments.seperatorWhitespace & ", leading SPACE LF" );
+		_executeTest( " " & chr( 10 ) & arguments.sql & " " & chr( 10 ), arguments.comments,
+			arguments.seperatorWhitespace & ", leading and trailing SPACE LF" );
+		_executeTest( arguments.sql & " " & chr( 10 ), arguments.comments,
+			arguments.seperatorWhitespace & ", trailing SPACE LF" );
+		_executeTest( chr( 10 ) & arguments.sql, arguments.comments,
+			arguments.seperatorWhitespace & ",  leading LF");
+		_executeTest( chr( 10 ) & arguments.sql & chr( 10 ), arguments.comments,
+			arguments.seperatorWhitespace & ", leading and trailing LF" );
+		_executeTest( arguments.sql & chr( 10 ), arguments.comments,
+			arguments.seperatorWhitespace & ", trailing LF" );
+	}
+
+	private function _executeTest( string sql, array comments, string whitespaceDesc ){
+
+		// real database, h2
+		var db = doQuery( arguments.sql, arguments.whitespaceDesc, "" );
+		for ( var comment in arguments.comments ){
+			expect ( db.result.sql ).toInclude( comment );
+		}
+		expect( db.rs.engine ).toBe( "lucee" );
+
+		// QoQ
+		var qoq = doQuery( arguments.sql, arguments.whitespaceDesc, "query" );
+		for ( var comment in arguments.comments ){
+			expect ( qoq.result.sql ).toInclude( comment );
+		}
+		expect( qoq.rs.engine ).toBe( "lucee" );
+		// systemOutput( out.result, true );
+	}
+
+	private function doQuery( string sql, string whitespaceDesc, string dbtype ){
+		try {
+			query name="local.rs" datasource="#ds#" params="#params#" dbtype="#arguments.dbtype#" result="local.result" {
+				echo( sql );
+			}
+		} catch (e) {
+			systemOutput( "WHITESPACE: " & arguments.whitespaceDesc, true );
+			systemOutput("Source: "& sql, true);
+		//	if ( e.stackTrace.indexOf("lucee.runtime.exp.DatabaseException:") neq 0 )
+			rethrow;
+			//systemOutput(e.stackTrace, true);
+		}
+		/*
+		systemOutput("", true);
+		systemOutput("Parsed: " & result.sql, true);
+		systemOutput("Source: "& sql, true);
+		*/
+		return {
+			result: result,
+			rs: rs
+		}
+	}
+
+	private function _setupDatabase() {
+		query datasource=ds {
+			echo("CREATE TABLE qry ( id int NOT NULL, engine varchar(255) ) ");
+		}
+		var delim = "";
+		query datasource=ds {
+			echo("insert into qry ( id, engine ) VALUES ");
+			loop query="qry" {
+				echo(" #delim# ( #qry.id#, '#qry.engine#' ) ");
+				delim = ",";
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4867
https://luceeserver.atlassian.net/browse/LDEV-4866


**Description**:
Port of PR #2382 to the 7.0 branch.

queryExecute() strips SQL comments before sending the query to the database, breaking tools that rely on comment directives in executed SQL — notably ProxySQL query routing (https://www.proxysql.com/features/query-routing).

Two bugs in QueryParamConverter.convert():
- LDEV-4867 — /* block */ and -- line comments are silently dropped from the SQL sent to the database
- LDEV-4866 — missing bounds check on charAt(i + 1) causes StringIndexOutOfBoundsException when SQL ends with a bare -, /, or a trailing -- comment with no newline

**Fix**: 
Comments are now preserved in the SQL sent to real datasources. The QoQ internal parser cannot handle comments, so stripSqlComments() is applied only in that path via a new ParserString(String, boolean) constructor.

**Tests**: 
- LDEV4866 5/5, LDEV4867 8/8 passed (49 whitespace variations per statement, tested against both H2 and QoQ). 
- Validated in production with ProxySQL — comment directives now pass through correctly.

**Related PRs**:
Thanks to @bdw429s  who fixed this for v6 (but was never merged)!!

- https://github.com/lucee/Lucee/pull/2382