### PR TITLE
LDEV-6455 - read spooler tasks with the class loader that created them

### DIFF
--- a/core/src/main/java/lucee/commons/lang/PhysicalClassLoaderFactory.java
+++ b/core/src/main/java/lucee/commons/lang/PhysicalClassLoaderFactory.java
@@ -287,23 +287,6 @@ public class PhysicalClassLoaderFactory {
 		}
 	}
 
-	/**
-	 * The class loaders this factory has handed out. An extension can contribute classes through
-	 * Maven coordinates instead of a bundle (a tag-class declared as
-	 * maven="group:artifact:version"), and those are only ever loaded into the RPC class loaders
-	 * built here - so these are the only place left to look for such a class.
-	 *
-	 * @return the currently cached class loaders
-	 */
-	public static Collection<ClassLoader> getClassLoaders() {
-		List<ClassLoader> list = new ArrayList<ClassLoader>(classLoaders.size());
-		for (CachedLoader cached: classLoaders.values()) {
-			PhysicalClassLoader pcl = cached.get();
-			if (pcl != null) list.add(pcl);
-		}
-		return list;
-	}
-
 	private static class CachedLoader {
 		final PhysicalClassLoader loader;
 		volatile long lastAccess;

--- a/core/src/main/java/lucee/commons/lang/PhysicalClassLoaderFactory.java
+++ b/core/src/main/java/lucee/commons/lang/PhysicalClassLoaderFactory.java
@@ -287,6 +287,23 @@ public class PhysicalClassLoaderFactory {
 		}
 	}
 
+	/**
+	 * The class loaders this factory has handed out. An extension can contribute classes through
+	 * Maven coordinates instead of a bundle (a tag-class declared as
+	 * maven="group:artifact:version"), and those are only ever loaded into the RPC class loaders
+	 * built here - so these are the only place left to look for such a class.
+	 *
+	 * @return the currently cached class loaders
+	 */
+	public static Collection<ClassLoader> getClassLoaders() {
+		List<ClassLoader> list = new ArrayList<ClassLoader>(classLoaders.size());
+		for (CachedLoader cached: classLoaders.values()) {
+			PhysicalClassLoader pcl = cached.get();
+			if (pcl != null) list.add(pcl);
+		}
+		return list;
+	}
+
 	private static class CachedLoader {
 		final PhysicalClassLoader loader;
 		volatile long lastAccess;

--- a/core/src/main/java/lucee/runtime/spooler/SpoolerEngineImpl.java
+++ b/core/src/main/java/lucee/runtime/spooler/SpoolerEngineImpl.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lucee.commons.io.IOUtil;
 import lucee.commons.io.SystemUtil;
@@ -36,16 +38,13 @@ import lucee.commons.io.log.LogUtil;
 import lucee.commons.io.res.Resource;
 import lucee.commons.io.res.filter.ResourceNameFilter;
 import lucee.commons.io.res.util.ResourceUtil;
-import lucee.commons.lang.ClassUtil;
 import lucee.commons.lang.ExceptionUtil;
-import lucee.commons.lang.PhysicalClassLoaderFactory;
 import lucee.commons.lang.SerializableObject;
 import lucee.commons.lang.StringUtil;
 import lucee.loader.engine.CFMLEngineFactory;
 import lucee.runtime.config.Config;
 import lucee.runtime.config.ConfigUtil;
 import lucee.runtime.config.ConfigWeb;
-import lucee.runtime.converter.JavaConverter;
 import lucee.runtime.engine.ThreadLocalConfig;
 import lucee.runtime.engine.ThreadLocalPageContext;
 import lucee.runtime.exp.DatabaseException;
@@ -93,6 +92,7 @@ public final class SpoolerEngineImpl implements SpoolerEngine {
 	private boolean init;
 
 	private Config config;
+	private final Map<String, ClassLoader> taskLoaders = new ConcurrentHashMap<>();
 
 	public SpoolerEngineImpl(Config config, String label) {
 
@@ -143,6 +143,8 @@ public final class SpoolerEngineImpl implements SpoolerEngine {
 		add++;
 		if (task.nextExecution() == 0) task.setNextExecution(System.currentTimeMillis());
 		task.setId(createId(config, task));
+		ClassLoader cl = task.getClass().getClassLoader();
+		if (cl != null) taskLoaders.put(task.getClass().getName(), cl);
 		if (store(config, task)) {
 			start(config);
 		}
@@ -208,9 +210,12 @@ public final class SpoolerEngineImpl implements SpoolerEngine {
 		SpoolerTask task = defaultValue;
 		try {
 			is = res.getInputStream();
-			ois = new TaskObjectInputStream(CFMLEngineFactory.getInstance().getClass().getClassLoader(), is);
-
+			ois = new TaskInputStream(is);
 			task = (SpoolerTask) ois.readObject();
+		}
+		// the task class is not loaded (yet), keep the file so it can be read once it is
+		catch (ClassNotFoundException e) {
+			LogUtil.log(ThreadLocalPageContext.get(), SpoolerEngineImpl.class.getName(), e);
 		}
 		catch (Exception e) {
 			LogUtil.log(ThreadLocalPageContext.get(), SpoolerEngineImpl.class.getName(), e);
@@ -686,71 +691,22 @@ public final class SpoolerEngineImpl implements SpoolerEngine {
 		return config.getRemoteClientDirectory();
 	}
 
-	/**
-	 * Reads a spooler task back from disk.
-	 *
-	 * A task does not have to come from the core - an extension can contribute one (the mail
-	 * extension's MailSpoolerTask, for instance), and an extension's classes are not necessarily
-	 * visible to the core class loader: they live either in the extension's own OSGi bundle or,
-	 * when the extension declares its implementation through Maven coordinates, in one of the RPC
-	 * class loaders. Resolving against the core class loader alone therefore fails with a
-	 * ClassNotFoundException, and since the spooler only ever runs tasks it has read back from
-	 * disk, the task - a queued cfmail, say - is dropped after having been stored successfully.
-	 */
-	private static class TaskObjectInputStream extends JavaConverter.ObjectInputStreamImpl {
+	private final class TaskInputStream extends ObjectInputStream {
+		private ClassLoader cl;
 
-		/**
-		 * The extension class loader this task came from, remembered as soon as one class in the
-		 * stream has been found in it. Everything a task references has to be resolved through the
-		 * same loader: the same class from two loaders is two distinct types, and reading the task
-		 * then fails with "cannot assign instance of X to field ... of type X". Preferring that
-		 * loader is safe for core classes too, since it delegates to the core loader for anything
-		 * it does not provide itself.
-		 */
-		private ClassLoader extensionLoader;
-
-		public TaskObjectInputStream(ClassLoader cl, InputStream in) throws IOException {
-			super(cl, in);
+		private TaskInputStream(InputStream in) throws IOException {
+			super(in);
 		}
 
 		@Override
 		protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
-			String name = desc.getName();
-
-			if (extensionLoader != null) {
-				Class<?> clazz = load(extensionLoader, name);
-				if (clazz != null) return clazz;
-			}
-
+			// the first class in the stream is the task itself, read the whole stream with the loader it was created by
+			if (cl == null) cl = taskLoaders.getOrDefault(desc.getName(), CFMLEngineFactory.getInstance().getClass().getClassLoader());
 			try {
+				return Class.forName(desc.getName(), false, cl);
+			}
+			catch (ClassNotFoundException e) {
 				return super.resolveClass(desc);
-			}
-			catch (ClassNotFoundException cnfe) {
-				// an extension shipping its classes as an OSGi bundle
-				Class<?> clazz = ClassUtil.loadClass(name, null);
-
-				// an extension shipping them through Maven coordinates
-				if (clazz == null) {
-					for (ClassLoader cl: PhysicalClassLoaderFactory.getClassLoaders()) {
-						clazz = load(cl, name);
-						if (clazz != null) break;
-					}
-				}
-
-				if (clazz == null) throw cnfe;
-				if (clazz.getClassLoader() != null) extensionLoader = clazz.getClassLoader();
-				return clazz;
-			}
-		}
-
-		private static Class<?> load(ClassLoader cl, String name) {
-			try {
-				// Class.forName also understands the array descriptors a serialized stream uses
-				return Class.forName(name, false, cl);
-			}
-			catch (Throwable t) {
-				ExceptionUtil.rethrowIfNecessary(t);
-				return null;
 			}
 		}
 	}

--- a/core/src/main/java/lucee/runtime/spooler/SpoolerEngineImpl.java
+++ b/core/src/main/java/lucee/runtime/spooler/SpoolerEngineImpl.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -35,7 +36,9 @@ import lucee.commons.io.log.LogUtil;
 import lucee.commons.io.res.Resource;
 import lucee.commons.io.res.filter.ResourceNameFilter;
 import lucee.commons.io.res.util.ResourceUtil;
+import lucee.commons.lang.ClassUtil;
 import lucee.commons.lang.ExceptionUtil;
+import lucee.commons.lang.PhysicalClassLoaderFactory;
 import lucee.commons.lang.SerializableObject;
 import lucee.commons.lang.StringUtil;
 import lucee.loader.engine.CFMLEngineFactory;
@@ -205,7 +208,7 @@ public final class SpoolerEngineImpl implements SpoolerEngine {
 		SpoolerTask task = defaultValue;
 		try {
 			is = res.getInputStream();
-			ois = new JavaConverter.ObjectInputStreamImpl(CFMLEngineFactory.getInstance().getClass().getClassLoader(), is);
+			ois = new TaskObjectInputStream(CFMLEngineFactory.getInstance().getClass().getClassLoader(), is);
 
 			task = (SpoolerTask) ois.readObject();
 		}
@@ -681,6 +684,75 @@ public final class SpoolerEngineImpl implements SpoolerEngine {
 
 	public Resource getPersisDirectory(ConfigWeb config) {
 		return config.getRemoteClientDirectory();
+	}
+
+	/**
+	 * Reads a spooler task back from disk.
+	 *
+	 * A task does not have to come from the core - an extension can contribute one (the mail
+	 * extension's MailSpoolerTask, for instance), and an extension's classes are not necessarily
+	 * visible to the core class loader: they live either in the extension's own OSGi bundle or,
+	 * when the extension declares its implementation through Maven coordinates, in one of the RPC
+	 * class loaders. Resolving against the core class loader alone therefore fails with a
+	 * ClassNotFoundException, and since the spooler only ever runs tasks it has read back from
+	 * disk, the task - a queued cfmail, say - is dropped after having been stored successfully.
+	 */
+	private static class TaskObjectInputStream extends JavaConverter.ObjectInputStreamImpl {
+
+		/**
+		 * The extension class loader this task came from, remembered as soon as one class in the
+		 * stream has been found in it. Everything a task references has to be resolved through the
+		 * same loader: the same class from two loaders is two distinct types, and reading the task
+		 * then fails with "cannot assign instance of X to field ... of type X". Preferring that
+		 * loader is safe for core classes too, since it delegates to the core loader for anything
+		 * it does not provide itself.
+		 */
+		private ClassLoader extensionLoader;
+
+		public TaskObjectInputStream(ClassLoader cl, InputStream in) throws IOException {
+			super(cl, in);
+		}
+
+		@Override
+		protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+			String name = desc.getName();
+
+			if (extensionLoader != null) {
+				Class<?> clazz = load(extensionLoader, name);
+				if (clazz != null) return clazz;
+			}
+
+			try {
+				return super.resolveClass(desc);
+			}
+			catch (ClassNotFoundException cnfe) {
+				// an extension shipping its classes as an OSGi bundle
+				Class<?> clazz = ClassUtil.loadClass(name, null);
+
+				// an extension shipping them through Maven coordinates
+				if (clazz == null) {
+					for (ClassLoader cl: PhysicalClassLoaderFactory.getClassLoaders()) {
+						clazz = load(cl, name);
+						if (clazz != null) break;
+					}
+				}
+
+				if (clazz == null) throw cnfe;
+				if (clazz.getClassLoader() != null) extensionLoader = clazz.getClassLoader();
+				return clazz;
+			}
+		}
+
+		private static Class<?> load(ClassLoader cl, String name) {
+			try {
+				// Class.forName also understands the array descriptors a serialized stream uses
+				return Class.forName(name, false, cl);
+			}
+			catch (Throwable t) {
+				ExceptionUtil.rethrowIfNecessary(t);
+				return null;
+			}
+		}
 	}
 }
 

--- a/test/tickets/LDEV6455.cfc
+++ b/test/tickets/LDEV6455.cfc
@@ -1,0 +1,35 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" {
+
+	function run( testResults, testBox ) {
+		describe( "Test suite for LDEV-6455", function() {
+
+			it( title="a spooled task contributed by an extension can be read back", body = function( currentSpec ) {
+				var subject = "LDEV6455-" & createUUID();
+
+				// Queue a mail without ever sending it: the send time is a day out, so the spooler
+				// leaves the task alone and this test needs no mail server. What matters is that
+				// the task class comes from the mail extension rather than from the core.
+				mail to="receiver@lucee.org" from="sender@lucee.org" subject=subject
+						server="localhost" port=25 spoolEnable=true sendTime=dateAdd( "d", 1, now() ) {
+					echo( "LDEV-6455" );
+				}
+
+				// Listing reads every task back from disk. A task whose class the core class
+				// loader cannot see failed to deserialize and was then deleted, so the queued
+				// mail disappeared without ever being sent and without an error to the caller.
+				admin action="getSpoolerTasks" type="web" password=server.WEBADMINPASSWORD
+						startrow="1" maxrow="1000" returnVariable="local.tasks";
+
+				var mine = queryFilter( local.tasks, function( row ) {
+					return row.name == subject;
+				} );
+
+				expect( mine.recordCount ).toBe( 1 );
+				expect( mine.type ).toBe( "mail" );
+
+				admin action="removeSpoolerTask" type="web" password=server.WEBADMINPASSWORD id=mine.id;
+			});
+
+		});
+	}
+}

--- a/test/tickets/LDEV6455.cfc
+++ b/test/tickets/LDEV6455.cfc
@@ -6,17 +6,13 @@ component extends="org.lucee.cfml.test.LuceeTestCase" {
 			it( title="a spooled task contributed by an extension can be read back", body = function( currentSpec ) {
 				var subject = "LDEV6455-" & createUUID();
 
-				// Queue a mail without ever sending it: the send time is a day out, so the spooler
-				// leaves the task alone and this test needs no mail server. What matters is that
-				// the task class comes from the mail extension rather than from the core.
+				// sendTime is a day out, so the task is stored but never sent and no mail server is needed
 				mail to="receiver@lucee.org" from="sender@lucee.org" subject=subject
 						server="localhost" port=25 spoolEnable=true sendTime=dateAdd( "d", 1, now() ) {
 					echo( "LDEV-6455" );
 				}
 
-				// Listing reads every task back from disk. A task whose class the core class
-				// loader cannot see failed to deserialize and was then deleted, so the queued
-				// mail disappeared without ever being sent and without an error to the caller.
+				// listing reads every task back from disk
 				admin action="getSpoolerTasks" type="web" password=server.WEBADMINPASSWORD
 						startrow="1" maxrow="1000" returnVariable="local.tasks";
 


### PR DESCRIPTION
## Ticket

[LDEV-6455](https://luceeserver.atlassian.net/browse/LDEV-6455)

## Problem

`SpoolerEngineImpl.getTask()` deserializes task files with the core class loader. Since mail moved into an extension, `MailSpoolerTask` and the `jakarta.mail` types it holds live in the extension's RPC class loader (declared via `maven="org.lucee:mail:1.1.0.8-RC"`), so reading the file fails with `ClassNotFoundException: org.lucee.extension.mail.spooler.MailSpoolerTask` and the file is deleted. Spooled `cfmail` is stored fine and then silently lost.

## Fix

The engine is handed the live task in `add()`, so it already knows the loader that defines the task class. It now remembers that loader per task class and deserializes each file with the loader of the class that wrote it, the same rule Java serialization itself follows. The core loader remains the default, so core tasks are read exactly as before. No other class loaders are consulted.

A file whose task class cannot be resolved is no longer deleted. It is skipped, logged, and read once the class becomes known again (for example after a restart, as soon as the extension queues its next task). Files that fail for any other reason are still deleted as before.

## Verification

`test/tickets/LDEV6455.cfc` spools a mail with a `sendTime` a day out, then lists spooler tasks, which reads the file back. Fails on `7.1` as it stands, passes with this change.

The second commit replaces the class loader search from the first one; the first commit is kept for history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LDEV-6455]: https://luceeserver.atlassian.net/browse/LDEV-6455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ